### PR TITLE
Include local SPM packages in project, instead of as additional files

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -7,7 +7,9 @@ let project = Project(
     name: "ApolloDev",
     organizationName: "apollographql",
     packages: [
-        .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0")
+        .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0"),
+        .package(path: "apollo-ios"),
+        .package(path: "apollo-ios-codegen"),
     ],
     settings: Settings.settings(configurations: [
         .debug(name: .debug, xcconfig: "Configuration/Apollo/Apollo-Project-Debug.xcconfig"),

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -4,11 +4,7 @@ let workspace = Workspace(
     name: "ApolloDev",
     projects: [
         "./"
-    ],
-    additionalFiles: [
-        .folderReference(path: "apollo-ios"),
-        .folderReference(path: "apollo-ios-codegen")
-    ],
+    ],    
     generationOptions: .options(
         enableAutomaticXcodeSchemes: true
     )


### PR DESCRIPTION
This cleans this up a bit by including these directly in the Project. 

I was making some other changes to the structure of the codgen packages that was causing build errors, and doing this resolved them.