### PR TITLE
Handle coercion of AnyHashable 

### DIFF
--- a/Tests/ApolloInternalTestHelpers/SelectionSet+TestHelpers.swift
+++ b/Tests/ApolloInternalTestHelpers/SelectionSet+TestHelpers.swift
@@ -9,7 +9,7 @@ public extension SelectionSet {
     guard let value = self.__data._data[key] else {
       return false
     }
-    return value == DataDict.NullValue
+    return value == DataDict._NullValue
   }
 
 }

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -1436,12 +1436,20 @@ class SelectionSetTests: XCTestCase {
       return
     }
     expect(nameValue).to(beNil())
-
-    guard let nameValue = nameValue as? String? else {
-      fail("name should be Optional.some(Optional.none).")
-      return
+    
+    if DataDict._AnyHashableCanBeCoerced {
+      guard let nameValue = nameValue as? String? else {
+        fail("name should be Optional.some(Optional.none).")
+        return
+      }
+      expect(nameValue).to(beNil())
+    } else {
+      guard let nameValue = nameValue.base as? String? else {
+        fail("name should be Optional.some(Optional.none).")
+        return
+      }
+      expect(nameValue).to(beNil())
     }
-    expect(nameValue).to(beNil())
   }
 
   func test__selectionInitializer_givenOptionalEntityField__fieldIsPresentWithOptionalNilValue() {
@@ -1510,11 +1518,20 @@ class SelectionSetTests: XCTestCase {
     }
     expect(childValue).to(beNil())
 
-    guard let childValue = childValue as? Hero.Child? else {
-      fail("child should be Optional.some(Optional.none).")
-      return
+    if DataDict._AnyHashableCanBeCoerced {
+      guard let childValue = childValue as? Hero.Child? else {
+        fail("child should be Optional.some(Optional.none).")
+        return
+      }
+      expect(childValue).to(beNil())
+
+    } else {
+      guard let childValue = childValue.base as? Hero.Child? else {
+        fail("child should be Optional.some(Optional.none).")
+        return
+      }
+      expect(childValue).to(beNil())
     }
-    expect(childValue).to(beNil())
   }
 
   func test__selectionInitializer_givenOptionalListOfOptionalEntitiesField__setsFieldDataCorrectly() {

--- a/apollo-ios/Sources/Apollo/GraphQLSelectionSetMapper.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLSelectionSetMapper.swift
@@ -45,7 +45,7 @@ final class GraphQLSelectionSetMapper<T: SelectionSet>: GraphQLResultAccumulator
   }
 
   func acceptNullValue(info: FieldExecutionInfo) -> AnyHashable? {
-    return DataDict.NullValue
+    return DataDict._NullValue
   }
 
   func acceptMissingValue(info: FieldExecutionInfo) throws -> AnyHashable? {
@@ -85,12 +85,4 @@ final class GraphQLSelectionSetMapper<T: SelectionSet>: GraphQLResultAccumulator
   func finish(rootValue: DataDict, info: ObjectExecutionInfo) -> T {
     return T.init(_dataDict: rootValue)
   }
-}
-
-// MARK: - Null Value Definition
-extension DataDict {
-  /// A common value used to represent a null value in a `DataDict`.
-  ///
-  /// This value can be cast to `NSNull` and will bridge automatically.
-  static let NullValue = AnyHashable(Optional<AnyHashable>.none)
 }

--- a/apollo-ios/Sources/ApolloAPI/DataDict.swift
+++ b/apollo-ios/Sources/ApolloAPI/DataDict.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// A structure that wraps the underlying data for a ``SelectionSet``.
 public struct DataDict: Hashable {
   @usableFromInline var _storage: _Storage
@@ -51,11 +53,16 @@ public struct DataDict: Hashable {
 
   @inlinable public subscript<T: AnyScalarType & Hashable>(_ key: String) -> T {
     get {
-#if swift(>=5.4)
-        _data[key] as! T
-#else
-        _data[key]?.base as! T
-#endif
+      if DataDict._AnyHashableCanBeCoerced {
+        return _data[key] as! T
+      } else {        
+        let value = _data[key]
+        if value == DataDict._NullValue {
+          return (Optional<T>.none as Any) as! T
+        } else {
+          return (value?.base as? T) ?? (value._asAnyHashable as! T)
+        }
+      }
     }
     set {
       _data[key] = newValue
@@ -126,6 +133,34 @@ public struct DataDict: Hashable {
   }
 }
 
+// MARK: - Null Value Definition
+extension DataDict {
+  /// A common value used to represent a null value in a `DataDict`.
+  ///
+  /// This value can be cast to `NSNull` and will bridge automatically.
+  public static let _NullValue = {
+    if DataDict._AnyHashableCanBeCoerced {
+      return AnyHashable(Optional<AnyHashable>.none)
+    } else {
+      return NSNull()
+    }
+  }()
+
+  /// Indicates if `AnyHashable` can be coerced via casting into its underlying type.
+  ///
+  /// In iOS versions 14.4 and lower, `AnyHashable` coercion does not work. On these platforms,
+  /// we need to do some additional unwrapping and casting of the values to avoid crashes and other
+  /// run time bugs.
+  public static var _AnyHashableCanBeCoerced: Bool {
+    if #available(iOS 14.5, *) {
+      return true
+    } else {
+      return false
+    }
+  }
+
+}
+
 // MARK: - Value Conversion Helpers
 
 public protocol SelectionSetEntityValue {
@@ -160,11 +195,13 @@ extension Optional: SelectionSetEntityValue where Wrapped: SelectionSetEntityVal
       case .none:
         self = .none
       case .some(let hashable):
-        if let optional = hashable.base as? Optional<AnyHashable>, optional == nil {
-          self = .none
-          return
-        }
+      if DataDict._AnyHashableCanBeCoerced && hashable == DataDict._NullValue {
+        self = .none
+      } else if let optional = hashable.base as? Optional<AnyHashable>, optional == nil {
+        self = .none
+      } else {
         self = .some(Wrapped.init(_fieldData: data))
+      }
     }
   }
 
@@ -179,11 +216,11 @@ extension Array: SelectionSetEntityValue where Element: SelectionSetEntityValue 
       fatalError("\(Self.self) expected list of data for entity.")
     }
     self = data.map {
-#if swift(>=5.4)
+      if DataDict._AnyHashableCanBeCoerced {
         Element.init(_fieldData:$0)
-#else
+      } else {
         Element.init(_fieldData:$0?.base as? AnyHashable)
-#endif
+      }
     }
   }
 

