### PR TITLE
[2/x] Refactor root field builder for deferred named fragments

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
@@ -5159,7 +5159,7 @@ class IRRootFieldBuilderTests: XCTestCase {
 
   // MARK: Deferred Fragments - Named Fragments
 
-  func test__deferredFragments__givenDeferredNamedFragment_buildsDeferredInlineFragment() throws {
+  func test__deferredFragments__givenDeferredNamedFragment_buildsDeferredNamedFragment() throws {
     // given
     schemaSDL = """
       type Query {
@@ -5199,7 +5199,7 @@ class IRRootFieldBuilderTests: XCTestCase {
     let Object_Dog = try XCTUnwrap(schema[object: "Dog"])
     let Fragment_DogFragment = try XCTUnwrap(ir.compilationResult[fragment: "DogFragment"])
 
-    let allAnimals = self.subject[field: "allAnimals"] as? IR.EntityField
+    let allAnimals = self.subject[field: "allAnimals"]
     let allAnimals_AsDog = allAnimals?[as: "Dog"]
     let allAnimals_AsDog_DogFragment = allAnimals_AsDog?[fragment: "DogFragment"]
 
@@ -5230,6 +5230,224 @@ class IRRootFieldBuilderTests: XCTestCase {
       )
     ))
     #warning("fix these 'wrong' merges")
+  }
+
+  func test__deferredFragments__givenDeferredNamedFragmentWithVariableCondition_buildsDeferredNamedFragmentWithVariable() throws {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      interface Animal {
+        id: String
+        species: String
+      }
+
+      type Dog implements Animal {
+        id: String
+        species: String
+      }
+      """
+
+    document = """
+      query TestOperation {
+        allAnimals {
+          __typename
+          id
+          ...DogFragment @defer(if: "a", label: "root")
+        }
+      }
+
+      fragment DogFragment on Dog {
+        species
+      }
+      """
+
+    // when
+    try buildSubjectRootField()
+
+    // then
+    let Interface_Animal = try XCTUnwrap(schema[interface: "Animal"])
+    let Object_Dog = try XCTUnwrap(schema[object: "Dog"])
+    let Fragment_DogFragment = try XCTUnwrap(ir.compilationResult[fragment: "DogFragment"])
+
+    let allAnimals = self.subject[field: "allAnimals"]
+    let allAnimals_AsDog = allAnimals?[as: "Dog"]
+    let allAnimals_AsDog_DogFragment = allAnimals_AsDog?[fragment: "DogFragment"]
+
+    expect(allAnimals?.selectionSet).to(shallowlyMatch(
+      SelectionSetMatcher(
+        parentType: Interface_Animal,
+        directSelections: [
+          .field("id", type: .string()),
+          .inlineFragment(parentType: Object_Dog),
+        ]
+      )
+    ))
+
+    expect(allAnimals_AsDog).to(shallowlyMatch(
+      SelectionSetMatcher(
+        parentType: Object_Dog,
+        directSelections: [
+          .deferred(Fragment_DogFragment, label: "root", variable: "a"),
+        ],
+        mergedSelections: [
+          .field("id", type: .string()),
+          .field("species", type: .string()), // wrong
+        ],
+        mergedSources: [
+          try .mock(allAnimals),
+          try .mock(allAnimals_AsDog_DogFragment), // wrong
+        ]
+      )
+    ))
+    #warning("fix these 'wrong' merges")
+  }
+
+  func test__deferredFragments__givenDeferredNamedFragmentWithTrueCondition_buildsDeferredNamedFragment() throws {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      interface Animal {
+        id: String
+        species: String
+      }
+
+      type Dog implements Animal {
+        id: String
+        species: String
+      }
+      """
+
+    document = """
+      query TestOperation {
+        allAnimals {
+          __typename
+          id
+          ...DogFragment @defer(if: true, label: "root")
+        }
+      }
+
+      fragment DogFragment on Dog {
+        species
+      }
+      """
+
+    // when
+    try buildSubjectRootField()
+
+    // then
+    let Interface_Animal = try XCTUnwrap(schema[interface: "Animal"])
+    let Object_Dog = try XCTUnwrap(schema[object: "Dog"])
+    let Fragment_DogFragment = try XCTUnwrap(ir.compilationResult[fragment: "DogFragment"])
+
+    let allAnimals = self.subject[field: "allAnimals"]
+    let allAnimals_AsDog = allAnimals?[as: "Dog"]
+    let allAnimals_AsDog_DogFragment = allAnimals_AsDog?[fragment: "DogFragment"]
+
+    expect(allAnimals?.selectionSet).to(shallowlyMatch(
+      SelectionSetMatcher(
+        parentType: Interface_Animal,
+        directSelections: [
+          .field("id", type: .string()),
+          .inlineFragment(parentType: Object_Dog),
+        ]
+      )
+    ))
+
+    expect(allAnimals_AsDog).to(shallowlyMatch(
+      SelectionSetMatcher(
+        parentType: Object_Dog,
+        directSelections: [
+          .deferred(Fragment_DogFragment, label: "root"),
+        ],
+        mergedSelections: [
+          .field("id", type: .string()),
+          .field("species", type: .string()), // wrong
+        ],
+        mergedSources: [
+          try .mock(allAnimals),
+          try .mock(allAnimals_AsDog_DogFragment), // wrong
+        ]
+      )
+    ))
+    #warning("fix these 'wrong' merges")
+  }
+
+  func test__deferredFragments__givenDeferredNamedFragmentWithFalseCondition_doesNotBuildDeferredNamedFragment() throws {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      interface Animal {
+        id: String
+        species: String
+      }
+
+      type Dog implements Animal {
+        id: String
+        species: String
+      }
+      """
+
+    document = """
+      query TestOperation {
+        allAnimals {
+          __typename
+          id
+          ...DogFragment @defer(if: false, label: "root")
+        }
+      }
+
+      fragment DogFragment on Dog {
+        species
+      }
+      """
+
+    // when
+    try buildSubjectRootField()
+
+    // then
+    let Interface_Animal = try XCTUnwrap(schema[interface: "Animal"])
+    let Object_Dog = try XCTUnwrap(schema[object: "Dog"])
+    let Fragment_DogFragment = try XCTUnwrap(ir.compilationResult[fragment: "DogFragment"])
+
+    let allAnimals = self.subject[field: "allAnimals"]
+    let allAnimals_AsDog = allAnimals?[as: "Dog"]
+    let allAnimals_AsDog_DogFragment = allAnimals_AsDog?[fragment: "DogFragment"]
+
+    expect(allAnimals?.selectionSet).to(shallowlyMatch(
+      SelectionSetMatcher(
+        parentType: Interface_Animal,
+        directSelections: [
+          .field("id", type: .string()),
+          .inlineFragment(parentType: Object_Dog),
+        ]
+      )
+    ))
+
+    expect(allAnimals_AsDog).to(shallowlyMatch(
+      SelectionSetMatcher(
+        parentType: Object_Dog,
+        directSelections: [
+          .fragmentSpread("DogFragment", type: Object_Dog),
+        ],
+        mergedSelections: [
+          .field("id", type: .string()),
+          .field("species", type: .string()),
+        ],
+        mergedSources: [
+          try .mock(allAnimals),
+          try .mock(allAnimals_AsDog_DogFragment),
+        ]
+      )
+    ))
   }
 
 }

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
@@ -4499,14 +4499,11 @@ class IRRootFieldBuilderTests: XCTestCase {
     interface Animal {
       id: String
       species: String
-      genus: String
     }
 
     type Dog implements Animal {
       id: String
       species: String
-      genus: String
-      name: String
     }
     """
 
@@ -5158,6 +5155,81 @@ class IRRootFieldBuilderTests: XCTestCase {
         ]
       )
     ))
+  }
+
+  // MARK: Deferred Fragments - Named Fragments
+
+  func test__deferredFragments__givenDeferredNamedFragment_buildsDeferredInlineFragment() throws {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      interface Animal {
+        id: String
+        species: String
+      }
+
+      type Dog implements Animal {
+        id: String
+        species: String
+      }
+      """
+
+    document = """
+      query TestOperation {
+        allAnimals {
+          __typename
+          id
+          ...DogFragment @defer(label: "root")
+        }
+      }
+
+      fragment DogFragment on Dog {
+        species
+      }
+      """
+
+    // when
+    try buildSubjectRootField()
+
+    // then
+    let Interface_Animal = try XCTUnwrap(schema[interface: "Animal"])
+    let Object_Dog = try XCTUnwrap(schema[object: "Dog"])
+    let Fragment_DogFragment = try XCTUnwrap(ir.compilationResult[fragment: "DogFragment"])
+
+    let allAnimals = self.subject[field: "allAnimals"] as? IR.EntityField
+    let allAnimals_AsDog = allAnimals?[as: "Dog"]
+    let allAnimals_AsDog_DogFragment = allAnimals_AsDog?[fragment: "DogFragment"]
+
+    expect(allAnimals?.selectionSet).to(shallowlyMatch(
+      SelectionSetMatcher(
+        parentType: Interface_Animal,
+        directSelections: [
+          .field("id", type: .string()),
+          .inlineFragment(parentType: Object_Dog),
+        ]
+      )
+    ))
+
+    expect(allAnimals_AsDog).to(shallowlyMatch(
+      SelectionSetMatcher(
+        parentType: Object_Dog,
+        directSelections: [
+          .deferred(Fragment_DogFragment, label: "root"),
+        ],
+        mergedSelections: [
+          .field("id", type: .string()),
+          .field("species", type: .string()), // wrong
+        ],
+        mergedSources: [
+          try .mock(allAnimals),
+          try .mock(allAnimals_AsDog_DogFragment), // wrong
+        ]
+      )
+    ))
+    #warning("fix these 'wrong' merges")
   }
 
 }

