### PR TITLE
Moving docs publish ci job

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release/1.0
     paths:
       - docs/**
 


### PR DESCRIPTION
Moving the docs publish ci job from the `apollo-ios` repo to the `apollo-ios-dev` repo