### PR TITLE
Fixing hashable implementation of GraphQLResponse

### DIFF
--- a/apollo-ios/Sources/Apollo/GraphQLResponse.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLResponse.swift
@@ -94,6 +94,6 @@ extension GraphQLResponse: Hashable where Data: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(body)
     hasher.combine(rootKey)
-    hasher.combine(variables?._jsonEncodableValue?._jsonValue)
+    hasher.combine(variables?._jsonEncodableObject._jsonValue)
   }
 }


### PR DESCRIPTION
-Fixing the implementation of GraphQLResponse that was causing xcframework build failures with Xcode 15 and Swift 5.9

Closes apollographql/apollo-ios#3154