### PR TITLE
Adjusting Xcode version for nightly job

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -141,9 +141,6 @@ jobs:
             name: Apollo Unit Tests - iOS 14.4
     name: ${{ matrix.name }}
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 12.4.0
     - name: Checkout Repo
       uses: actions/checkout@v3
     - name: Setup Repo
@@ -159,6 +156,9 @@ jobs:
       with:
           command: 'generate'
           arguments: ''
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: 12.4.0
     - name: Build and Test
       uses: ./.github/actions/build-and-run-unit-tests
       with:


### PR DESCRIPTION
Adjusting the Xcode version for the legacy testing nightly job to try and resolve an error with tuist where it appears to have a dependency on Swift Concurrency then switching to a lower version to test iOS 14.4