### PR TITLE
Updating pagination docs and pr close bot

### DIFF
--- a/apollo-ios-pagination/.github/workflows/pr-close.yml
+++ b/apollo-ios-pagination/.github/workflows/pr-close.yml
@@ -1,0 +1,14 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    name: Close and Comment PR
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: "We do not accept PRs directly to the 'apollo-ios-pagination' repo. All development is done through the 'apollo-ios-dev' repo, please see the CONTRIBUTING guide for more information."

--- a/apollo-ios-pagination/CONTRIBUTING.md
+++ b/apollo-ios-pagination/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+If you would like to contribute to this library, you should make your code modifications and pull requests in the the [apollo-ios-dev](https://github.com/apollographql/apollo-ios-dev) repository. For more information, see the contributor guide in the `apollo-ios-dev` repo [here](https://github.com/apollographql/apollo-ios-dev/tree/main/CONTRIBUTING.md)


### PR DESCRIPTION
-Adding CI job to auto closes PRs in the pagination repo and direct users to apollo-ios-dev 
-Adding CONTRIBUTING guide that directs users to apollo-ios-dev to contribute to the pagination library