--- a/Tests/ApolloCodegenTests/TestHelpers/IRMatchers.swift
+++ b/Tests/ApolloCodegenTests/TestHelpers/IRMatchers.swift
@@ -258,12 +258,11 @@ public enum ShallowSelectionMatcher {
   public static func deferred(
     _ parentType: GraphQLCompositeType,
     label: String,
-    variable: String? = nil,
-    inclusionConditions: [IR.InclusionCondition]? = nil
+    variable: String? = nil
   ) -> ShallowSelectionMatcher {
     .shallowInlineFragment(ShallowInlineFragmentMatcher(
       parentType: parentType,
-      inclusionConditions: inclusionConditions,
+      inclusionConditions: nil,
       deferCondition: IR.DeferCondition(label: label, variable: variable)
     ))
   }

--- a/Tests/ApolloCodegenTests/TestHelpers/IRMatchers.swift
+++ b/Tests/ApolloCodegenTests/TestHelpers/IRMatchers.swift
@@ -229,7 +229,8 @@ public enum ShallowSelectionMatcher {
     .shallowFragmentSpread(ShallowFragmentSpreadMatcher(
       name: name,
       type: type,
-      inclusionConditions: inclusionConditions
+      inclusionConditions: inclusionConditions,
+      deferCondition: nil
     ))
   }
 
@@ -240,7 +241,8 @@ public enum ShallowSelectionMatcher {
     .shallowFragmentSpread(ShallowFragmentSpreadMatcher(
       name: fragment.name,
       type: fragment.type,
-      inclusionConditions: inclusionConditions
+      inclusionConditions: inclusionConditions,
+      deferCondition: nil
     ))
   }
 
@@ -251,7 +253,8 @@ public enum ShallowSelectionMatcher {
     .shallowFragmentSpread(ShallowFragmentSpreadMatcher(
       name: fragment.name,
       type: fragment.type,
-      inclusionConditions: inclusionConditions
+      inclusionConditions: inclusionConditions,
+      deferCondition: nil
     ))
   }
 
@@ -275,7 +278,8 @@ public enum ShallowSelectionMatcher {
     .shallowFragmentSpread(ShallowFragmentSpreadMatcher(
       name: fragment.name,
       type: fragment.type,
-      inclusionConditions: nil
+      inclusionConditions: nil,
+      deferCondition: DeferCondition(label: label, variable: variable)
     ))
   }
 }