--- a/apollo-ios/Sources/ApolloAPI/DataDict.swift
+++ b/apollo-ios/Sources/ApolloAPI/DataDict.swift
@@ -217,9 +217,9 @@ extension Array: SelectionSetEntityValue where Element: SelectionSetEntityValue 
     }
     self = data.map {
       if DataDict._AnyHashableCanBeCoerced {
-        Element.init(_fieldData:$0)
+        return Element.init(_fieldData:$0)
       } else {
-        Element.init(_fieldData:$0?.base as? AnyHashable)
+        return Element.init(_fieldData:$0?.base as? AnyHashable)
       }
     }
   }

--- a/apollo-ios/Sources/ApolloTestSupport/TestMock.swift
+++ b/apollo-ios/Sources/ApolloTestSupport/TestMock.swift
@@ -97,7 +97,7 @@ public class Mock<O: MockObject>: AnyMock, Hashable {
 
   public var _selectionSetMockData: JSONObject {
     _data.mapValues {
-      if let mock = $0 as? AnyMock {
+      if let mock = $0.base as? AnyMock {
         return mock._selectionSetMockData
       }
       if let mockArray = $0 as? Array<Any> {
@@ -188,20 +188,27 @@ fileprivate extension Array {
   }
 
   func _unsafelyConvertToSelectionSetData() -> [AnyHashable?] {
-    map { element in
-      switch element {
-      case let element as AnyMock:
-        return element._selectionSetMockData
+    map(_unsafelyConvertToSelectionSetData(element:))
+  }
 
-      case let innerArray as Array<Any>:
-        return innerArray._unsafelyConvertToSelectionSetData()
+  private func _unsafelyConvertToSelectionSetData(element: Any) -> AnyHashable? {
+    switch element {
+    case let element as AnyMock:
+      return element._selectionSetMockData
 
-      case let element as AnyHashable:
+    case let innerArray as Array<Any>:
+      return innerArray._unsafelyConvertToSelectionSetData()
+
+    case let element as AnyHashable:
+      if DataDict._AnyHashableCanBeCoerced {
         return element
 
-      default:
-        return nil
+      } else {
+        return _unsafelyConvertToSelectionSetData(element: element.base)
       }
+
+    default:
+      return nil
     }
   }
 }


### PR DESCRIPTION
In iOS versions 14.4 and lower, `AnyHashable` coercion does not work. On these platforms, we need to do some additional unwrapping and casting of the values to avoid crashes and other run time bugs.

In addition to doing some more explicit handling of the null values, this PR changes the check for the coercion from 
`#if swift (>=5.4)` to `if #available(iOS 14.5, *)`. It turns out that this is not particularly related to the swift version, but to the iOS version being run.

This PR has been tested locally on iOS 14.4, 14.5, and 17.0.