### PR TITLE
chore: Updates the git hook to disable Xcode opening from `tuist generate`

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-tuist generate
+tuist generate --no-open


### PR DESCRIPTION
It's annoying, this disables it.