@@ -460,14 +464,18 @@ public struct ShallowFragmentSpreadMatcher: Equatable, CustomDebugStringConverti
   let name: String
   let type: GraphQLCompositeType
   let inclusionConditions: AnyOf<IR.InclusionConditions>?
+  let deferCondition: IR.DeferCondition?
 
   init(
     name: String,
     type: GraphQLCompositeType,
-    inclusionConditions: [IR.InclusionCondition]?
+    inclusionConditions: [IR.InclusionCondition]?,
+    deferCondition: IR.DeferCondition?
   ) {
     self.name = name
     self.type = type
+    self.deferCondition = deferCondition
+
     if let inclusionConditions = inclusionConditions,
      let evaluatedConditions = IR.InclusionConditions.allOf(inclusionConditions).conditions {
       self.inclusionConditions = AnyOf(evaluatedConditions)
@@ -480,33 +488,47 @@ public struct ShallowFragmentSpreadMatcher: Equatable, CustomDebugStringConverti
   init(
     name: String,
     type: GraphQLCompositeType,
-    inclusionConditions: AnyOf<IR.InclusionConditions>?
+    inclusionConditions: AnyOf<IR.InclusionConditions>?,
+    deferCondition: IR.DeferCondition?
   ) {
     self.name = name
     self.type = type
     self.inclusionConditions = inclusionConditions
+    self.deferCondition = deferCondition
   }
 
   public static func mock(
     _ name: String,
     type: GraphQLCompositeType,
-    inclusionConditions: AnyOf<IR.InclusionConditions>? = nil
+    inclusionConditions: AnyOf<IR.InclusionConditions>? = nil,
+    deferCondition: IR.DeferCondition? = nil
   ) -> ShallowFragmentSpreadMatcher {
-    self.init(name: name, type: type, inclusionConditions: inclusionConditions)
+    self.init(
+      name: name,
+      type: type,
+      inclusionConditions: inclusionConditions,
+      deferCondition: deferCondition
+    )
   }
 
   public static func mock(
     _ fragment: CompilationResult.FragmentDefinition,
-    inclusionConditions: AnyOf<IR.InclusionConditions>? = nil
+    inclusionConditions: AnyOf<IR.InclusionConditions>? = nil,
+    deferCondition: IR.DeferCondition? = nil
   ) -> ShallowFragmentSpreadMatcher {
-    self.init(name: fragment.name, type: fragment.type, inclusionConditions: inclusionConditions)
+    self.init(
+      name: fragment.name,
+      type: fragment.type,
+      inclusionConditions: inclusionConditions,
+      deferCondition: deferCondition
+    )
   }
 
   public var debugDescription: String {
     TemplateString("""
-    fragment \(name) on \(type.debugDescription)\(ifLet: inclusionConditions, {
-      " \($0.debugDescription)"
-      })
+    fragment \(name) on \(type.debugDescription)\
+    \(ifLet: inclusionConditions, { " \($0.debugDescription)" })
+    \(ifLet: deferCondition, { " \($0.debugDescription)" })
     """).description
   }
 }
@@ -552,9 +574,10 @@ fileprivate func shallowlyMatch<T: Collection>(
 }
 
 fileprivate func shallowlyMatch(expected: ShallowFragmentSpreadMatcher, actual: IR.NamedFragmentSpread) -> Bool {
-  return expected.name == actual.fragment.name &&
-  expected.type == actual.fragment.type &&
-  expected.inclusionConditions == actual.inclusionConditions
+  return expected.name == actual.fragment.name 
+  && expected.type == actual.fragment.type
+  && expected.inclusionConditions == actual.inclusionConditions
+  && expected.deferCondition == actual.typeInfo.deferCondition
 }
 
 // MARK: - Predicate Mapping

--- a/Tests/ApolloCodegenTests/TestHelpers/IRMatchers.swift
+++ b/Tests/ApolloCodegenTests/TestHelpers/IRMatchers.swift
@@ -266,6 +266,18 @@ public enum ShallowSelectionMatcher {
       deferCondition: IR.DeferCondition(label: label, variable: variable)
     ))
   }
