### PR TITLE
Prep apollo-ios subtree for release

### DIFF
--- a/apollo-ios/.github/CODEOWNERS.md
+++ b/apollo-ios/.github/CODEOWNERS.md
@@ -1,2 +1,2 @@
 # https://help.github.com/articles/about-code-owners/
-/docs/ @stephenbarlow
+/docs/ @apollographql/docs

--- a/apollo-ios/.gitleaks.toml
+++ b/apollo-ios/.gitleaks.toml
@@ -1,3 +1,18 @@
+# This file exists primarily to influence scheduled scans that Apollo runs of all repos in Apollo-managed orgs.
+# This is an Apollo-Internal link, but more information about these scans is available here:
+# https://apollographql.atlassian.net/wiki/spaces/SecOps/pages/81330213/Everything+Static+Application+Security+Testing#Scheduled-Scans.1
+#
+# Apollo is using Gitleaks (https://github.com/gitleaks/gitleaks) to run these scans.
+# However, this file is not something that Gitleaks natively consumes. This file is an
+# Apollo-convention. Prior to scanning a repo, Apollo merges
+# our standard Gitleaks configuration (which is largely just the Gitleaks-default config) with
+# this file if it exists in a repo. The combined config is then used to scan a repo.
+#
+# We did this because the natively-supported allowlisting functionality in Gitleaks didn't do everything we wanted
+# or wasn't as robust as we needed. For example, one of the allowlisting options offered by Gitleaks depends on the line number
+# on which a false positive secret exists to allowlist it. (https://github.com/gitleaks/gitleaks#gitleaksignore).
+# This creates a fairly fragile allowlisting mechanism. This file allows us to leverage the full capabilities of the Gitleaks rule syntax
+# to create allowlisting functionality.
 
 [[ rules ]]
     id = "high-entropy-base64"
@@ -10,7 +25,17 @@
 [[ rules ]]
     id = "generic-api-key"
     [ rules.allowlist ]
