### PR TITLE
Adjusting PR Subtree Push config

### DIFF
--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -4,7 +4,7 @@ permissions:
   contents: write
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
         - main
     types: [closed]


### PR DESCRIPTION
Adjusting the pr-subtree-push workflow to be based on 'pull_request_target' instead of 'pull_request' so it runs based in our repo vs the forked repo and can access the secrets needed to perform the work.

Docs here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target