+
+  public static func deferred(
+    _ fragment: CompilationResult.FragmentDefinition,
+    label: String,
+    variable: String? = nil
+  ) -> ShallowSelectionMatcher {
+    .shallowFragmentSpread(ShallowFragmentSpreadMatcher(
+      name: fragment.name,
+      type: fragment.type,
+      inclusionConditions: nil
+    ))
+  }
 }
 
 // MARK: - Shallow Field Matcher
@@ -394,7 +406,9 @@ public struct ShallowInlineFragmentMatcher: Equatable, CustomDebugStringConverti
 
   public var debugDescription: String {
     TemplateString("""
-      ... on \(parentType.debugDescription)\(ifLet: inclusionConditions, { " \($0.debugDescription)"})
+      ... on \(parentType.debugDescription)\
+      \(ifLet: inclusionConditions, { " \($0.debugDescription)"})\
+      \(ifLet: deferCondition, { " \($0.debugDescription)"})
       """).description
   }
 }
@@ -462,6 +476,7 @@ public struct ShallowFragmentSpreadMatcher: Equatable, CustomDebugStringConverti
     }
   }
 
+  @_disfavoredOverload
   init(
     name: String,
     type: GraphQLCompositeType,

--- a/apollo-ios-codegen/Sources/IR/IR+RootFieldBuilder.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+RootFieldBuilder.swift
@@ -173,46 +173,7 @@ class RootFieldBuilder {
       add(inlineFragment, from: selection, to: target, atTypePath: typeInfo)
 
     case let .fragmentSpread(fragmentSpread):
-      guard let scope = scopeCondition(for: fragmentSpread, in: typeInfo) else {
-        return
-      }
-      let selectionSetScope = typeInfo.scope
-
-      var matchesType: Bool {
-        guard let typeCondition = scope.type else { return true }
-        return selectionSetScope.matches(typeCondition)
-      }
-      let matchesScope = selectionSetScope.matches(scope)
-
-      if matchesScope {
-        let irFragmentSpread = buildNamedFragmentSpread(
-          fromFragment: fragmentSpread,
-          with: scope,
-          spreadIntoParentWithTypePath: typeInfo
-        )
-        target.mergeIn(irFragmentSpread)
-
-      } else {
-        let irTypeCaseEnclosingFragment = buildInlineFragmentSpread(
-          from: CompilationResult.SelectionSet(
-            parentType: fragmentSpread.parentType,
-            selections: [selection]
-          ),
-          with: scope,
-          inParentTypePath: typeInfo,
-          deferCondition: (fragmentSpread.deferCondition != nil ? .init(fragmentSpread.deferCondition!) : nil)
-        )
-        #warning("remove force unwrap above")
-
-        target.mergeIn(irTypeCaseEnclosingFragment)
-
-        if matchesType {
-          typeInfo.entity.selectionTree.mergeIn(
-            selections: irTypeCaseEnclosingFragment.selectionSet.selections.direct.unsafelyUnwrapped.readOnlyView,
-            with: typeInfo
-          )
-        }
-      }
+      add(fragmentSpread, from: selection, to: target, atTypePath: typeInfo)
     }
   }
 
