### PR TITLE
Allow empty commit when amending message

### DIFF
--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Update Merge Commit Message
       shell: bash
       run: |
-        git commit --amend -m "${{ github.event.pull_request.title }} (apollographql/apollo-ios-dev#${{ github.event.pull_request.number }})"
+        git commit --allow-empty --amend -m "${{ github.event.pull_request.title }} (apollographql/apollo-ios-dev#${{ github.event.pull_request.number }})"
         git push --force-with-lease
     - name: Subtree - Apollo iOS
       uses: ./.github/actions/subtree-split-push


### PR DESCRIPTION
Noticed an error when just updating the codegen subtree to its main remote branch that the commit amend failed because the commit is technically empty so adding support for empty commits to this part of the ci to prevent this error in the future if we need to do subtree updates.