### PR TITLE
Adding migration guide for 1.6

### DIFF
--- a/docs/source/migrations/1.6.mdx
+++ b/docs/source/migrations/1.6.mdx
@@ -9,7 +9,7 @@ This guide describes the process of migrating your code from version 1.5 to vers
 
 The 1.6 update restructured the Apollo iOS ecosystem by splitting the code up into multiple different repositories/packages. One of these changes was the creation of the new `apollo-ios-codegen` repo and SPM package for users who want to do their code generation through Swift vs using the CLI tool.
 
-> **Note:** For more information on the project restructuring in the 1.6 release see [this](https://github.com/apollographql/apollo-ios/issues/3240) GitHub issue.
+> **Note:** If you use the CLI tool for code generation, this change does not affect you. For more information on the project restructuring in the 1.6 release see [this](https://github.com/apollographql/apollo-ios/issues/3240) GitHub issue.
 
 If you are doing your code generation through Swift you have something like the following in your `Package.swift` file:
 

--- a/docs/source/migrations/1.6.mdx
+++ b/docs/source/migrations/1.6.mdx
@@ -1,0 +1,52 @@
+---
+title: Apollo iOS 1.6 migration guide
+description: From 1.5 to 1.6
+---
+
+This guide describes the process of migrating your code from version 1.5 to version 1.6 of Apollo iOS. Please follow the relevant migration guides if you're on a version other than 1.5.
+
+## Apollo Codegen SPM Package
+
+The 1.6 update restructured the Apollo iOS ecosystem by splitting the code up into multiple different repositories/packages. One of these changes was the creation of the new `apollo-ios-codegen` repo and SPM package for users who want to do their code generation through Swift vs using the CLI tool.
+
+> **Note:** For more information on the project restructuring in the 1.6 release see [this](https://github.com/apollographql/apollo-ios/issues/3240) GitHub issue.
+
+If you are doing your code generation through Swift you have something like the following in your `Package.swift` file:
+
+```swift title="Package.swift"
+let package = Package(
+  name: "MyCodegen",
+  platforms: [.macOS(.v10_15)],
+  dependencies: [
+    .package(url: "https://github.com/apollographql/apollo-ios", exact: "1.5.0")
+  ],
+  targets: [
+    .executableTarget(
+      name: "MyCodegen",
+      dependencies: [
+        .product(name: "ApolloCodegenLib", package: "apollo-ios"),
+      ],
+      path: "Sources"),
+  ]
+)
+```
+
+In order to keep your code building successfully in the 1.6 release you will need to use the new `apollo-ios-codegen` package instead of the `apollo-ios` package:
+
+```swift title="Package.swift"
+let package = Package(
+  name: "MyCodegen",
+  platforms: [.macOS(.v10_15)],
+  dependencies: [
+    .package(url: "https://github.com/apollographql/apollo-ios-codegen", exact: "1.6.0")
+  ],
+  targets: [
+    .executableTarget(
+      name: "MyCodegen",
+      dependencies: [
+        .product(name: "ApolloCodegenLib", package: "apollo-ios-codegen"),
+      ],
+      path: "Sources"),
+  ]
+)
+```


### PR DESCRIPTION
Creating the migration guide for 1.6 release and adding information for the codegen package change from `apollo-ios` to `apollo-ios-codegen`