@@ -260,6 +221,75 @@ class RootFieldBuilder {
         inParentTypePath: typeInfo
       )
       target.mergeIn(irTypeCase)
+    }
+  }
+
+  private func add(
+    _ fragmentSpread: CompilationResult.FragmentSpread,
+    from selection: CompilationResult.Selection,
+    to target: DirectSelections,
+    atTypePath typeInfo: SelectionSet.TypeInfo
+  ) {
+    guard let scope = scopeCondition(
+      for: fragmentSpread,
+      in: typeInfo,
+      deferCondition: fragmentSpread.deferCondition
+    ) else {
+      return
+    }
+
+    let selectionSetScope = typeInfo.scope
+    let matchesScope = selectionSetScope.matches(scope)
+
+    switch (matchesScope, fragmentSpread.deferCondition) {
+    case let (true, .some(deferCondition)):
+      let irFragmentSpread = buildNamedFragmentSpread(
+        fromFragment: fragmentSpread,
+        with: scope,
+        spreadIntoParentWithTypePath: typeInfo,
+        deferCondition: DeferCondition(deferCondition)
+      )
+      target.mergeIn(irFragmentSpread)
+
+    case (true, nil):
+      let irFragmentSpread = buildNamedFragmentSpread(
+        fromFragment: fragmentSpread,
+        with: scope,
+        spreadIntoParentWithTypePath: typeInfo
+      )
+      target.mergeIn(irFragmentSpread)
+
+    case (false, .some):
+      let irTypeCase = buildInlineFragmentSpread(
+        toWrap: selection,
+        with: scope,
+        inParentTypePath: typeInfo
+      )
+      target.mergeIn(irTypeCase)
+
+    case (false, nil):
+      let irTypeCaseEnclosingFragment = buildInlineFragmentSpread(
+        from: CompilationResult.SelectionSet(
+          parentType: fragmentSpread.parentType,
+          selections: [selection]
+        ),
+        with: scope,
+        inParentTypePath: typeInfo
+      )
+
+      target.mergeIn(irTypeCaseEnclosingFragment)
+
+      var matchesType: Bool {
+        guard let typeCondition = scope.type else { return true }
+        return selectionSetScope.matches(typeCondition)
+      }
+
+      if matchesType {
+        typeInfo.entity.selectionTree.mergeIn(
+          selections: irTypeCaseEnclosingFragment.selectionSet.selections.direct.unsafelyUnwrapped.readOnlyView,
+          with: typeInfo
+        )
+      }
     }
   }
 