-        commits = [
-            "474554504e7e33cef2a71774f825d5b3947ff797",
-            
+
+        paths = [
+            # Allowlists a false positive detection at  
+            # https://github.com/apollographql/apollo-ios/blob/474554504e7e33cef2a71774f825d5b3947ff797/Tests/ApolloCodegenTests/TestHelpers/ASTMatchers.swift#L72
+            # This was previously allowlisted via commit hash, but updating that rule
+            # To support allowlisting false positive detections in the files below as well.
+            '''Tests/ApolloCodegenTests/TestHelpers/ASTMatchers.swift''',
+
+            # Allowlist the various high-entropy strings in xcscmblueprint files
+            '''Apollo.xcodeproj/project.xcworkspace/xcshareddata/Apollo.xcscmblueprint$''',
+            '''ApolloSQLite.xcodeproj/project.xcworkspace/xcshareddata/ApolloSQLite.xcscmblueprint$''',
+            '''Apollo.xcworkspace/xcshareddata/Apollo.xcscmblueprint$''',
         ]
+

--- a/apollo-ios/CHANGELOG.md
+++ b/apollo-ios/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## v1.5.2
+
+The purpose of this release is to provide a deprecation message to users of `ApolloCodegenLib` who are scripting their code generation in advance of an upcoming change to our libraries and repo structure. Beginning with the upcoming 1.6.0 release the code generation libraries will be their own SPM package in their own repo which will require you to add a new dependency to you project in order for your code generation scripting to compile. More information can be found in our [announcement](https://github.com/apollographql/apollo-ios/issues/3240) of this change.
+
+**If you would like to avoid this deprecation warning in your builds feel free to stay on 1.5.1 or earlier, this warning will be gone in the 1.6.0 release**
+
+PR containing deprecation warning for reference: [#3243](https://github.com/apollographql/apollo-ios/pull/3243).
+
+## v1.5.1
+
+### Improvement
+
+- **Added `OutputOptions` property to codegen for marking generated classes as `final` ([#3189](https://github.com/apollographql/apollo-ios/pull/3189)):** _Thank you to [@Mordil](https://github.com/Mordil) for the contribution._
+
+### Fixed
+
+- **Codegen `itemsToGenerate` option for `.all` not generating an operation manifest ([#3215](https://github.com/apollographql/apollo-ios/pull/3215)):** _Thank you to [@TizianoCoroneo](https://github.com/TizianoCoroneo) for finding and fixing the issue._
+- **Codegen operation manifest inadvertantly being generated twice ([#3225](https://github.com/apollographql/apollo-ios/pull/3225)):** _Thank you to [@jimisaacs](https://github.com/jimisaacs) for finding and fixing the issue._
+
 ## v1.5.0
 
 ### New

--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -80,11 +80,13 @@ extension ApolloClient: ApolloClientProtocol {
   @discardableResult public func fetch<Query: GraphQLQuery>(query: Query,
                                                             cachePolicy: CachePolicy = .default,
                                                             contextIdentifier: UUID? = nil,
+                                                            context: RequestContext? = nil,
                                                             queue: DispatchQueue = .main,
                                                             resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable {
     return self.networkTransport.send(operation: query,
                                       cachePolicy: cachePolicy,
                                       contextIdentifier: contextIdentifier,
+                                      context: context,
                                       callbackQueue: queue) { result in
       resultHandler?(result)
     }
@@ -92,10 +94,12 @@ extension ApolloClient: ApolloClientProtocol {
 
   public func watch<Query: GraphQLQuery>(query: Query,
                                          cachePolicy: CachePolicy = .default,
+                                         context: RequestContext? = nil,
                                          callbackQueue: DispatchQueue = .main,
                                          resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query> {
     let watcher = GraphQLQueryWatcher(client: self,
                                       query: query,
+                                      context: context,
                                       callbackQueue: callbackQueue,
                                       resultHandler: resultHandler)
     watcher.fetch(cachePolicy: cachePolicy)
@@ -105,12 +109,14 @@ extension ApolloClient: ApolloClientProtocol {
   @discardableResult
   public func perform<Mutation: GraphQLMutation>(mutation: Mutation,
                                                  publishResultToStore: Bool = true,
+                                                 context: RequestContext? = nil,
                                                  queue: DispatchQueue = .main,
                                                  resultHandler: GraphQLResultHandler<Mutation.Data>? = nil) -> Cancellable {
     return self.networkTransport.send(
       operation: mutation,
       cachePolicy: publishResultToStore ? .default : .fetchIgnoringCacheCompletely,
       contextIdentifier: nil,
+      context: context,
       callbackQueue: queue,
       completionHandler: { result in
         resultHandler?(result)
@@ -121,6 +127,7 @@ extension ApolloClient: ApolloClientProtocol {
   @discardableResult
   public func upload<Operation: GraphQLOperation>(operation: Operation,
                                                   files: [GraphQLFile],
+                                                  context: RequestContext? = nil,
                                                   queue: DispatchQueue = .main,
                                                   resultHandler: GraphQLResultHandler<Operation.Data>? = nil) -> Cancellable {
     guard let uploadingTransport = self.networkTransport as? UploadingNetworkTransport else {
@@ -133,17 +140,20 @@ extension ApolloClient: ApolloClientProtocol {
 
     return uploadingTransport.upload(operation: operation,
                                      files: files,
+                                     context: context,
                                      callbackQueue: queue) { result in
       resultHandler?(result)
     }
   }
   
   public func subscribe<Subscription: GraphQLSubscription>(subscription: Subscription,
+                                                           context: RequestContext? = nil,
                                                            queue: DispatchQueue = .main,
                                                            resultHandler: @escaping GraphQLResultHandler<Subscription.Data>) -> Cancellable {
     return self.networkTransport.send(operation: subscription,
                                       cachePolicy: .default,
                                       contextIdentifier: nil,
+                                      context: context,
                                       callbackQueue: queue,
                                       completionHandler: resultHandler)
   }

--- a/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
@@ -24,11 +24,13 @@ public protocol ApolloClientProtocol: AnyObject {
   ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server and when data should be loaded from the local cache.
   ///   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - contextIdentifier: [optional] A unique identifier for this request, to help with deduping cache hits for watchers. Should default to `nil`.
+  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
   /// - Returns: An object that can be used to cancel an in progress fetch.
   func fetch<Query: GraphQLQuery>(query: Query,
                                   cachePolicy: CachePolicy,
                                   contextIdentifier: UUID?,
+                                  context: RequestContext?,
                                   queue: DispatchQueue,
                                   resultHandler: GraphQLResultHandler<Query.Data>?) -> Cancellable
 
@@ -37,11 +39,13 @@ public protocol ApolloClientProtocol: AnyObject {
   /// - Parameters:
   ///   - query: The query to fetch.
   ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
+  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   ///   - callbackQueue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
   /// - Returns: A query watcher object that can be used to control the watching behavior.
   func watch<Query: GraphQLQuery>(query: Query,
                                   cachePolicy: CachePolicy,
+                                  context: RequestContext?,
                                   callbackQueue: DispatchQueue,
                                   resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query>
 
@@ -50,11 +54,13 @@ public protocol ApolloClientProtocol: AnyObject {
   /// - Parameters:
   ///   - mutation: The mutation to perform.
   ///   - publishResultToStore: If `true`, this will publish the result returned from the operation to the cache store. Default is `true`.
+  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   ///   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
   /// - Returns: An object that can be used to cancel an in progress mutation.
   func perform<Mutation: GraphQLMutation>(mutation: Mutation,
                                           publishResultToStore: Bool,
+                                          context: RequestContext?,
                                           queue: DispatchQueue,
                                           resultHandler: GraphQLResultHandler<Mutation.Data>?) -> Cancellable
 
@@ -63,11 +69,13 @@ public protocol ApolloClientProtocol: AnyObject {
   /// - Parameters:
   ///   - operation: The operation to send
   ///   - files: An array of `GraphQLFile` objects to send.
+  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   ///   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - completionHandler: The completion handler to execute when the request completes or errors. Note that an error will be returned If your `networkTransport` does not also conform to `UploadingNetworkTransport`.
   /// - Returns: An object that can be used to cancel an in progress request.
   func upload<Operation: GraphQLOperation>(operation: Operation,
                                            files: [GraphQLFile],
+                                           context: RequestContext?,
                                            queue: DispatchQueue,
                                            resultHandler: GraphQLResultHandler<Operation.Data>?) -> Cancellable
 
@@ -75,11 +83,13 @@ public protocol ApolloClientProtocol: AnyObject {
   ///
   /// - Parameters:
   ///   - subscription: The subscription to subscribe to.
+  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   ///   - fetchHTTPMethod: The HTTP Method to be used.
   ///   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
   /// - Returns: An object that can be used to cancel an in progress subscription.
   func subscribe<Subscription: GraphQLSubscription>(subscription: Subscription,
+                                                    context: RequestContext?,
                                                     queue: DispatchQueue,
                                                     resultHandler: @escaping GraphQLResultHandler<Subscription.Data>) -> Cancellable
 }

--- a/apollo-ios/Sources/Apollo/HTTPRequest.swift
+++ b/apollo-ios/Sources/Apollo/HTTPRequest.swift
@@ -20,6 +20,9 @@ open class HTTPRequest<Operation: GraphQLOperation>: Hashable {
   
   /// [optional] A unique identifier for this request, to help with deduping cache hits for watchers.
   public let contextIdentifier: UUID?
+
+  /// [optional] A context that is being passed through the request chain.
+  public let context: RequestContext?
   
   /// Designated Initializer
   ///
@@ -32,6 +35,7 @@ open class HTTPRequest<Operation: GraphQLOperation>: Hashable {
   ///   - clientVersion:  The version of the client to send with the `"apollographql-client-version"` header
   ///   - additionalHeaders: Any additional headers you wish to add by default to this request.
   ///   - cachePolicy: The `CachePolicy` to use for this request. Defaults to the `.default` policy
+  ///   - context: [optional] A context that is being passed through the request chain. Defaults to `nil`.
   public init(graphQLEndpoint: URL,
               operation: Operation,
               contextIdentifier: UUID? = nil,
@@ -39,12 +43,14 @@ open class HTTPRequest<Operation: GraphQLOperation>: Hashable {
               clientName: String,
               clientVersion: String,
               additionalHeaders: [String: String],
-              cachePolicy: CachePolicy = .default) {
+              cachePolicy: CachePolicy = .default,
+              context: RequestContext? = nil) {
     self.graphQLEndpoint = graphQLEndpoint
     self.operation = operation
     self.contextIdentifier = contextIdentifier
     self.additionalHeaders = additionalHeaders
     self.cachePolicy = cachePolicy
+    self.context = context
     
     self.addHeader(name: "Content-Type", value: contentType)
     // Note: in addition to this being a generally useful header to send, Apollo

--- a/apollo-ios/Sources/Apollo/JSONRequest.swift
+++ b/apollo-ios/Sources/Apollo/JSONRequest.swift
@@ -37,6 +37,7 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
   ///   - clientVersion:  The version of the client to send with the `"apollographql-client-version"` header
   ///   - additionalHeaders: Any additional headers you wish to add by default to this request
   ///   - cachePolicy: The `CachePolicy` to use for this request.
+  ///   - context: [optional] A context that is being passed through the request chain. Defaults to `nil`.
   ///   - autoPersistQueries: `true` if Auto-Persisted Queries should be used. Defaults to `false`.
   ///   - useGETForQueries: `true` if Queries should use `GET` instead of `POST` for HTTP requests. Defaults to `false`.
   ///   - useGETForPersistedQueryRetry: `true` if when an Auto-Persisted query is retried, it should use `GET` instead of `POST` to send the query. Defaults to `false`.
@@ -49,6 +50,7 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
     clientVersion: String,
     additionalHeaders: [String: String] = [:],
     cachePolicy: CachePolicy = .default,
+    context: RequestContext? = nil,
     autoPersistQueries: Bool = false,
     useGETForQueries: Bool = false,
     useGETForPersistedQueryRetry: Bool = false,
@@ -67,7 +69,8 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
       clientName: clientName,
       clientVersion: clientVersion,
       additionalHeaders: additionalHeaders,
-      cachePolicy: cachePolicy
+      cachePolicy: cachePolicy,
+      context: context
     )
   }
 

--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -14,12 +14,14 @@ public protocol NetworkTransport: AnyObject {
   ///   - operation: The operation to send.
   ///   - cachePolicy: The `CachePolicy` to use making this request.
   ///   - contextIdentifier:  [optional] A unique identifier for this request, to help with deduping cache hits for watchers. Defaults to `nil`.
+  ///   - context: [optional] A context that is being passed through the request chain. Defaults to `nil`.
   ///   - callbackQueue: The queue to call back on with the results. Should default to `.main`.
   ///   - completionHandler: A closure to call when a request completes. On `success` will contain the response received from the server. On `failure` will contain the error which occurred.
   /// - Returns: An object that can be used to cancel an in progress request.
   func send<Operation: GraphQLOperation>(operation: Operation,
                                          cachePolicy: CachePolicy,
                                          contextIdentifier: UUID?,
+                                         context: RequestContext?,
                                          callbackQueue: DispatchQueue,
                                          completionHandler: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) -> Cancellable
 
@@ -99,12 +101,14 @@ public protocol UploadingNetworkTransport: NetworkTransport {
   /// - Parameters:
   ///   - operation: The operation to send
   ///   - files: An array of `GraphQLFile` objects to send.
+  ///   - context: [optional] A context that is being passed through the request chain.
   ///   - callbackQueue: The queue to call back on with the results. Should default to `.main`.
   ///   - completionHandler: The completion handler to execute when the request completes or errors
   /// - Returns: An object that can be used to cancel an in progress request.
   func upload<Operation: GraphQLOperation>(
     operation: Operation,
     files: [GraphQLFile],
+    context: RequestContext?,
     callbackQueue: DispatchQueue,
     completionHandler: @escaping (Result<GraphQLResult<Operation.Data>,Error>) -> Void) -> Cancellable
 }

--- a/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -77,11 +77,14 @@ open class RequestChainNetworkTransport: NetworkTransport {
   ///   - operation: The operation to create the request for
   ///   - cachePolicy: The `CachePolicy` to use when creating the request
   ///   - contextIdentifier: [optional] A unique identifier for this request, to help with deduping cache hits for watchers. Should default to `nil`.
+  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   /// - Returns: The constructed request.
   open func constructRequest<Operation: GraphQLOperation>(
     for operation: Operation,
     cachePolicy: CachePolicy,
-    contextIdentifier: UUID? = nil) -> HTTPRequest<Operation> {
+    contextIdentifier: UUID? = nil,
+    context: RequestContext? = nil
+  ) -> HTTPRequest<Operation> {
     JSONRequest(operation: operation,
                 graphQLEndpoint: self.endpointURL,
                 contextIdentifier: contextIdentifier,
@@ -89,6 +92,7 @@ open class RequestChainNetworkTransport: NetworkTransport {
                 clientVersion: self.clientVersion,
                 additionalHeaders: self.additionalHeaders,
                 cachePolicy: cachePolicy,
+                context: context,
                 autoPersistQueries: self.autoPersistQueries,
                 useGETForQueries: self.useGETForQueries,
                 useGETForPersistedQueryRetry: self.useGETForPersistedQueryRetry,
@@ -104,13 +108,15 @@ open class RequestChainNetworkTransport: NetworkTransport {
     operation: Operation,
     cachePolicy: CachePolicy = .default,
     contextIdentifier: UUID? = nil,
+    context: RequestContext? = nil,
     callbackQueue: DispatchQueue = .main,
     completionHandler: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) -> Cancellable {
     
     let chain = makeChain(operation: operation, callbackQueue: callbackQueue)
     let request = self.constructRequest(for: operation,
                                         cachePolicy: cachePolicy,
-                                        contextIdentifier: contextIdentifier)
+                                        contextIdentifier: contextIdentifier,
+                                        context: context)
 
     if Operation.operationType == .subscription {
       request.addHeader(
@@ -144,11 +150,13 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
   /// - Parameters:
   ///   - operation: The operation to create a request for
   ///   - files: The files you wish to upload
+  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   ///   - manualBoundary: [optional] A manually set boundary for your upload request. Defaults to nil. 
   /// - Returns: The created request.
   public func constructUploadRequest<Operation: GraphQLOperation>(
     for operation: Operation,
     with files: [GraphQLFile],
+    context: RequestContext? = nil,
     manualBoundary: String? = nil) -> HTTPRequest<Operation> {
     
     UploadRequest(graphQLEndpoint: self.endpointURL,
@@ -164,10 +172,11 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
   public func upload<Operation: GraphQLOperation>(
     operation: Operation,
     files: [GraphQLFile],
+    context: RequestContext?,
     callbackQueue: DispatchQueue = .main,
     completionHandler: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) -> Cancellable {
     
-    let request = self.constructUploadRequest(for: operation, with: files)
+    let request = self.constructUploadRequest(for: operation, with: files, context: context)
     let chain = makeChain(operation: operation, callbackQueue: callbackQueue)
     chain.kickoff(request: request, completion: completionHandler)
     return chain

--- a/apollo-ios/Sources/Apollo/RequestContext.swift
+++ b/apollo-ios/Sources/Apollo/RequestContext.swift
@@ -1,0 +1,12 @@
+import Foundation
+#if !COCOAPODS
+import ApolloAPI
+#endif
+
+/// A marker protocol to set up an object to pass through the request chain.
+///
+/// Used to allow additional context-specific information to pass the length of the request chain.
+///
+/// This allows the various interceptors to make modifications, or perform actions, with information
+/// that they cannot get just from the existing operation. It can be anything that conforms to this protocol.
+public protocol RequestContext {}

--- a/apollo-ios/Sources/Apollo/UploadRequest.swift
+++ b/apollo-ios/Sources/Apollo/UploadRequest.swift
@@ -22,6 +22,7 @@ open class UploadRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
   ///   - additionalHeaders: Any additional headers you wish to add by default to this request. Defaults to an empty dictionary.
   ///   - files: The array of files to upload for all `Upload` parameters in the mutation.
   ///   - manualBoundary: [optional] A manual boundary to pass in. A default boundary will be used otherwise. Defaults to nil.
+  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   ///   - requestBodyCreator: An object conforming to the `RequestBodyCreator` protocol to assist with creating the request body. Defaults to the provided `ApolloRequestBodyCreator` implementation.
   public init(graphQLEndpoint: URL,
               operation: Operation,
@@ -30,6 +31,7 @@ open class UploadRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
               additionalHeaders: [String: String] = [:],
               files: [GraphQLFile],
               manualBoundary: String? = nil,
+              context: RequestContext? = nil,
               requestBodyCreator: RequestBodyCreator = ApolloRequestBodyCreator()) {
     self.requestBodyCreator = requestBodyCreator
     self.files = files
@@ -39,7 +41,8 @@ open class UploadRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
                contentType: "multipart/form-data",
                clientName: clientName,
                clientVersion: clientVersion,
-               additionalHeaders: additionalHeaders)
+               additionalHeaders: additionalHeaders,
+               context: context)
   }
   
   public override func toURLRequest() throws -> URLRequest {

--- a/apollo-ios/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -47,18 +47,21 @@ extension SplitNetworkTransport: NetworkTransport {
   public func send<Operation: GraphQLOperation>(operation: Operation,
                                                 cachePolicy: CachePolicy,
                                                 contextIdentifier: UUID? = nil,
+                                                context: RequestContext? = nil,
                                                 callbackQueue: DispatchQueue = .main,
                                                 completionHandler: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) -> Cancellable {
     if Operation.operationType == .subscription {
       return webSocketNetworkTransport.send(operation: operation,
                                             cachePolicy: cachePolicy,
                                             contextIdentifier: contextIdentifier,
+                                            context: context,
                                             callbackQueue: callbackQueue,
                                             completionHandler: completionHandler)
     } else {
       return uploadingNetworkTransport.send(operation: operation,
                                             cachePolicy: cachePolicy,
                                             contextIdentifier: contextIdentifier,
+                                            context: context,
                                             callbackQueue: callbackQueue,
                                             completionHandler: completionHandler)
     }
@@ -72,10 +75,12 @@ extension SplitNetworkTransport: UploadingNetworkTransport {
   public func upload<Operation: GraphQLOperation>(
     operation: Operation,
     files: [GraphQLFile],
+    context: RequestContext?,
     callbackQueue: DispatchQueue = .main,
     completionHandler: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) -> Cancellable {
     return uploadingNetworkTransport.upload(operation: operation,
                                             files: files,
+                                            context: context,
                                             callbackQueue: callbackQueue,
                                             completionHandler: completionHandler)
   }

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -438,6 +438,7 @@ extension WebSocketTransport: NetworkTransport {
     operation: Operation,
     cachePolicy: CachePolicy,
     contextIdentifier: UUID? = nil,
+    context: RequestContext? = nil,
     callbackQueue: DispatchQueue = .main,
     completionHandler: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) -> Cancellable {
     


### PR DESCRIPTION
Merged `main` from `apollo-ios` repo into the `apollo-ios` subtree to sync histories in preparation for full release.