### PR TITLE
Adding issue callout to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ After working and making changes in the `ApolloDev.xcworkspace` you can commit y
 
 ## Issues
 
-To report an issue, bug, or feature request ou can do so in the [apollo-ios](https://github.com/apollographql/apollo-ios) repo.
+To report an issue, bug, or feature request ou can do so in the [apollo-ios](https://github.com/apollographql/apollo-ios/issues) repo.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ After you have run the `tuist generate` command you should see both an `ApolloDe
 
 After working and making changes in the `ApolloDev.xcworkspace` you can commit your changes as normal and submit a PR to the `main` branch of the `apollo-ios-dev` repo for review.
 
+## Issues
+
+To report an issue, bug, or feature request ou can do so in the [apollo-ios](https://github.com/apollographql/apollo-ios) repo.
+
 ## Roadmap
 
 The [roadmap](https://github.com/apollographql/apollo-ios/blob/main/ROADMAP.md) is a high-level document that describes the next major steps or milestones for this project. We are always open to feature requests, and contributions from the community.

--- a/apollo-ios-codegen/README.md
+++ b/apollo-ios-codegen/README.md
@@ -29,6 +29,10 @@ This repo provides the code necessary to do GraphQL code generation for the [Apo
 
 However, if you plan to handle your code generation through Swift scripting, you will now need to include the `apollo-ios-codegen` package as a dependency as it is no longer packaged as part of `apollo-ios`. In order to get start with scripting your code generation check out our guide [here](https://www.apollographql.com/docs/ios/code-generation/run-codegen-in-swift-code).
 
+## Issues
+
+To report an issue, bug, or feature request ou can do so in the [apollo-ios](https://github.com/apollographql/apollo-ios) repo.
+
 ## Releases and changelog
 
 Release of the Apollo iOS Codegen repo are tied to the releases of the [Apollo iOS](https://github.com/apollographql/apollo-ios) repo.

--- a/apollo-ios-codegen/README.md
+++ b/apollo-ios-codegen/README.md
@@ -31,7 +31,7 @@ However, if you plan to handle your code generation through Swift scripting, you
 
 ## Issues
 
-To report an issue, bug, or feature request ou can do so in the [apollo-ios](https://github.com/apollographql/apollo-ios) repo.
+To report an issue, bug, or feature request ou can do so in the [apollo-ios](https://github.com/apollographql/apollo-ios/issues) repo.
 
 ## Releases and changelog
 


### PR DESCRIPTION
Adding a callout for reporting issues in the README for `apollo-ios-codegen` and `apollo-ios-dev` as suggested in feedback in apollographql/apollo-ios#3240