@@ -409,7 +439,8 @@ class RootFieldBuilder {
   private func buildNamedFragmentSpread(
     fromFragment fragmentSpread: CompilationResult.FragmentSpread,
     with scopeCondition: ScopeCondition,
-    spreadIntoParentWithTypePath parentTypeInfo: SelectionSet.TypeInfo
+    spreadIntoParentWithTypePath parentTypeInfo: SelectionSet.TypeInfo,
+    deferCondition: DeferCondition? = nil
   ) -> NamedFragmentSpread {
     let fragment = ir.build(fragment: fragmentSpread.fragment)
     referencedFragments.append(fragment)
@@ -417,10 +448,16 @@ class RootFieldBuilder {
 
     self.containsDeferredFragment = fragment.containsDeferredFragment
 
+    let scope = ScopeCondition(
+      type: scopeCondition.type,
+      conditions: scopeCondition.conditions,
+      deferCondition: deferCondition
+    )
+
     let scopePath = scopeCondition.isEmpty ?
     parentTypeInfo.scopePath :
     parentTypeInfo.scopePath.mutatingLast {
-      $0.appending(scopeCondition)
+      $0.appending(scope)
     }
 
     let typeInfo = SelectionSet.TypeInfo(
@@ -431,7 +468,7 @@ class RootFieldBuilder {
     let fragmentSpread = NamedFragmentSpread(
       fragment: fragment,
       typeInfo: typeInfo,
-      inclusionConditions: AnyOf(scopeCondition.conditions)
+      inclusionConditions: AnyOf(scope.conditions)
     )
 
     entityStorage.mergeAllSelectionsIntoEntitySelectionTrees(from: fragmentSpread)

--- a/apollo-ios-codegen/Sources/IR/IR+RootFieldBuilder.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+RootFieldBuilder.swift
@@ -136,8 +136,6 @@ class RootFieldBuilder {
   ) {
     addSelections(from: selectionSet, to: target, atTypePath: typeInfo)
 
-    self.containsDeferredFragment = typeInfo.scope.scopePath.containsDeferredFragment
-
     if typeInfo.deferCondition == nil {
       typeInfo.entity.selectionTree.mergeIn(
         selections: target.readOnlyView,
@@ -395,6 +393,8 @@ class RootFieldBuilder {
       deferCondition: deferCondition
     )
 
+    self.containsDeferredFragment = (scope.deferCondition != nil)
+
     let typePath = enclosingTypeInfo.scopePath.mutatingLast {
       $0.appending(scope)
     }
@@ -448,13 +448,13 @@ class RootFieldBuilder {
     referencedFragments.append(fragment)
     referencedFragments.append(contentsOf: fragment.referencedFragments)
 
-    self.containsDeferredFragment = fragment.containsDeferredFragment
-
     let scope = ScopeCondition(
       type: scopeCondition.type,
       conditions: scopeCondition.conditions,
       deferCondition: deferCondition
     )
+
+    self.containsDeferredFragment = fragment.containsDeferredFragment || scope.deferCondition != nil
 
     let scopePath = scopeCondition.isEmpty ?
     parentTypeInfo.scopePath :

--- a/apollo-ios-codegen/Sources/IR/IR+RootFieldBuilder.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+RootFieldBuilder.swift
@@ -192,18 +192,19 @@ class RootFieldBuilder {
     }
 
     let inlineSelectionSet = inlineFragment.selectionSet
+    let matchesScope = typeInfo.scope.matches(scope)
 
-    switch (typeInfo.scope.matches(scope), inlineFragment.deferCondition) {
+    switch (matchesScope, inlineFragment.deferCondition) {
     case let (true, .some(deferCondition)):
       let irTypeCase = buildInlineFragmentSpread(
         from: inlineSelectionSet,
         with: scope,
         inParentTypePath: typeInfo,
-        deferCondition: .init(deferCondition)
+        deferCondition: DeferCondition(deferCondition)
       )
       target.mergeIn(irTypeCase)
 
-    case (true, .none):
+    case (true, nil):
       addSelections(from: inlineSelectionSet, to: target, atTypePath: typeInfo)
 
     case (false, .some):
@@ -214,7 +215,7 @@ class RootFieldBuilder {
       )
       target.mergeIn(irTypeCase)
 
-    case (false, .none):
+    case (false, nil):
       let irTypeCase = buildInlineFragmentSpread(
         from: inlineSelectionSet,
         with: scope,
@@ -393,6 +394,7 @@ class RootFieldBuilder {
       conditions: scopeCondition.conditions,
       deferCondition: deferCondition
     )
+
     let typePath = enclosingTypeInfo.scopePath.mutatingLast {
       $0.appending(scope)
     }


### PR DESCRIPTION
This second PR for https://github.com/apollographql/apollo-ios/issues/3141 refactors the root field builder to build deferred named fragments into the IR. The next PR will generate selection sets from the refactored IR.

* Adds IR matchers for named fragment.
* Refactored logic for `containsDeferredFragment`; moved to where the scope condition is modified to include the defer condition.
* Refactored add selections logic for `.fragmentSpread` 