### PR TITLE
Remove stripping of null values from Selection Set models

### DIFF
--- a/Tests/ApolloInternalTestHelpers/SelectionSet+TestHelpers.swift
+++ b/Tests/ApolloInternalTestHelpers/SelectionSet+TestHelpers.swift
@@ -1,0 +1,15 @@
+@testable import ApolloAPI
+@testable import Apollo
+
+public extension SelectionSet {
+
+  var _rawData: [String: AnyHashable] { self.__data._data }
+
+  func hasNullValue(forKey key: String) -> Bool {
+    guard let value = self.__data._data[key] else {
+      return false
+    }
+    return value == DataDict.NullValue
+  }
+
+}

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -23,7 +23,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
       selectionSet: selectionSet,
       on: object,      
       variables: variables,
-      accumulator: GraphQLSelectionSetMapper<T>(stripNullValues: true)
+      accumulator: GraphQLSelectionSetMapper<T>()
     )
   }
 
@@ -238,7 +238,8 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     let data = try readValues(GivenSelectionSet.self, from: object)
 
     // then
-    XCTAssertNil(data.name)
+    expect(data.name).to(beNil())
+    expect(data.hasNullValue(forKey: "name")).to(beTrue())
   }
 
   func test__optional_scalar__givenDataWithTypeConvertibleToFieldType_getsConvertedValue() throws {
@@ -689,7 +690,8 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     let data = try readValues(GivenSelectionSet.self, from: object)
 
     // then
-    XCTAssertEqual(data.favorites! as [String?], ["Red", nil, "Bird"])
+    expect(data.favorites! as [String?]).to(equal(["Red", nil, "Bird"]))
+    expect((data._rawData["favorites"] as? [AnyHashable])?[1]).to(equal(DataDict.NullValue))
   }
 
   // MARK: Optional List Of Optional Scalar

--- a/apollo-ios/Sources/Apollo/ApolloStore.swift
+++ b/apollo-ios/Sources/Apollo/ApolloStore.swift
@@ -278,7 +278,6 @@ public class ApolloStore {
         withKey: key,
         variables: variables,
         accumulator: GraphQLSelectionSetMapper<SelectionSet>(
-          stripNullValues: false,
           handleMissingValues: .allowForOptionalFields
         )
       )

--- a/apollo-ios/Sources/Apollo/GraphQLSelectionSetMapper.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLSelectionSetMapper.swift
@@ -7,7 +7,6 @@ final class GraphQLSelectionSetMapper<T: SelectionSet>: GraphQLResultAccumulator
 
   let requiresCacheKeyComputation: Bool = false
 
-  let stripNullValues: Bool
   let handleMissingValues: HandleMissingValues
 
   enum HandleMissingValues {
@@ -19,10 +18,8 @@ final class GraphQLSelectionSetMapper<T: SelectionSet>: GraphQLResultAccumulator
   }
 
   init(
-    stripNullValues: Bool = true,
     handleMissingValues: HandleMissingValues = .disallow
   ) {
-    self.stripNullValues = stripNullValues
     self.handleMissingValues = handleMissingValues
   }
 
@@ -48,7 +45,7 @@ final class GraphQLSelectionSetMapper<T: SelectionSet>: GraphQLResultAccumulator
   }
 
   func acceptNullValue(info: FieldExecutionInfo) -> AnyHashable? {
-    return stripNullValues ? nil : Optional<AnyHashable>.none
+    return DataDict.NullValue
   }
 
   func acceptMissingValue(info: FieldExecutionInfo) throws -> AnyHashable? {
@@ -88,4 +85,12 @@ final class GraphQLSelectionSetMapper<T: SelectionSet>: GraphQLResultAccumulator
   func finish(rootValue: DataDict, info: ObjectExecutionInfo) -> T {
     return T.init(_dataDict: rootValue)
   }
+}
+
+// MARK: - Null Value Definition
+extension DataDict {
+  /// A common value used to represent a null value in a `DataDict`.
+  ///
+  /// This value can be cast to `NSNull` and will bridge automatically.
+  static let NullValue = AnyHashable(Optional<AnyHashable>.none)
 }

--- a/apollo-ios/Sources/ApolloAPI/DataDict.swift
+++ b/apollo-ios/Sources/ApolloAPI/DataDict.swift
@@ -126,9 +126,7 @@ public struct DataDict: Hashable {
   }
 }
 
-
-
-// MARK: Value Conversion Helpers
+// MARK: - Value Conversion Helpers
 
 public protocol SelectionSetEntityValue {
   /// - Warning: This function is not supported for external use.


### PR DESCRIPTION
This PR removes the stripping of null values from the selection set models. 

This fixes apollographql/apollo-ios#3092. Because data returned from a network request was having null values stripped, when the returned models were then manually written to the cache, the null values were not written. This results in a `missingValue` error when you try to read those objects from the cache later.

This situation could occur if you fetched from the network with a cache policy of `.fetchIgnoringCacheCompletely` and then wrote some of the data to the cache manually. It also occurs in the common case of a fetched object be appended to another list of objects in a cache mutation.

## Null Value Representation

This bug fix revealed another related bug. We previously used `NSNull` to represent null values in a `SelectionSet`, then in order to work for Swift 5.3 and below, we needed to change this. We changed it to `Optional<AnyHashable>.none`, which actually was just `nil`. These `nil` values were being stripped by the executor as well. 

In order to handle null values in the selection set appropriately, we need to store them as a concrete value. This is now represented as `AnyHashable(Optional<AnyHashable>.none)`, which wraps a `nil` value inside of an `AnyHashable` struct. This is a concrete value instead of just `nil`, which provides the desired behavior.

To make the code clearer and more expressive, I've created a `DataDict.NullValue` static property that contains this value.