### PR TITLE
Adding new validation job

### DIFF
--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -42,6 +42,7 @@ jobs:
         pr-number: ${{ github.event.pull_request.number }}
         pr-title: ${{ github.event.pull_request.title }}
     - name: Subtree - Apollo iOS Codegen
+      if: always()
       uses: ./.github/actions/subtree-split-push
       with:
         subtree: apollo-ios-codegen
@@ -50,6 +51,7 @@ jobs:
         pr-number: ${{ github.event.pull_request.number }}
         pr-title: ${{ github.event.pull_request.title }}
     - name: Subtree - Apollo iOS Pagination
+      if: always()
       uses: ./.github/actions/subtree-split-push
       with:
         subtree: apollo-ios-pagination
@@ -58,6 +60,7 @@ jobs:
         pr-number: ${{ github.event.pull_request.number }}
         pr-title: ${{ github.event.pull_request.title }}
     - name: Push Updated History
+      if: always()
       shell: bash
       run: |
         git push

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,312 @@
+name: "Main Branch Health"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * *"
+
+env:
+  XCODE_VERSION: "15.0.0"
+
+jobs:
+  run-swift-builds:
+    runs-on: macos-13
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: apollo-ios
+          - package: apollo-ios-codegen
+          - package: apollo-ios-pagination
+    name: Run swift build for SPM packages
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Setup Repo
+      id: setup-repo
+      uses: ./.github/actions/setup-repo
+    - name: Run Swift Build
+      shell: bash
+      run: |
+        cd ${{ matrix.package }} && swift build
+
+  build-and-unit-test:
+    runs-on: macos-13
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS_current
+          - destination: platform=macOS,arch=x86_64
+            scheme: ApolloTests
+            test-plan: Apollo-CITestPlan
+            name: Apollo Unit Tests - macOS
+            run-js-tests: false
+          # iOS_current
+          - destination: platform=iOS Simulator,OS=17.0,name=iPhone 15
+            scheme: ApolloTests
+            test-plan: Apollo-CITestPlan
+            name: Apollo Unit Tests - iOS 17.0
+            run-js-tests: false
+          # tvOS_current
+          - destination: platform=tvOS Simulator,OS=17.0,name=Apple TV
+            scheme: ApolloTests
+            test-plan: Apollo-CITestPlan
+            name: Apollo Unit Tests - tvOS ${{ vars.TVOS_VERSION }}
+            run-js-tests: false
+          # Codegen CLI Test
+          - destination: platform=macOS,arch=x86_64
+            scheme: CodegenCLITests
+            test-plan: CodegenCLITestPlan
+            name: Codegen CLI Unit Tests - macOS
+            run-js-tests: false
+          # CodegenLib Test
+          - destination: platform=macOS,arch=x86_64
+            scheme: ApolloCodegenTests
+            test-plan: Apollo-Codegen-CITestPlan
+            name: Codegen Lib Unit Tests - macOS
+            run-js-tests: true
+    name: ${{ matrix.name }}
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Setup Repo
+      id: setup-repo
+      uses: ./.github/actions/setup-repo
+    # Caching for apollo-ios and apollo-ios-codegen SPM dependencies
+    # - uses: actions/cache@v3
+    #   with:
+    #     path: ./DerivedData/SourcePackages
+    #     key: ${{ runner.os }}-spm-${{ hashFiles('./apollo-ios/Package.resolved') }}-${{ hashFiles('./apollo-ios-codegen/Package.resolved') }}
+    - name: Run Tuist Generation
+      uses: tuist/tuist-action@0.13.0
+      with:
+          command: 'generate'
+          arguments: ''
+    - name: Build and Test
+      uses: ./.github/actions/build-and-run-unit-tests
+      with:
+        destination: ${{ matrix.destination }}
+        scheme: ${{ matrix.scheme }}
+        test-plan: ${{ matrix.test-plan }}
+    - name: Run-JS-Tests
+      if: ${{ matrix.run-js-tests == true }}
+      shell: bash
+      working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/
+      run: |
+        npm install && npm test
+    - name: Save xcodebuild logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}-logs
+        path: |
+          DerivedData/Logs/Build
+    - name: Save crash logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}-crashes
+        path: |
+          ~/Library/Logs/DiagnosticReports
+    - name: Zip Result Bundle
+      shell: bash
+      working-directory: TestResults
+      run: |
+        zip -r ResultBundle.zip ResultBundle.xcresult
+    - name: Save test results
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}-results
+        path: |
+          TestResults/ResultBundle.zip
+
+  legacy-unit-test:
+    runs-on: macos-11
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # iOS 14.4
+          - destination: platform=iOS Simulator,OS=14.4,name=iPhone 12
+            scheme: ApolloTests
+            test-plan: Apollo-CITestPlan
+            name: Apollo Unit Tests - iOS 14.4
+    name: ${{ matrix.name }}
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: 12.4.0
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Setup Repo
+      id: setup-repo
+      uses: ./.github/actions/setup-repo
+    # Caching for apollo-ios and apollo-ios-codegen SPM dependencies
+    # - uses: actions/cache@v3
+    #   with:
+    #     path: ./DerivedData/SourcePackages
+    #     key: ${{ runner.os }}-spm-${{ hashFiles('./apollo-ios/Package.resolved') }}-${{ hashFiles('./apollo-ios-codegen/Package.resolved') }}
+    - name: Run Tuist Generation
+      uses: tuist/tuist-action@0.13.0
+      with:
+          command: 'generate'
+          arguments: ''
+    - name: Build and Test
+      uses: ./.github/actions/build-and-run-unit-tests
+      with:
+        destination: ${{ matrix.destination }}
+        scheme: ${{ matrix.scheme }}
+        test-plan: ${{ matrix.test-plan }}
+    - name: Run-JS-Tests
+      if: ${{ matrix.run-js-tests == true }}
+      shell: bash
+      working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/
+      run: |
+        npm install && npm test
+    - name: Save xcodebuild logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}-logs
+        path: |
+          DerivedData/Logs/Build
+    - name: Save crash logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}-crashes
+        path: |
+          ~/Library/Logs/DiagnosticReports
+    - name: Zip Result Bundle
+      shell: bash
+      working-directory: TestResults
+      run: |
+        zip -r ResultBundle.zip ResultBundle.xcresult
+    - name: Save test results
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}-results
+        path: |
+          TestResults/ResultBundle.zip
+
+  run-codegen-test-configurations:
+    runs-on: macos-13
+    timeout-minutes: 20
+    name: Codegen Test Configurations - macOS
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Setup Repo
+      id: setup-repo
+      uses: ./.github/actions/setup-repo
+    - name: Install XCBeautify
+      shell: bash
+      run: |
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify
+    - name: Test Codegen Configurations
+      shell: bash
+      run: |
+        ./scripts/run-test-codegen-configurations.sh -t
+
+  run-cocoapods-integration-tests:
+    runs-on: macos-13
+    timeout-minutes: 20
+    name: Cocoapods Integration Tests - macOS
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Setup Repo
+      id: setup-repo
+      uses: ./.github/actions/setup-repo
+    - name: Export ENV Variables
+      shell: bash
+      working-directory: apollo-ios
+      run: |
+        apollo_ios_sha=$(git rev-parse HEAD)
+        echo "APOLLO_IOS_SHA=$apollo_ios_sha" >> ${GITHUB_ENV}
+    - name: Run CocoaPods Integration Tests
+      id: run-cocoapods-integration-tests
+      uses: ./.github/actions/run-cocoapods-integration-tests
+
+  run-integration-tests:
+    runs-on: macos-13
+    timeout-minutes: 20
+    name: Apollo Integration Tests - macOS
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Setup Repo
+      id: setup-repo
+      uses: ./.github/actions/setup-repo
+    - name: Setup Node 12.22.10
+      uses: actions/setup-node@v3
+      with:
+        node-version: 12.22.10
+    - name: Setup Upload Server
+      shell: bash
+      run: |
+        sudo chmod -R +rwx SimpleUploadServer
+        cd SimpleUploadServer && npm install && npm start &
+    - name: Setup Node 18.15.0
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.15.0
+    - name: Setup Subscription Server
+      shell: bash
+      run: |
+        sh ./scripts/install-apollo-server-docs-example-server.sh
+        cd ../docs-examples/apollo-server/v3/subscriptions-graphql-ws && npm start &
+    - name: Setup Star Wars Server
+      shell: bash
+      run: |
+        sh ./scripts/install-or-update-starwars-server.sh
+        cd ../starwars-server && npm start &
+    - name: Run Tuist Generation
+      uses: tuist/tuist-action@0.13.0
+      with:
+          command: 'generate'
+          arguments: ''
+    - name: Build and Test
+      uses: ./.github/actions/build-and-run-unit-tests
+      with:
+        destination: platform=macOS,arch=x86_64
+        scheme: ApolloServerIntegrationTests
+        test-plan: Apollo-IntegrationTestPlan
+    - name: Save xcodebuild logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: macOS-Integration-logs
+        path: |
+          DerivedData/Logs/Build
+    - name: Save crash logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: macOS-Integration-crashes
+        path: |
+          ~/Library/Logs/DiagnosticReports
+    - name: Zip Result Bundle
+      shell: bash
+      working-directory: TestResults
+      run: |
+        zip -r ResultBundle.zip ResultBundle.xcresult
+    - name: Save test results
+      uses: actions/upload-artifact@v3
+      with:
+        name: macOS-Integration-results
+        path: |
+          TestResults/ResultBundle.zip


### PR DESCRIPTION
- Adding new job to run nightly and with releases to validate tests on all platforms
- Updated PR Subtree CI to always run each subtree job regardless of if the others fails