### PR TITLE
refactor: Don't require `label` argument for deferred named fragments

### DIFF
--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/__tests__/deferDirectiveTests.ts
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/__tests__/deferDirectiveTests.ts
@@ -208,7 +208,7 @@ describe("given schema", () => {
 
       expect(validationErrors.length).toEqual(1)
       expect(validationErrors[0].message).toEqual(
-        "Apollo requires all @defer directives to use the 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment."
+        "Apollo does not support deferred inline fragments without a 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment."
       )
     })
   })
@@ -261,7 +261,7 @@ describe("given schema", () => {
 
       expect(validationErrors.length).toEqual(1)
       expect(validationErrors[0].message).toEqual(
-        "Apollo requires all @defer directives to use the 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment."
+        "Apollo does not support deferred inline fragments without a 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment."
       )
     })
   })

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/__tests__/deferDirectiveTests.ts
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/__tests__/deferDirectiveTests.ts
@@ -230,13 +230,10 @@ describe("given schema", () => {
       new Source(documentString, "Test Query", { line: 1, column: 1 })
     );
 
-    it("should fail validation", () => {
+    it("should pass validation", () => {
       const validationErrors: readonly GraphQLError[] = validateDocument(schema, document, emptyValidationOptions)
 
-      expect(validationErrors.length).toEqual(1)
-      expect(validationErrors[0].message).toEqual(
-        "Apollo requires all @defer directives to use the 'label' argument. Please add a 'label' argument to the @defer directive on this fragment spread."
-      )
+      expect(validationErrors.length).toEqual(0)
     })
   })
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/__tests__/deferDirectiveTests.ts
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/__tests__/deferDirectiveTests.ts
@@ -62,7 +62,7 @@ describe("given schema", () => {
       const allAnimals = operation.selectionSet.selections[0] as Field;
       const inlineFragment = allAnimals?.selectionSet?.selections?.[0] as InlineFragment;
 
-      expect(inlineFragment.directives?.length).toEqual(1);
+      expect(inlineFragment.directives).toHaveLength(1);
 
       expect(inlineFragment.directives?.[0].name).toEqual("defer");
     });
@@ -89,11 +89,11 @@ describe("given schema", () => {
       const allAnimals = operation.selectionSet.selections[0] as Field;
       const inlineFragment = allAnimals?.selectionSet?.selections?.[0] as InlineFragment;
 
-      expect(inlineFragment.directives?.length).toEqual(1);
+      expect(inlineFragment.directives).toHaveLength(1);
 
       expect(inlineFragment.directives?.[0].name).toEqual("defer");
       
-      expect(inlineFragment.directives?.[0].arguments?.length).toEqual(2);
+      expect(inlineFragment.directives?.[0].arguments).toHaveLength(2);
       expect(inlineFragment.directives?.[0].arguments?.[0].name).toEqual("if");
       expect(inlineFragment.directives?.[0].arguments?.[1].name).toEqual("label");
     });
@@ -122,7 +122,7 @@ describe("given schema", () => {
       const allAnimals = operation.selectionSet.selections[0] as Field;
       const inlineFragment = allAnimals?.selectionSet?.selections?.[0] as FragmentSpread;
 
-      expect(inlineFragment.directives?.length).toEqual(1);
+      expect(inlineFragment.directives).toHaveLength(1);
 
       expect(inlineFragment.directives?.[0].name).toEqual("defer");
     });
@@ -151,11 +151,11 @@ describe("given schema", () => {
       const allAnimals = operation.selectionSet.selections[0] as Field;
       const inlineFragment = allAnimals?.selectionSet?.selections?.[0] as FragmentSpread;
 
-      expect(inlineFragment.directives?.length).toEqual(1);
+      expect(inlineFragment.directives).toHaveLength(1);
       
       expect(inlineFragment.directives?.[0].name).toEqual("defer");
       
-      expect(inlineFragment.directives?.[0].arguments?.length).toEqual(2);
+      expect(inlineFragment.directives?.[0].arguments).toHaveLength(2);
       expect(inlineFragment.directives?.[0].arguments?.[0].name).toEqual("if");
       expect(inlineFragment.directives?.[0].arguments?.[1].name).toEqual("label");
     });
@@ -181,7 +181,7 @@ describe("given schema", () => {
     it("should fail validation", () => {
       const validationErrors: readonly GraphQLError[] = validateDocument(schema, document, emptyValidationOptions)
 
-      expect(validationErrors.length).toEqual(1)
+      expect(validationErrors).toHaveLength(1)
       expect(validationErrors[0].message).toEqual(
         "Apollo does not support deferred inline fragments without a type condition. Please add a type condition to this inline fragment."
       )
@@ -206,7 +206,7 @@ describe("given schema", () => {
     it("should fail validation", () => {
       const validationErrors: readonly GraphQLError[] = validateDocument(schema, document, emptyValidationOptions)
 
-      expect(validationErrors.length).toEqual(1)
+      expect(validationErrors).toHaveLength(1)
       expect(validationErrors[0].message).toEqual(
         "Apollo does not support deferred inline fragments without a 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment."
       )
@@ -233,7 +233,7 @@ describe("given schema", () => {
     it("should pass validation", () => {
       const validationErrors: readonly GraphQLError[] = validateDocument(schema, document, emptyValidationOptions)
 
-      expect(validationErrors).to(beEmpty())
+      expect(validationErrors).toHaveLength(0)
     })
   })
 
@@ -259,7 +259,7 @@ describe("given schema", () => {
     it("should fail validation", () => {
       const validationErrors: readonly GraphQLError[] = validateDocument(schema, document, emptyValidationOptions)
 
-      expect(validationErrors.length).toEqual(1)
+      expect(validationErrors).toHaveLength(1)
       expect(validationErrors[0].message).toEqual(
         "Apollo does not support deferred inline fragments without a 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment."
       )
@@ -284,7 +284,7 @@ describe("given schema", () => {
     it("should pass validation", () => {
       const validationErrors: readonly GraphQLError[] = validateDocument(schema, document, emptyValidationOptions)
 
-      expect(validationErrors.length).toEqual(0)
+      expect(validationErrors).toHaveLength(0)
     })
   })
 
@@ -308,7 +308,7 @@ describe("given schema", () => {
     it("should pass validation", () => {
       const validationErrors: readonly GraphQLError[] = validateDocument(schema, document, emptyValidationOptions)
 
-      expect(validationErrors.length).toEqual(0)
+      expect(validationErrors).toHaveLength(0)
     })
   })
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/validationRules.ts
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/validationRules.ts
@@ -98,7 +98,7 @@ export function DeferredInlineFragmentMissingLabelArgument(context: ValidationCo
           ))) {
             context.reportError(
               new GraphQLError(
-                "Apollo requires all @defer directives to use the 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment.",
+                "Apollo does not support deferred inline fragments without a 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment.",
                 { nodes: node }
               )
             )

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/validationRules.ts
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Frontend/JavaScript/src/validationRules.ts
@@ -9,7 +9,6 @@ import {
   VariableDefinitionNode,
   InlineFragmentNode,
   GraphQLDeferDirective,
-  FragmentSpreadNode,
 } from "graphql";
 
 const specifiedRulesToBeRemoved: [ValidationRule] = [NoUnusedFragmentsRule];
@@ -33,7 +32,7 @@ export function defaultValidationRules(options: ValidationOptions): ValidationRu
     NoAnonymousQueries,
     NoTypenameAlias,
     DeferredInlineFragmentNoTypeCondition,
-    DeferDirectiveMissingLabelArgument,
+    DeferredInlineFragmentMissingLabelArgument,
     ...(disallowedFieldNamesRule ? [disallowedFieldNamesRule] : []),
     ...(disallowedInputParameterNamesRule ? [disallowedInputParameterNamesRule] : []),
     ...specifiedRules.filter((rule) => !specifiedRulesToBeRemoved.includes(rule)),
@@ -89,39 +88,23 @@ export function DeferredInlineFragmentNoTypeCondition(context: ValidationContext
   };
 }
 
-export function DeferDirectiveMissingLabelArgument(context: ValidationContext) {
-  function ValidateDeferDirectiveLabelArgument(node: InlineFragmentNode | FragmentSpreadNode, error: GraphQLError) {
-    if (node.directives) {
-      for (const directive of node.directives) {
-        if (directive.name.value == GraphQLDeferDirective.name && !(directive.arguments?.find(
-          function(element) {
-            return element.name.value == 'label'
-          }) ? true: false)
-        ) {
-          context.reportError(error)
-        }
-      }
-    }
-  }
-
+export function DeferredInlineFragmentMissingLabelArgument(context: ValidationContext) {
   return {
     InlineFragment(node: InlineFragmentNode) {
-      ValidateDeferDirectiveLabelArgument(
-        node, 
-        new GraphQLError(
-          "Apollo requires all @defer directives to use the 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment.",
-          { nodes: node }
-        )
-      )
-    },
-    FragmentSpread(node: FragmentSpreadNode) {
-      ValidateDeferDirectiveLabelArgument(
-        node,
-        new GraphQLError(
-          "Apollo requires all @defer directives to use the 'label' argument. Please add a 'label' argument to the @defer directive on this fragment spread.",
-          { nodes: node }
-        )
-      )
+      if (node.directives) {
+        for (const directive of node.directives) {
+          if (directive.name.value == GraphQLDeferDirective.name && !(directive.arguments?.find((element) =>
+            element.name.value == 'label'
+          ))) {
+            context.reportError(
+              new GraphQLError(
+                "Apollo requires all @defer directives to use the 'label' argument. Please add a 'label' argument to the @defer directive on this inline fragment.",
+                { nodes: node }
+              )
+            )
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
The label value of the `@defer` directive is not used when we have a named fragment so we can drop the requirement for a `label` argument to only inline fragments.