### PR TITLE
Adding ci to auto close PRs

### DIFF
--- a/apollo-ios-codegen/.github/workflows/pr-close.yml
+++ b/apollo-ios-codegen/.github/workflows/pr-close.yml
@@ -1,0 +1,14 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    name: Close and Comment PR
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: "We do not accept PRs directly to the 'apollo-ios-codegen' repo. All development is done through the 'apollo-ios-dev' repo, please see the CONTRIBUTING guide for more information."

--- a/apollo-ios/.github/workflows/pr-close.yml
+++ b/apollo-ios/.github/workflows/pr-close.yml
@@ -1,0 +1,14 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    name: Close and Comment PR
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: "We do not accept PRs directly to the 'apollo-ios' repo. All development is done through the 'apollo-ios-dev' repo, please see the CONTRIBUTING guide for more information."


### PR DESCRIPTION
-Adding ci script to auto close and comment on PRs in the apollo-ios and apollo-ios-codegen repos

When this PR is merged we will need to manually go disable these workflows in their respective repos until we rollout the new project structure publicly and then we can re-enable them.