### PR TITLE
Adding name spacing to ApolloAPI.Object

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -7,7 +7,7 @@ public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"query DogQuery { allAnimals { __typename id skinCovering ... on Dog { ...DogFragment } } }"#,
+      #"query DogQuery { allAnimals { __typename id skinCovering ... on Dog { ...DogFragment houseDetails } } }"#,
       fragments: [DogFragment.self]
     ))
 
@@ -85,9 +85,11 @@ public class DogQuery: GraphQLQuery {
         public typealias RootEntityType = DogQuery.Data.AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("houseDetails", AnimalKingdomAPI.Object?.self),
           .fragment(DogFragment.self),
         ] }
 
+        public var houseDetails: AnimalKingdomAPI.Object? { __data["houseDetails"] }
         public var id: AnimalKingdomAPI.ID { __data["id"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var species: String { __data["species"] }
@@ -100,6 +102,7 @@ public class DogQuery: GraphQLQuery {
         }
 
         public init(
+          houseDetails: AnimalKingdomAPI.Object? = nil,
           id: AnimalKingdomAPI.ID,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           species: String
@@ -107,6 +110,7 @@ public class DogQuery: GraphQLQuery {
           self.init(_dataDict: DataDict(
             data: [
               "__typename": AnimalKingdomAPI.Objects.Dog.typename,
+              "houseDetails": houseDetails,
               "id": id,
               "skinCovering": skinCovering,
               "species": species,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/CustomScalars/Object.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/CustomScalars/Object.swift
@@ -1,0 +1,10 @@
+// @generated
+// This file was automatically generated and can be edited to
+// implement advanced custom scalar functionality.
+//
+// Any changes to this file will not be overwritten by future
+// code generation execution.
+
+import ApolloAPI
+
+public typealias Object = String

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Bird.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Bird.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Bird = Object(
+  static let Bird = ApolloAPI.Object(
     typename: "Bird",
     implementedInterfaces: [
       Interfaces.Animal.self,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Cat.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Cat.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Cat = Object(
+  static let Cat = ApolloAPI.Object(
     typename: "Cat",
     implementedInterfaces: [
       Interfaces.Animal.self,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Crocodile.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Crocodile.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Crocodile = Object(
+  static let Crocodile = ApolloAPI.Object(
     typename: "Crocodile",
     implementedInterfaces: [Interfaces.Animal.self]
   )

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Dog.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Dog.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Dog = Object(
+  static let Dog = ApolloAPI.Object(
     typename: "Dog",
     implementedInterfaces: [
       Interfaces.Animal.self,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Fish.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Fish.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Fish = Object(
+  static let Fish = ApolloAPI.Object(
     typename: "Fish",
     implementedInterfaces: [
       Interfaces.Animal.self,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Height.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Height.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Height = Object(
+  static let Height = ApolloAPI.Object(
     typename: "Height",
     implementedInterfaces: []
   )

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Human.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Human.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Human = Object(
+  static let Human = ApolloAPI.Object(
     typename: "Human",
     implementedInterfaces: [
       Interfaces.Animal.self,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Mutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Mutation.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Mutation = Object(
+  static let Mutation = ApolloAPI.Object(
     typename: "Mutation",
     implementedInterfaces: []
   )

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/PetRock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/PetRock.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let PetRock = Object(
+  static let PetRock = ApolloAPI.Object(
     typename: "PetRock",
     implementedInterfaces: [Interfaces.Pet.self]
   )

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Query.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Query.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Query = Object(
+  static let Query = ApolloAPI.Object(
     typename: "Query",
     implementedInterfaces: []
   )

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Rat.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Objects/Rat.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Rat = Object(
+  static let Rat = ApolloAPI.Object(
     typename: "Rat",
     implementedInterfaces: [
       Interfaces.Animal.self,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -20,7 +20,7 @@ where Schema == AnimalKingdomAPI.SchemaMetadata {}
 public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
   public static let configuration: ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
 
-  public static func objectType(forTypename typename: String) -> Object? {
+  public static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
     switch typename {
     case "Query": return AnimalKingdomAPI.Objects.Query
     case "Human": return AnimalKingdomAPI.Objects.Human

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Bird+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Bird+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Bird: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Bird
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Bird
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Bird>>
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Cat+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Cat+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Cat: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Cat
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Cat
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Cat>>
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Crocodile+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Crocodile+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Crocodile: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Crocodile
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Crocodile
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Crocodile>>
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Dog+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Dog+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Dog: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Dog
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Dog
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Dog>>
 
@@ -14,6 +14,7 @@ public class Dog: MockObject {
     @Field<Int>("bodyTemperature") public var bodyTemperature
     @Field<String>("favoriteToy") public var favoriteToy
     @Field<Height>("height") public var height
+    @Field<AnimalKingdomAPI.Object>("houseDetails") public var houseDetails
     @Field<String>("humanName") public var humanName
     @Field<AnimalKingdomAPI.ID>("id") public var id
     @Field<Bool>("laysEggs") public var laysEggs
@@ -30,6 +31,7 @@ public extension Mock where O == Dog {
     bodyTemperature: Int? = nil,
     favoriteToy: String? = nil,
     height: Mock<Height>? = nil,
+    houseDetails: AnimalKingdomAPI.Object? = nil,
     humanName: String? = nil,
     id: AnimalKingdomAPI.ID? = nil,
     laysEggs: Bool? = nil,
@@ -43,6 +45,7 @@ public extension Mock where O == Dog {
     _setScalar(bodyTemperature, for: \.bodyTemperature)
     _setScalar(favoriteToy, for: \.favoriteToy)
     _setEntity(height, for: \.height)
+    _setScalar(houseDetails, for: \.houseDetails)
     _setScalar(humanName, for: \.humanName)
     _setScalar(id, for: \.id)
     _setScalar(laysEggs, for: \.laysEggs)

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Fish+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Fish+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Fish: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Fish
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Fish
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Fish>>
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Height+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Height+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Height: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Height
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Height
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Height>>
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Human+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Human+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Human: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Human
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Human
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Human>>
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Mutation+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Mutation+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Mutation: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Mutation
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Mutation
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Mutation>>
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/PetRock+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/PetRock+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class PetRock: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.PetRock
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.PetRock
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<PetRock>>
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Query+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Query+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Query: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Query
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Query
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Query>>
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Rat+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Rat+Mock.graphql.swift
@@ -5,7 +5,7 @@ import ApolloTestSupport
 import AnimalKingdomAPI
 
 public class Rat: MockObject {
-  public static let objectType: Object = AnimalKingdomAPI.Objects.Rat
+  public static let objectType: ApolloAPI.Object = AnimalKingdomAPI.Objects.Rat
   public static let _mockFields = MockFields()
   public typealias MockValueCollectionType = Array<Mock<Rat>>
 

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
@@ -10,6 +10,8 @@ type Mutation {
 
 scalar CustomDate
 
+scalar Object
+
 input PetAdoptionInput {
   ownerID: ID!
   petID: ID!
@@ -121,6 +123,7 @@ type Dog implements Animal & Pet & HousePet & WarmBlooded {
   rival: Cat
   livesWith: Bird
   birthdate: CustomDate
+  houseDetails: Object
 }
 
 type Bird implements Animal & Pet & WarmBlooded {

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/DogQuery.graphql
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/DogQuery.graphql
@@ -4,6 +4,7 @@ query DogQuery {
     skinCovering
     ... on Dog {
       ... DogFragment
+      houseDetails
     }
   }
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/AddedToProjectEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/AddedToProjectEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'added_to_project' event on a given issue or pull request.
-  static let AddedToProjectEvent = Object(
+  static let AddedToProjectEvent = ApolloAPI.Object(
     typename: "AddedToProjectEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/App.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/App.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A GitHub App.
-  static let App = Object(
+  static let App = ApolloAPI.Object(
     typename: "App",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/AssignedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/AssignedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an 'assigned' event on any assignable object.
-  static let AssignedEvent = Object(
+  static let AssignedEvent = ApolloAPI.Object(
     typename: "AssignedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/AutomaticBaseChangeFailedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/AutomaticBaseChangeFailedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'automatic_base_change_failed' event on a given pull request.
-  static let AutomaticBaseChangeFailedEvent = Object(
+  static let AutomaticBaseChangeFailedEvent = ApolloAPI.Object(
     typename: "AutomaticBaseChangeFailedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/AutomaticBaseChangeSucceededEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/AutomaticBaseChangeSucceededEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'automatic_base_change_succeeded' event on a given pull request.
-  static let AutomaticBaseChangeSucceededEvent = Object(
+  static let AutomaticBaseChangeSucceededEvent = ApolloAPI.Object(
     typename: "AutomaticBaseChangeSucceededEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/BaseRefChangedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/BaseRefChangedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'base_ref_changed' event on a given issue or pull request.
-  static let BaseRefChangedEvent = Object(
+  static let BaseRefChangedEvent = ApolloAPI.Object(
     typename: "BaseRefChangedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/BaseRefForcePushedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/BaseRefForcePushedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'base_ref_force_pushed' event on a given pull request.
-  static let BaseRefForcePushedEvent = Object(
+  static let BaseRefForcePushedEvent = ApolloAPI.Object(
     typename: "BaseRefForcePushedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Blob.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Blob.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a Git blob.
-  static let Blob = Object(
+  static let Blob = ApolloAPI.Object(
     typename: "Blob",
     implementedInterfaces: [
       Interfaces.GitObject.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Bot.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Bot.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A special type of user which takes actions on behalf of GitHub Apps.
-  static let Bot = Object(
+  static let Bot = ApolloAPI.Object(
     typename: "Bot",
     implementedInterfaces: [
       Interfaces.Actor.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/BranchProtectionRule.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/BranchProtectionRule.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A branch protection rule.
-  static let BranchProtectionRule = Object(
+  static let BranchProtectionRule = ApolloAPI.Object(
     typename: "BranchProtectionRule",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CheckRun.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CheckRun.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A check run.
-  static let CheckRun = Object(
+  static let CheckRun = ApolloAPI.Object(
     typename: "CheckRun",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CheckSuite.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CheckSuite.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A check suite.
-  static let CheckSuite = Object(
+  static let CheckSuite = ApolloAPI.Object(
     typename: "CheckSuite",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ClosedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ClosedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'closed' event on any `Closable`.
-  static let ClosedEvent = Object(
+  static let ClosedEvent = ApolloAPI.Object(
     typename: "ClosedEvent",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CodeOfConduct.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CodeOfConduct.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// The Code of Conduct for a repository
-  static let CodeOfConduct = Object(
+  static let CodeOfConduct = ApolloAPI.Object(
     typename: "CodeOfConduct",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CommentDeletedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CommentDeletedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'comment_deleted' event on a given issue or pull request.
-  static let CommentDeletedEvent = Object(
+  static let CommentDeletedEvent = ApolloAPI.Object(
     typename: "CommentDeletedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Commit.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Commit.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a Git commit.
-  static let Commit = Object(
+  static let Commit = ApolloAPI.Object(
     typename: "Commit",
     implementedInterfaces: [
       Interfaces.GitObject.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CommitComment.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CommitComment.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a comment on a given Commit.
-  static let CommitComment = Object(
+  static let CommitComment = ApolloAPI.Object(
     typename: "CommitComment",
     implementedInterfaces: [
       Interfaces.Comment.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CommitCommentThread.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CommitCommentThread.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A thread of comments on a commit.
-  static let CommitCommentThread = Object(
+  static let CommitCommentThread = ApolloAPI.Object(
     typename: "CommitCommentThread",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ConnectedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ConnectedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'connected' event on a given issue or pull request.
-  static let ConnectedEvent = Object(
+  static let ConnectedEvent = ApolloAPI.Object(
     typename: "ConnectedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ConvertToDraftEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ConvertToDraftEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'convert_to_draft' event on a given pull request.
-  static let ConvertToDraftEvent = Object(
+  static let ConvertToDraftEvent = ApolloAPI.Object(
     typename: "ConvertToDraftEvent",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ConvertedNoteToIssueEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ConvertedNoteToIssueEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'converted_note_to_issue' event on a given issue or pull request.
-  static let ConvertedNoteToIssueEvent = Object(
+  static let ConvertedNoteToIssueEvent = ApolloAPI.Object(
     typename: "ConvertedNoteToIssueEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CrossReferencedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/CrossReferencedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a mention made by one issue or pull request to another.
-  static let CrossReferencedEvent = Object(
+  static let CrossReferencedEvent = ApolloAPI.Object(
     typename: "CrossReferencedEvent",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DemilestonedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DemilestonedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'demilestoned' event on a given issue or pull request.
-  static let DemilestonedEvent = Object(
+  static let DemilestonedEvent = ApolloAPI.Object(
     typename: "DemilestonedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DependencyGraphManifest.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DependencyGraphManifest.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Dependency manifest for a repository
-  static let DependencyGraphManifest = Object(
+  static let DependencyGraphManifest = ApolloAPI.Object(
     typename: "DependencyGraphManifest",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DeployKey.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DeployKey.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A repository deploy key.
-  static let DeployKey = Object(
+  static let DeployKey = ApolloAPI.Object(
     typename: "DeployKey",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DeployedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DeployedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'deployed' event on a given pull request.
-  static let DeployedEvent = Object(
+  static let DeployedEvent = ApolloAPI.Object(
     typename: "DeployedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Deployment.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Deployment.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents triggered deployment instance.
-  static let Deployment = Object(
+  static let Deployment = ApolloAPI.Object(
     typename: "Deployment",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DeploymentEnvironmentChangedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DeploymentEnvironmentChangedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'deployment_environment_changed' event on a given pull request.
-  static let DeploymentEnvironmentChangedEvent = Object(
+  static let DeploymentEnvironmentChangedEvent = ApolloAPI.Object(
     typename: "DeploymentEnvironmentChangedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DeploymentStatus.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DeploymentStatus.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Describes the status of a given deployment attempt.
-  static let DeploymentStatus = Object(
+  static let DeploymentStatus = ApolloAPI.Object(
     typename: "DeploymentStatus",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DisconnectedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/DisconnectedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'disconnected' event on a given issue or pull request.
-  static let DisconnectedEvent = Object(
+  static let DisconnectedEvent = ApolloAPI.Object(
     typename: "DisconnectedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Enterprise.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Enterprise.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An account to manage multiple organizations with consolidated policy and billing.
-  static let Enterprise = Object(
+  static let Enterprise = ApolloAPI.Object(
     typename: "Enterprise",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseAdministratorInvitation.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseAdministratorInvitation.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An invitation for a user to become an owner or billing manager of an enterprise.
-  static let EnterpriseAdministratorInvitation = Object(
+  static let EnterpriseAdministratorInvitation = ApolloAPI.Object(
     typename: "EnterpriseAdministratorInvitation",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseIdentityProvider.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseIdentityProvider.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An identity provider configured to provision identities for an enterprise.
-  static let EnterpriseIdentityProvider = Object(
+  static let EnterpriseIdentityProvider = ApolloAPI.Object(
     typename: "EnterpriseIdentityProvider",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseRepositoryInfo.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseRepositoryInfo.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A subset of repository information queryable from an enterprise.
-  static let EnterpriseRepositoryInfo = Object(
+  static let EnterpriseRepositoryInfo = ApolloAPI.Object(
     typename: "EnterpriseRepositoryInfo",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseServerInstallation.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseServerInstallation.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An Enterprise Server installation.
-  static let EnterpriseServerInstallation = Object(
+  static let EnterpriseServerInstallation = ApolloAPI.Object(
     typename: "EnterpriseServerInstallation",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseServerUserAccount.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseServerUserAccount.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A user account on an Enterprise Server installation.
-  static let EnterpriseServerUserAccount = Object(
+  static let EnterpriseServerUserAccount = ApolloAPI.Object(
     typename: "EnterpriseServerUserAccount",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseServerUserAccountEmail.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseServerUserAccountEmail.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An email belonging to a user account on an Enterprise Server installation.
-  static let EnterpriseServerUserAccountEmail = Object(
+  static let EnterpriseServerUserAccountEmail = ApolloAPI.Object(
     typename: "EnterpriseServerUserAccountEmail",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseServerUserAccountsUpload.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseServerUserAccountsUpload.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A user accounts upload from an Enterprise Server installation.
-  static let EnterpriseServerUserAccountsUpload = Object(
+  static let EnterpriseServerUserAccountsUpload = ApolloAPI.Object(
     typename: "EnterpriseServerUserAccountsUpload",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseUserAccount.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/EnterpriseUserAccount.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An account for a user who is an admin of an enterprise or a member of an enterprise through one or more organizations.
-  static let EnterpriseUserAccount = Object(
+  static let EnterpriseUserAccount = ApolloAPI.Object(
     typename: "EnterpriseUserAccount",
     implementedInterfaces: [
       Interfaces.Actor.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ExternalIdentity.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ExternalIdentity.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An external identity provisioned by SAML SSO or SCIM.
-  static let ExternalIdentity = Object(
+  static let ExternalIdentity = ApolloAPI.Object(
     typename: "ExternalIdentity",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Gist.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Gist.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A Gist.
-  static let Gist = Object(
+  static let Gist = ApolloAPI.Object(
     typename: "Gist",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/GistComment.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/GistComment.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a comment on an Gist.
-  static let GistComment = Object(
+  static let GistComment = ApolloAPI.Object(
     typename: "GistComment",
     implementedInterfaces: [
       Interfaces.Comment.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/HeadRefDeletedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/HeadRefDeletedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'head_ref_deleted' event on a given pull request.
-  static let HeadRefDeletedEvent = Object(
+  static let HeadRefDeletedEvent = ApolloAPI.Object(
     typename: "HeadRefDeletedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/HeadRefForcePushedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/HeadRefForcePushedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'head_ref_force_pushed' event on a given pull request.
-  static let HeadRefForcePushedEvent = Object(
+  static let HeadRefForcePushedEvent = ApolloAPI.Object(
     typename: "HeadRefForcePushedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/HeadRefRestoredEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/HeadRefRestoredEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'head_ref_restored' event on a given pull request.
-  static let HeadRefRestoredEvent = Object(
+  static let HeadRefRestoredEvent = ApolloAPI.Object(
     typename: "HeadRefRestoredEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/IpAllowListEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/IpAllowListEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An IP address or range of addresses that is allowed to access an owner's resources.
-  static let IpAllowListEntry = Object(
+  static let IpAllowListEntry = ApolloAPI.Object(
     typename: "IpAllowListEntry",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Issue.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Issue.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
-  static let Issue = Object(
+  static let Issue = ApolloAPI.Object(
     typename: "Issue",
     implementedInterfaces: [
       Interfaces.Assignable.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/IssueComment.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/IssueComment.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a comment on an Issue.
-  static let IssueComment = Object(
+  static let IssueComment = ApolloAPI.Object(
     typename: "IssueComment",
     implementedInterfaces: [
       Interfaces.Comment.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/IssueCommentConnection.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/IssueCommentConnection.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// The connection type for IssueComment.
-  static let IssueCommentConnection = Object(
+  static let IssueCommentConnection = ApolloAPI.Object(
     typename: "IssueCommentConnection",
     implementedInterfaces: []
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/IssueConnection.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/IssueConnection.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// The connection type for Issue.
-  static let IssueConnection = Object(
+  static let IssueConnection = ApolloAPI.Object(
     typename: "IssueConnection",
     implementedInterfaces: []
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Label.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Label.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A label for categorizing Issues or Milestones with a given Repository.
-  static let Label = Object(
+  static let Label = ApolloAPI.Object(
     typename: "Label",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/LabeledEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/LabeledEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'labeled' event on a given issue or pull request.
-  static let LabeledEvent = Object(
+  static let LabeledEvent = ApolloAPI.Object(
     typename: "LabeledEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Language.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Language.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a given language found in repositories.
-  static let Language = Object(
+  static let Language = ApolloAPI.Object(
     typename: "Language",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/License.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/License.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A repository's open source license
-  static let License = Object(
+  static let License = ApolloAPI.Object(
     typename: "License",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/LockedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/LockedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'locked' event on a given issue or pull request.
-  static let LockedEvent = Object(
+  static let LockedEvent = ApolloAPI.Object(
     typename: "LockedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Mannequin.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Mannequin.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A placeholder user for attribution of imported data on GitHub.
-  static let Mannequin = Object(
+  static let Mannequin = ApolloAPI.Object(
     typename: "Mannequin",
     implementedInterfaces: [
       Interfaces.Actor.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MarkedAsDuplicateEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MarkedAsDuplicateEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'marked_as_duplicate' event on a given issue or pull request.
-  static let MarkedAsDuplicateEvent = Object(
+  static let MarkedAsDuplicateEvent = ApolloAPI.Object(
     typename: "MarkedAsDuplicateEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MarketplaceCategory.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MarketplaceCategory.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A public description of a Marketplace category.
-  static let MarketplaceCategory = Object(
+  static let MarketplaceCategory = ApolloAPI.Object(
     typename: "MarketplaceCategory",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MarketplaceListing.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MarketplaceListing.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A listing in the GitHub integration marketplace.
-  static let MarketplaceListing = Object(
+  static let MarketplaceListing = ApolloAPI.Object(
     typename: "MarketplaceListing",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MembersCanDeleteReposClearAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MembersCanDeleteReposClearAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a members_can_delete_repos.clear event.
-  static let MembersCanDeleteReposClearAuditEntry = Object(
+  static let MembersCanDeleteReposClearAuditEntry = ApolloAPI.Object(
     typename: "MembersCanDeleteReposClearAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MembersCanDeleteReposDisableAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MembersCanDeleteReposDisableAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a members_can_delete_repos.disable event.
-  static let MembersCanDeleteReposDisableAuditEntry = Object(
+  static let MembersCanDeleteReposDisableAuditEntry = ApolloAPI.Object(
     typename: "MembersCanDeleteReposDisableAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MembersCanDeleteReposEnableAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MembersCanDeleteReposEnableAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a members_can_delete_repos.enable event.
-  static let MembersCanDeleteReposEnableAuditEntry = Object(
+  static let MembersCanDeleteReposEnableAuditEntry = ApolloAPI.Object(
     typename: "MembersCanDeleteReposEnableAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MentionedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MentionedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'mentioned' event on a given issue or pull request.
-  static let MentionedEvent = Object(
+  static let MentionedEvent = ApolloAPI.Object(
     typename: "MentionedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MergedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MergedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'merged' event on a given pull request.
-  static let MergedEvent = Object(
+  static let MergedEvent = ApolloAPI.Object(
     typename: "MergedEvent",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Milestone.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Milestone.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a Milestone object on a given repository.
-  static let Milestone = Object(
+  static let Milestone = ApolloAPI.Object(
     typename: "Milestone",
     implementedInterfaces: [
       Interfaces.Closable.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MilestonedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MilestonedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'milestoned' event on a given issue or pull request.
-  static let MilestonedEvent = Object(
+  static let MilestonedEvent = ApolloAPI.Object(
     typename: "MilestonedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MovedColumnsInProjectEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/MovedColumnsInProjectEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'moved_columns_in_project' event on a given issue or pull request.
-  static let MovedColumnsInProjectEvent = Object(
+  static let MovedColumnsInProjectEvent = ApolloAPI.Object(
     typename: "MovedColumnsInProjectEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OauthApplicationCreateAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OauthApplicationCreateAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a oauth_application.create event.
-  static let OauthApplicationCreateAuditEntry = Object(
+  static let OauthApplicationCreateAuditEntry = ApolloAPI.Object(
     typename: "OauthApplicationCreateAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgAddBillingManagerAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgAddBillingManagerAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.add_billing_manager
-  static let OrgAddBillingManagerAuditEntry = Object(
+  static let OrgAddBillingManagerAuditEntry = ApolloAPI.Object(
     typename: "OrgAddBillingManagerAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgAddMemberAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgAddMemberAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.add_member
-  static let OrgAddMemberAuditEntry = Object(
+  static let OrgAddMemberAuditEntry = ApolloAPI.Object(
     typename: "OrgAddMemberAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgBlockUserAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgBlockUserAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.block_user
-  static let OrgBlockUserAuditEntry = Object(
+  static let OrgBlockUserAuditEntry = ApolloAPI.Object(
     typename: "OrgBlockUserAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgConfigDisableCollaboratorsOnlyAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgConfigDisableCollaboratorsOnlyAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.config.disable_collaborators_only event.
-  static let OrgConfigDisableCollaboratorsOnlyAuditEntry = Object(
+  static let OrgConfigDisableCollaboratorsOnlyAuditEntry = ApolloAPI.Object(
     typename: "OrgConfigDisableCollaboratorsOnlyAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgConfigEnableCollaboratorsOnlyAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgConfigEnableCollaboratorsOnlyAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.config.enable_collaborators_only event.
-  static let OrgConfigEnableCollaboratorsOnlyAuditEntry = Object(
+  static let OrgConfigEnableCollaboratorsOnlyAuditEntry = ApolloAPI.Object(
     typename: "OrgConfigEnableCollaboratorsOnlyAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgCreateAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgCreateAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.create event.
-  static let OrgCreateAuditEntry = Object(
+  static let OrgCreateAuditEntry = ApolloAPI.Object(
     typename: "OrgCreateAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgDisableOauthAppRestrictionsAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgDisableOauthAppRestrictionsAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.disable_oauth_app_restrictions event.
-  static let OrgDisableOauthAppRestrictionsAuditEntry = Object(
+  static let OrgDisableOauthAppRestrictionsAuditEntry = ApolloAPI.Object(
     typename: "OrgDisableOauthAppRestrictionsAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgDisableSamlAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgDisableSamlAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.disable_saml event.
-  static let OrgDisableSamlAuditEntry = Object(
+  static let OrgDisableSamlAuditEntry = ApolloAPI.Object(
     typename: "OrgDisableSamlAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgDisableTwoFactorRequirementAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgDisableTwoFactorRequirementAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.disable_two_factor_requirement event.
-  static let OrgDisableTwoFactorRequirementAuditEntry = Object(
+  static let OrgDisableTwoFactorRequirementAuditEntry = ApolloAPI.Object(
     typename: "OrgDisableTwoFactorRequirementAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgEnableOauthAppRestrictionsAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgEnableOauthAppRestrictionsAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.enable_oauth_app_restrictions event.
-  static let OrgEnableOauthAppRestrictionsAuditEntry = Object(
+  static let OrgEnableOauthAppRestrictionsAuditEntry = ApolloAPI.Object(
     typename: "OrgEnableOauthAppRestrictionsAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgEnableSamlAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgEnableSamlAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.enable_saml event.
-  static let OrgEnableSamlAuditEntry = Object(
+  static let OrgEnableSamlAuditEntry = ApolloAPI.Object(
     typename: "OrgEnableSamlAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgEnableTwoFactorRequirementAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgEnableTwoFactorRequirementAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.enable_two_factor_requirement event.
-  static let OrgEnableTwoFactorRequirementAuditEntry = Object(
+  static let OrgEnableTwoFactorRequirementAuditEntry = ApolloAPI.Object(
     typename: "OrgEnableTwoFactorRequirementAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgInviteMemberAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgInviteMemberAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.invite_member event.
-  static let OrgInviteMemberAuditEntry = Object(
+  static let OrgInviteMemberAuditEntry = ApolloAPI.Object(
     typename: "OrgInviteMemberAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgInviteToBusinessAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgInviteToBusinessAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.invite_to_business event.
-  static let OrgInviteToBusinessAuditEntry = Object(
+  static let OrgInviteToBusinessAuditEntry = ApolloAPI.Object(
     typename: "OrgInviteToBusinessAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgOauthAppAccessApprovedAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgOauthAppAccessApprovedAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.oauth_app_access_approved event.
-  static let OrgOauthAppAccessApprovedAuditEntry = Object(
+  static let OrgOauthAppAccessApprovedAuditEntry = ApolloAPI.Object(
     typename: "OrgOauthAppAccessApprovedAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgOauthAppAccessDeniedAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgOauthAppAccessDeniedAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.oauth_app_access_denied event.
-  static let OrgOauthAppAccessDeniedAuditEntry = Object(
+  static let OrgOauthAppAccessDeniedAuditEntry = ApolloAPI.Object(
     typename: "OrgOauthAppAccessDeniedAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgOauthAppAccessRequestedAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgOauthAppAccessRequestedAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.oauth_app_access_requested event.
-  static let OrgOauthAppAccessRequestedAuditEntry = Object(
+  static let OrgOauthAppAccessRequestedAuditEntry = ApolloAPI.Object(
     typename: "OrgOauthAppAccessRequestedAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRemoveBillingManagerAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRemoveBillingManagerAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.remove_billing_manager event.
-  static let OrgRemoveBillingManagerAuditEntry = Object(
+  static let OrgRemoveBillingManagerAuditEntry = ApolloAPI.Object(
     typename: "OrgRemoveBillingManagerAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRemoveMemberAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRemoveMemberAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.remove_member event.
-  static let OrgRemoveMemberAuditEntry = Object(
+  static let OrgRemoveMemberAuditEntry = ApolloAPI.Object(
     typename: "OrgRemoveMemberAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRemoveOutsideCollaboratorAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRemoveOutsideCollaboratorAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.remove_outside_collaborator event.
-  static let OrgRemoveOutsideCollaboratorAuditEntry = Object(
+  static let OrgRemoveOutsideCollaboratorAuditEntry = ApolloAPI.Object(
     typename: "OrgRemoveOutsideCollaboratorAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRestoreMemberAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRestoreMemberAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.restore_member event.
-  static let OrgRestoreMemberAuditEntry = Object(
+  static let OrgRestoreMemberAuditEntry = ApolloAPI.Object(
     typename: "OrgRestoreMemberAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRestoreMemberMembershipOrganizationAuditEntryData.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRestoreMemberMembershipOrganizationAuditEntryData.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Metadata for an organization membership for org.restore_member actions
-  static let OrgRestoreMemberMembershipOrganizationAuditEntryData = Object(
+  static let OrgRestoreMemberMembershipOrganizationAuditEntryData = ApolloAPI.Object(
     typename: "OrgRestoreMemberMembershipOrganizationAuditEntryData",
     implementedInterfaces: [Interfaces.OrganizationAuditEntryData.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRestoreMemberMembershipRepositoryAuditEntryData.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRestoreMemberMembershipRepositoryAuditEntryData.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Metadata for a repository membership for org.restore_member actions
-  static let OrgRestoreMemberMembershipRepositoryAuditEntryData = Object(
+  static let OrgRestoreMemberMembershipRepositoryAuditEntryData = ApolloAPI.Object(
     typename: "OrgRestoreMemberMembershipRepositoryAuditEntryData",
     implementedInterfaces: [Interfaces.RepositoryAuditEntryData.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRestoreMemberMembershipTeamAuditEntryData.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgRestoreMemberMembershipTeamAuditEntryData.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Metadata for a team membership for org.restore_member actions
-  static let OrgRestoreMemberMembershipTeamAuditEntryData = Object(
+  static let OrgRestoreMemberMembershipTeamAuditEntryData = ApolloAPI.Object(
     typename: "OrgRestoreMemberMembershipTeamAuditEntryData",
     implementedInterfaces: [Interfaces.TeamAuditEntryData.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUnblockUserAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUnblockUserAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.unblock_user
-  static let OrgUnblockUserAuditEntry = Object(
+  static let OrgUnblockUserAuditEntry = ApolloAPI.Object(
     typename: "OrgUnblockUserAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUpdateDefaultRepositoryPermissionAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUpdateDefaultRepositoryPermissionAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.update_default_repository_permission
-  static let OrgUpdateDefaultRepositoryPermissionAuditEntry = Object(
+  static let OrgUpdateDefaultRepositoryPermissionAuditEntry = ApolloAPI.Object(
     typename: "OrgUpdateDefaultRepositoryPermissionAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUpdateMemberAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUpdateMemberAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.update_member event.
-  static let OrgUpdateMemberAuditEntry = Object(
+  static let OrgUpdateMemberAuditEntry = ApolloAPI.Object(
     typename: "OrgUpdateMemberAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUpdateMemberRepositoryCreationPermissionAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUpdateMemberRepositoryCreationPermissionAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.update_member_repository_creation_permission event.
-  static let OrgUpdateMemberRepositoryCreationPermissionAuditEntry = Object(
+  static let OrgUpdateMemberRepositoryCreationPermissionAuditEntry = ApolloAPI.Object(
     typename: "OrgUpdateMemberRepositoryCreationPermissionAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUpdateMemberRepositoryInvitationPermissionAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrgUpdateMemberRepositoryInvitationPermissionAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a org.update_member_repository_invitation_permission event.
-  static let OrgUpdateMemberRepositoryInvitationPermissionAuditEntry = Object(
+  static let OrgUpdateMemberRepositoryInvitationPermissionAuditEntry = ApolloAPI.Object(
     typename: "OrgUpdateMemberRepositoryInvitationPermissionAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Organization.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Organization.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An account on GitHub, with one or more owners, that has repositories, members and teams.
-  static let Organization = Object(
+  static let Organization = ApolloAPI.Object(
     typename: "Organization",
     implementedInterfaces: [
       Interfaces.Actor.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrganizationIdentityProvider.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrganizationIdentityProvider.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An Identity Provider configured to provision SAML and SCIM identities for Organizations
-  static let OrganizationIdentityProvider = Object(
+  static let OrganizationIdentityProvider = ApolloAPI.Object(
     typename: "OrganizationIdentityProvider",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrganizationInvitation.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/OrganizationInvitation.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An Invitation for a user to an organization.
-  static let OrganizationInvitation = Object(
+  static let OrganizationInvitation = ApolloAPI.Object(
     typename: "OrganizationInvitation",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Package.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Package.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Information for an uploaded package.
-  static let Package = Object(
+  static let Package = ApolloAPI.Object(
     typename: "Package",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PackageFile.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PackageFile.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A file in a package version.
-  static let PackageFile = Object(
+  static let PackageFile = ApolloAPI.Object(
     typename: "PackageFile",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PackageTag.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PackageTag.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A version tag contains the mapping between a tag name and a version.
-  static let PackageTag = Object(
+  static let PackageTag = ApolloAPI.Object(
     typename: "PackageTag",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PackageVersion.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PackageVersion.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Information about a specific package version.
-  static let PackageVersion = Object(
+  static let PackageVersion = ApolloAPI.Object(
     typename: "PackageVersion",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PinnedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PinnedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'pinned' event on a given issue or pull request.
-  static let PinnedEvent = Object(
+  static let PinnedEvent = ApolloAPI.Object(
     typename: "PinnedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PinnedIssue.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PinnedIssue.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A Pinned Issue is a issue pinned to a repository's index page.
-  static let PinnedIssue = Object(
+  static let PinnedIssue = ApolloAPI.Object(
     typename: "PinnedIssue",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PrivateRepositoryForkingDisableAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PrivateRepositoryForkingDisableAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a private_repository_forking.disable event.
-  static let PrivateRepositoryForkingDisableAuditEntry = Object(
+  static let PrivateRepositoryForkingDisableAuditEntry = ApolloAPI.Object(
     typename: "PrivateRepositoryForkingDisableAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PrivateRepositoryForkingEnableAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PrivateRepositoryForkingEnableAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a private_repository_forking.enable event.
-  static let PrivateRepositoryForkingEnableAuditEntry = Object(
+  static let PrivateRepositoryForkingEnableAuditEntry = ApolloAPI.Object(
     typename: "PrivateRepositoryForkingEnableAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Project.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Project.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Projects manage issues, pull requests and notes within a project owner.
-  static let Project = Object(
+  static let Project = ApolloAPI.Object(
     typename: "Project",
     implementedInterfaces: [
       Interfaces.Closable.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ProjectCard.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ProjectCard.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A card in a project.
-  static let ProjectCard = Object(
+  static let ProjectCard = ApolloAPI.Object(
     typename: "ProjectCard",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ProjectColumn.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ProjectColumn.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A column inside a project.
-  static let ProjectColumn = Object(
+  static let ProjectColumn = ApolloAPI.Object(
     typename: "ProjectColumn",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PublicKey.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PublicKey.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A user's public key.
-  static let PublicKey = Object(
+  static let PublicKey = ApolloAPI.Object(
     typename: "PublicKey",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequest.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequest.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A repository pull request.
-  static let PullRequest = Object(
+  static let PullRequest = ApolloAPI.Object(
     typename: "PullRequest",
     implementedInterfaces: [
       Interfaces.Assignable.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestCommit.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestCommit.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a Git commit part of a pull request.
-  static let PullRequestCommit = Object(
+  static let PullRequestCommit = ApolloAPI.Object(
     typename: "PullRequestCommit",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestCommitCommentThread.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestCommitCommentThread.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a commit comment thread part of a pull request.
-  static let PullRequestCommitCommentThread = Object(
+  static let PullRequestCommitCommentThread = ApolloAPI.Object(
     typename: "PullRequestCommitCommentThread",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestReview.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestReview.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A review object for a given pull request.
-  static let PullRequestReview = Object(
+  static let PullRequestReview = ApolloAPI.Object(
     typename: "PullRequestReview",
     implementedInterfaces: [
       Interfaces.Comment.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestReviewComment.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestReviewComment.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A review comment associated with a given repository pull request.
-  static let PullRequestReviewComment = Object(
+  static let PullRequestReviewComment = ApolloAPI.Object(
     typename: "PullRequestReviewComment",
     implementedInterfaces: [
       Interfaces.Comment.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestReviewThread.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PullRequestReviewThread.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A threaded list of comments for a given pull request.
-  static let PullRequestReviewThread = Object(
+  static let PullRequestReviewThread = ApolloAPI.Object(
     typename: "PullRequestReviewThread",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Push.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Push.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A Git push.
-  static let Push = Object(
+  static let Push = ApolloAPI.Object(
     typename: "Push",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PushAllowance.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/PushAllowance.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A team, user or app who has the ability to push to a protected branch.
-  static let PushAllowance = Object(
+  static let PushAllowance = ApolloAPI.Object(
     typename: "PushAllowance",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Query.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Query.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// The query root of GitHub's GraphQL interface.
-  static let Query = Object(
+  static let Query = ApolloAPI.Object(
     typename: "Query",
     implementedInterfaces: []
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Reaction.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Reaction.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An emoji reaction to a particular piece of content.
-  static let Reaction = Object(
+  static let Reaction = ApolloAPI.Object(
     typename: "Reaction",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReadyForReviewEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReadyForReviewEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'ready_for_review' event on a given pull request.
-  static let ReadyForReviewEvent = Object(
+  static let ReadyForReviewEvent = ApolloAPI.Object(
     typename: "ReadyForReviewEvent",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Ref.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Ref.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a Git reference.
-  static let Ref = Object(
+  static let Ref = ApolloAPI.Object(
     typename: "Ref",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReferencedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReferencedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'referenced' event on a given `ReferencedSubject`.
-  static let ReferencedEvent = Object(
+  static let ReferencedEvent = ApolloAPI.Object(
     typename: "ReferencedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Release.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Release.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A release contains the content for a release.
-  static let Release = Object(
+  static let Release = ApolloAPI.Object(
     typename: "Release",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReleaseAsset.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReleaseAsset.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A release asset contains the content for a release asset.
-  static let ReleaseAsset = Object(
+  static let ReleaseAsset = ApolloAPI.Object(
     typename: "ReleaseAsset",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RemovedFromProjectEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RemovedFromProjectEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'removed_from_project' event on a given issue or pull request.
-  static let RemovedFromProjectEvent = Object(
+  static let RemovedFromProjectEvent = ApolloAPI.Object(
     typename: "RemovedFromProjectEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RenamedTitleEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RenamedTitleEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'renamed' event on a given issue or pull request
-  static let RenamedTitleEvent = Object(
+  static let RenamedTitleEvent = ApolloAPI.Object(
     typename: "RenamedTitleEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReopenedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReopenedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'reopened' event on any `Closable`.
-  static let ReopenedEvent = Object(
+  static let ReopenedEvent = ApolloAPI.Object(
     typename: "ReopenedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoAccessAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoAccessAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.access event.
-  static let RepoAccessAuditEntry = Object(
+  static let RepoAccessAuditEntry = ApolloAPI.Object(
     typename: "RepoAccessAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoAddMemberAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoAddMemberAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.add_member event.
-  static let RepoAddMemberAuditEntry = Object(
+  static let RepoAddMemberAuditEntry = ApolloAPI.Object(
     typename: "RepoAddMemberAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoAddTopicAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoAddTopicAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.add_topic event.
-  static let RepoAddTopicAuditEntry = Object(
+  static let RepoAddTopicAuditEntry = ApolloAPI.Object(
     typename: "RepoAddTopicAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoArchivedAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoArchivedAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.archived event.
-  static let RepoArchivedAuditEntry = Object(
+  static let RepoArchivedAuditEntry = ApolloAPI.Object(
     typename: "RepoArchivedAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoChangeMergeSettingAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoChangeMergeSettingAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.change_merge_setting event.
-  static let RepoChangeMergeSettingAuditEntry = Object(
+  static let RepoChangeMergeSettingAuditEntry = ApolloAPI.Object(
     typename: "RepoChangeMergeSettingAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigDisableAnonymousGitAccessAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigDisableAnonymousGitAccessAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.disable_anonymous_git_access event.
-  static let RepoConfigDisableAnonymousGitAccessAuditEntry = Object(
+  static let RepoConfigDisableAnonymousGitAccessAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigDisableAnonymousGitAccessAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigDisableCollaboratorsOnlyAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigDisableCollaboratorsOnlyAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.disable_collaborators_only event.
-  static let RepoConfigDisableCollaboratorsOnlyAuditEntry = Object(
+  static let RepoConfigDisableCollaboratorsOnlyAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigDisableCollaboratorsOnlyAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigDisableContributorsOnlyAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigDisableContributorsOnlyAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.disable_contributors_only event.
-  static let RepoConfigDisableContributorsOnlyAuditEntry = Object(
+  static let RepoConfigDisableContributorsOnlyAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigDisableContributorsOnlyAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigDisableSockpuppetDisallowedAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigDisableSockpuppetDisallowedAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.disable_sockpuppet_disallowed event.
-  static let RepoConfigDisableSockpuppetDisallowedAuditEntry = Object(
+  static let RepoConfigDisableSockpuppetDisallowedAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigDisableSockpuppetDisallowedAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigEnableAnonymousGitAccessAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigEnableAnonymousGitAccessAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.enable_anonymous_git_access event.
-  static let RepoConfigEnableAnonymousGitAccessAuditEntry = Object(
+  static let RepoConfigEnableAnonymousGitAccessAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigEnableAnonymousGitAccessAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigEnableCollaboratorsOnlyAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigEnableCollaboratorsOnlyAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.enable_collaborators_only event.
-  static let RepoConfigEnableCollaboratorsOnlyAuditEntry = Object(
+  static let RepoConfigEnableCollaboratorsOnlyAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigEnableCollaboratorsOnlyAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigEnableContributorsOnlyAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigEnableContributorsOnlyAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.enable_contributors_only event.
-  static let RepoConfigEnableContributorsOnlyAuditEntry = Object(
+  static let RepoConfigEnableContributorsOnlyAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigEnableContributorsOnlyAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigEnableSockpuppetDisallowedAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigEnableSockpuppetDisallowedAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.enable_sockpuppet_disallowed event.
-  static let RepoConfigEnableSockpuppetDisallowedAuditEntry = Object(
+  static let RepoConfigEnableSockpuppetDisallowedAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigEnableSockpuppetDisallowedAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigLockAnonymousGitAccessAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigLockAnonymousGitAccessAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.lock_anonymous_git_access event.
-  static let RepoConfigLockAnonymousGitAccessAuditEntry = Object(
+  static let RepoConfigLockAnonymousGitAccessAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigLockAnonymousGitAccessAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigUnlockAnonymousGitAccessAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoConfigUnlockAnonymousGitAccessAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.config.unlock_anonymous_git_access event.
-  static let RepoConfigUnlockAnonymousGitAccessAuditEntry = Object(
+  static let RepoConfigUnlockAnonymousGitAccessAuditEntry = ApolloAPI.Object(
     typename: "RepoConfigUnlockAnonymousGitAccessAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoCreateAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoCreateAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.create event.
-  static let RepoCreateAuditEntry = Object(
+  static let RepoCreateAuditEntry = ApolloAPI.Object(
     typename: "RepoCreateAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoDestroyAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoDestroyAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.destroy event.
-  static let RepoDestroyAuditEntry = Object(
+  static let RepoDestroyAuditEntry = ApolloAPI.Object(
     typename: "RepoDestroyAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoRemoveMemberAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoRemoveMemberAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.remove_member event.
-  static let RepoRemoveMemberAuditEntry = Object(
+  static let RepoRemoveMemberAuditEntry = ApolloAPI.Object(
     typename: "RepoRemoveMemberAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoRemoveTopicAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepoRemoveTopicAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repo.remove_topic event.
-  static let RepoRemoveTopicAuditEntry = Object(
+  static let RepoRemoveTopicAuditEntry = ApolloAPI.Object(
     typename: "RepoRemoveTopicAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Repository.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Repository.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A repository contains the content for a project.
-  static let Repository = Object(
+  static let Repository = ApolloAPI.Object(
     typename: "Repository",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryInvitation.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryInvitation.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An invitation for a user to be added to a repository.
-  static let RepositoryInvitation = Object(
+  static let RepositoryInvitation = ApolloAPI.Object(
     typename: "RepositoryInvitation",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryTopic.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryTopic.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A repository-topic connects a repository to a topic.
-  static let RepositoryTopic = Object(
+  static let RepositoryTopic = ApolloAPI.Object(
     typename: "RepositoryTopic",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryVisibilityChangeDisableAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryVisibilityChangeDisableAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repository_visibility_change.disable event.
-  static let RepositoryVisibilityChangeDisableAuditEntry = Object(
+  static let RepositoryVisibilityChangeDisableAuditEntry = ApolloAPI.Object(
     typename: "RepositoryVisibilityChangeDisableAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryVisibilityChangeEnableAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryVisibilityChangeEnableAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a repository_visibility_change.enable event.
-  static let RepositoryVisibilityChangeEnableAuditEntry = Object(
+  static let RepositoryVisibilityChangeEnableAuditEntry = ApolloAPI.Object(
     typename: "RepositoryVisibilityChangeEnableAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryVulnerabilityAlert.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/RepositoryVulnerabilityAlert.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A alert for a repository with an affected vulnerability.
-  static let RepositoryVulnerabilityAlert = Object(
+  static let RepositoryVulnerabilityAlert = ApolloAPI.Object(
     typename: "RepositoryVulnerabilityAlert",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewDismissalAllowance.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewDismissalAllowance.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A team or user who has the ability to dismiss a review on a protected branch.
-  static let ReviewDismissalAllowance = Object(
+  static let ReviewDismissalAllowance = ApolloAPI.Object(
     typename: "ReviewDismissalAllowance",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewDismissedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewDismissedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'review_dismissed' event on a given issue or pull request.
-  static let ReviewDismissedEvent = Object(
+  static let ReviewDismissedEvent = ApolloAPI.Object(
     typename: "ReviewDismissedEvent",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewRequest.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewRequest.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A request for a user to review a pull request.
-  static let ReviewRequest = Object(
+  static let ReviewRequest = ApolloAPI.Object(
     typename: "ReviewRequest",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewRequestRemovedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewRequestRemovedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an 'review_request_removed' event on a given pull request.
-  static let ReviewRequestRemovedEvent = Object(
+  static let ReviewRequestRemovedEvent = ApolloAPI.Object(
     typename: "ReviewRequestRemovedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewRequestedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/ReviewRequestedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an 'review_requested' event on a given pull request.
-  static let ReviewRequestedEvent = Object(
+  static let ReviewRequestedEvent = ApolloAPI.Object(
     typename: "ReviewRequestedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SavedReply.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SavedReply.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A Saved Reply is text a user can use to reply quickly.
-  static let SavedReply = Object(
+  static let SavedReply = ApolloAPI.Object(
     typename: "SavedReply",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SecurityAdvisory.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SecurityAdvisory.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A GitHub Security Advisory
-  static let SecurityAdvisory = Object(
+  static let SecurityAdvisory = ApolloAPI.Object(
     typename: "SecurityAdvisory",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SponsorsListing.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SponsorsListing.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A GitHub Sponsors listing.
-  static let SponsorsListing = Object(
+  static let SponsorsListing = ApolloAPI.Object(
     typename: "SponsorsListing",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SponsorsTier.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SponsorsTier.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A GitHub Sponsors tier associated with a GitHub Sponsors listing.
-  static let SponsorsTier = Object(
+  static let SponsorsTier = ApolloAPI.Object(
     typename: "SponsorsTier",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Sponsorship.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Sponsorship.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A sponsorship relationship between a sponsor and a maintainer
-  static let Sponsorship = Object(
+  static let Sponsorship = ApolloAPI.Object(
     typename: "Sponsorship",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Status.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Status.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a commit status.
-  static let Status = Object(
+  static let Status = ApolloAPI.Object(
     typename: "Status",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/StatusCheckRollup.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/StatusCheckRollup.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents the rollup for both the check runs and status for a commit.
-  static let StatusCheckRollup = Object(
+  static let StatusCheckRollup = ApolloAPI.Object(
     typename: "StatusCheckRollup",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/StatusContext.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/StatusContext.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an individual commit status context
-  static let StatusContext = Object(
+  static let StatusContext = ApolloAPI.Object(
     typename: "StatusContext",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SubscribedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/SubscribedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'subscribed' event on a given `Subscribable`.
-  static let SubscribedEvent = Object(
+  static let SubscribedEvent = ApolloAPI.Object(
     typename: "SubscribedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Tag.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Tag.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a Git tag.
-  static let Tag = Object(
+  static let Tag = ApolloAPI.Object(
     typename: "Tag",
     implementedInterfaces: [
       Interfaces.GitObject.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Team.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Team.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A team of users in an organization.
-  static let Team = Object(
+  static let Team = ApolloAPI.Object(
     typename: "Team",
     implementedInterfaces: [
       Interfaces.MemberStatusable.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamAddMemberAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamAddMemberAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a team.add_member event.
-  static let TeamAddMemberAuditEntry = Object(
+  static let TeamAddMemberAuditEntry = ApolloAPI.Object(
     typename: "TeamAddMemberAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamAddRepositoryAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamAddRepositoryAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a team.add_repository event.
-  static let TeamAddRepositoryAuditEntry = Object(
+  static let TeamAddRepositoryAuditEntry = ApolloAPI.Object(
     typename: "TeamAddRepositoryAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamChangeParentTeamAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamChangeParentTeamAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a team.change_parent_team event.
-  static let TeamChangeParentTeamAuditEntry = Object(
+  static let TeamChangeParentTeamAuditEntry = ApolloAPI.Object(
     typename: "TeamChangeParentTeamAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamDiscussion.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamDiscussion.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A team discussion.
-  static let TeamDiscussion = Object(
+  static let TeamDiscussion = ApolloAPI.Object(
     typename: "TeamDiscussion",
     implementedInterfaces: [
       Interfaces.Comment.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamDiscussionComment.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamDiscussionComment.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A comment on a team discussion.
-  static let TeamDiscussionComment = Object(
+  static let TeamDiscussionComment = ApolloAPI.Object(
     typename: "TeamDiscussionComment",
     implementedInterfaces: [
       Interfaces.Comment.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamRemoveMemberAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamRemoveMemberAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a team.remove_member event.
-  static let TeamRemoveMemberAuditEntry = Object(
+  static let TeamRemoveMemberAuditEntry = ApolloAPI.Object(
     typename: "TeamRemoveMemberAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamRemoveRepositoryAuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TeamRemoveRepositoryAuditEntry.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Audit log entry for a team.remove_repository event.
-  static let TeamRemoveRepositoryAuditEntry = Object(
+  static let TeamRemoveRepositoryAuditEntry = ApolloAPI.Object(
     typename: "TeamRemoveRepositoryAuditEntry",
     implementedInterfaces: [
       Interfaces.AuditEntry.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Topic.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Topic.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A topic aggregates entities that are related to a subject.
-  static let Topic = Object(
+  static let Topic = ApolloAPI.Object(
     typename: "Topic",
     implementedInterfaces: [
       Interfaces.Node.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TransferredEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/TransferredEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'transferred' event on a given issue or pull request.
-  static let TransferredEvent = Object(
+  static let TransferredEvent = ApolloAPI.Object(
     typename: "TransferredEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Tree.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/Tree.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a Git tree.
-  static let Tree = Object(
+  static let Tree = ApolloAPI.Object(
     typename: "Tree",
     implementedInterfaces: [
       Interfaces.GitObject.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnassignedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnassignedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an 'unassigned' event on any assignable object.
-  static let UnassignedEvent = Object(
+  static let UnassignedEvent = ApolloAPI.Object(
     typename: "UnassignedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnlabeledEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnlabeledEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an 'unlabeled' event on a given issue or pull request.
-  static let UnlabeledEvent = Object(
+  static let UnlabeledEvent = ApolloAPI.Object(
     typename: "UnlabeledEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnlockedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnlockedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an 'unlocked' event on a given issue or pull request.
-  static let UnlockedEvent = Object(
+  static let UnlockedEvent = ApolloAPI.Object(
     typename: "UnlockedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnmarkedAsDuplicateEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnmarkedAsDuplicateEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an 'unmarked_as_duplicate' event on a given issue or pull request.
-  static let UnmarkedAsDuplicateEvent = Object(
+  static let UnmarkedAsDuplicateEvent = ApolloAPI.Object(
     typename: "UnmarkedAsDuplicateEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnpinnedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnpinnedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an 'unpinned' event on a given issue or pull request.
-  static let UnpinnedEvent = Object(
+  static let UnpinnedEvent = ApolloAPI.Object(
     typename: "UnpinnedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnsubscribedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UnsubscribedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents an 'unsubscribed' event on a given `Subscribable`.
-  static let UnsubscribedEvent = Object(
+  static let UnsubscribedEvent = ApolloAPI.Object(
     typename: "UnsubscribedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/User.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/User.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A user is an individual's account on GitHub that owns repositories and can make new content.
-  static let User = Object(
+  static let User = ApolloAPI.Object(
     typename: "User",
     implementedInterfaces: [
       Interfaces.Actor.self,

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UserBlockedEvent.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UserBlockedEvent.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a 'user_blocked' event on a given user.
-  static let UserBlockedEvent = Object(
+  static let UserBlockedEvent = ApolloAPI.Object(
     typename: "UserBlockedEvent",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UserContentEdit.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UserContentEdit.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An edit on user content
-  static let UserContentEdit = Object(
+  static let UserContentEdit = ApolloAPI.Object(
     typename: "UserContentEdit",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UserStatus.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Objects/UserStatus.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// The user's description of what they're currently doing.
-  static let UserStatus = Object(
+  static let UserStatus = ApolloAPI.Object(
     typename: "UserStatus",
     implementedInterfaces: [Interfaces.Node.self]
   )

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -20,7 +20,7 @@ where Schema == GitHubAPI.SchemaMetadata {}
 public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
   public static let configuration: ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
 
-  public static func objectType(forTypename typename: String) -> Object? {
+  public static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
     switch typename {
     case "Query": return GitHubAPI.Objects.Query
     case "Repository": return GitHubAPI.Objects.Repository

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class DroidDetailsWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "DroidDetailsWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "6696d5064faa0c379b73574aa6d4c5b912eb17339afc8b66babae61542d233d7",
+    operationIdentifier: "a13f4b95faffed327e8ebcc6bff72ee986314d608f1bf73767535ccb6657c70e",
     definition: .init(
       #"query DroidDetailsWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...DroidDetails } }"#,
       fragments: [DroidDetails.self]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "07c54599c2b5f9d4215d1bff7f5f6ff458c983aa5c13338fd44b051210d5ecc6",
+    operationIdentifier: "599cd7d91ede7a5508cdb26b424e3b8e99e6c2c5575b799f6090695289ff8e99",
     definition: .init(
       #"query HeroAndFriendsNamesWithFragment($episode: Episode) { hero(episode: $episode) { __typename name ...FriendsNames } }"#,
       fragments: [FriendsNames.self]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithFragmentTwice"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "9a769ab058900912bff4e4c51c1b257f609e4dfb4aaa1f17166adc19d510e363",
+    operationIdentifier: "fb791b8d40d4a404b65a51886a29493d8e43053e14552d112f248565a11c893f",
     definition: .init(
       #"query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) { hero(episode: $episode) { __typename friends { __typename ...CharacterName } ... on Droid { __typename friends { __typename ...CharacterName } } } }"#,
       fragments: [CharacterName.self]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroAppearsInWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "b7e9c75d75c77765849b67116235609b3a05b9052975c617f51a315f8fbaf45a",
+    operationIdentifier: "eb4b78213933a59abc81f8b5b17f1548a1de3c1fec8c228cddabbab41014688d",
     definition: .init(
       #"query HeroAppearsInWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...CharacterAppearsIn } }"#,
       fragments: [CharacterAppearsIn.self]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsFragmentConditionalInclusion"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "17dfb13c5d9e6c67703fc037b9114ea53ccc8f9274dfecb4abfc2d5a168cf612",
+    operationIdentifier: "48319024203f115072c25e1c19237ab7699fe8e73936689a5e5c2e412ab9f64e",
     definition: .init(
       #"query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) { hero { __typename ...HeroDetails @include(if: $includeDetails) } }"#,
       fragments: [HeroDetails.self]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class HeroDetailsWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "09fe4fc0cbcde5f0ba08b1207526cae13eb2b73ca95f929d4153dd3f643b6780",
+    operationIdentifier: "ffe0a8189e4b2c1fa2c309e2c545cd49b61fd9428b64aa62582513d7413beb11",
     definition: .init(
       #"query HeroDetailsWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...HeroDetails } }"#,
       fragments: [HeroDetails.self]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class HeroNameAndAppearsInQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameAndAppearsIn"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "ecdf5248575524004a9d43832abc54e8c0e1d2b3c0afb8bb0c1c1c514b4f9baf",
+    operationIdentifier: "fb791b8d40d4a404b65a51886a29493d8e43053e14552d112f248565a11c893f",
     definition: .init(
       #"query HeroNameAndAppearsIn($episode: Episode) { hero(episode: $episode) { __typename name appearsIn } }"#
     ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameAndAppearsInWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "4fc9c2e7f9fbe8ef3f28936bd0b12e8f32bc8d70f3e8ec5df8a6aaf3efd4921c",
+    operationIdentifier: "4ae734544e707769dbe7be2ff25cb2abd75d03634bda31a53ec7ae6e9e661fa5",
     definition: .init(
       #"query HeroNameAndAppearsInWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...CharacterNameAndAppearsIn } }"#,
       fragments: [CharacterNameAndAppearsIn.self]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithFragmentAndID"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "ec14e5fffc56163c516a21f0d211a7a86d68a3512e6fb6df38a19babe0d1df8d",
+    operationIdentifier: "003467c64c7ab5a5bacfa69442c9611d5899fe9bd63ab726b241c02b1719327a",
     definition: .init(
       #"query HeroNameWithFragmentAndID($episode: Episode) { hero(episode: $episode) { __typename id ...CharacterName } }"#,
       fragments: [CharacterName.self]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -6,7 +6,7 @@
 public class HeroNameWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "68baad3c27796cb1bf980681324e43b948aa1109698ba57404c1afa46e914ab1",
+    operationIdentifier: "2ba4aaad1ab5ea994f5bb2850a3d377a46a8d48bb14e158e626ccb6c9ab77db1",
     definition: .init(
       #"query HeroNameWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...CharacterName } }"#,
       fragments: [CharacterName.self]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Droid.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Droid.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// An autonomous mechanical character in the Star Wars universe
-  static let Droid = Object(
+  static let Droid = ApolloAPI.Object(
     typename: "Droid",
     implementedInterfaces: [Interfaces.Character.self]
   )

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Human.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Human.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// A humanoid creature from the Star Wars universe
-  static let Human = Object(
+  static let Human = ApolloAPI.Object(
     typename: "Human",
     implementedInterfaces: [Interfaces.Character.self]
   )

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Mutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Mutation.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// The mutation type, represents all updates we can make to our data
-  static let Mutation = Object(
+  static let Mutation = ApolloAPI.Object(
     typename: "Mutation",
     implementedInterfaces: []
   )

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Query.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Query.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// The query type, represents all of the entry points into our object graph
-  static let Query = Object(
+  static let Query = ApolloAPI.Object(
     typename: "Query",
     implementedInterfaces: []
   )

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Review.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Review.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// Represents a review for a movie
-  static let Review = Object(
+  static let Review = ApolloAPI.Object(
     typename: "Review",
     implementedInterfaces: []
   )

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Starship.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Starship.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Starship = Object(
+  static let Starship = ApolloAPI.Object(
     typename: "Starship",
     implementedInterfaces: []
   )

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Subscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Objects/Subscription.graphql.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public extension Objects {
   /// The subscription type, represents all subscriptions we can make to our data
-  static let Subscription = Object(
+  static let Subscription = ApolloAPI.Object(
     typename: "Subscription",
     implementedInterfaces: []
   )

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -20,7 +20,7 @@ where Schema == StarWarsAPI.SchemaMetadata {}
 public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
   public static let configuration: ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
 
-  public static func objectType(forTypename typename: String) -> Object? {
+  public static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
     switch typename {
     case "Query": return StarWarsAPI.Objects.Query
     case "Human": return StarWarsAPI.Objects.Human

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Schema/Objects/Subscription.graphql.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Schema/Objects/Subscription.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Subscription = Object(
+  static let Subscription = ApolloAPI.Object(
     typename: "Subscription",
     implementedInterfaces: []
   )

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -20,7 +20,7 @@ where Schema == SubscriptionAPI.SchemaMetadata {}
 public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
   public static let configuration: ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
 
-  public static func objectType(forTypename typename: String) -> Object? {
+  public static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
     switch typename {
     case "Subscription": return SubscriptionAPI.Objects.Subscription
     default: return nil

--- a/Sources/UploadAPI/UploadAPI/Sources/Schema/Objects/File.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Schema/Objects/File.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let File = Object(
+  static let File = ApolloAPI.Object(
     typename: "File",
     implementedInterfaces: []
   )

--- a/Sources/UploadAPI/UploadAPI/Sources/Schema/Objects/Mutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Schema/Objects/Mutation.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  static let Mutation = Object(
+  static let Mutation = ApolloAPI.Object(
     typename: "Mutation",
     implementedInterfaces: []
   )

--- a/Sources/UploadAPI/UploadAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -20,7 +20,7 @@ where Schema == UploadAPI.SchemaMetadata {}
 public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
   public static let configuration: ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
 
-  public static func objectType(forTypename typename: String) -> Object? {
+  public static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
     switch typename {
     case "Mutation": return UploadAPI.Objects.Mutation
     case "File": return UploadAPI.Objects.File

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -641,6 +641,7 @@ class ApolloCodegenTests: XCTestCase {
       directoryURL.appendingPathComponent("Sources/Schema/Objects/Dog.graphql.swift").path,
 
       directoryURL.appendingPathComponent("Sources/Schema/CustomScalars/CustomDate.swift").path,
+      directoryURL.appendingPathComponent("Sources/Schema/CustomScalars/Object.swift").path,
       
       directoryURL.appendingPathComponent("Sources/Operations/Queries/AllAnimalsQuery.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift").path,
@@ -739,6 +740,7 @@ class ApolloCodegenTests: XCTestCase {
       directoryURL.appendingPathComponent("Sources/Objects/Mutation.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/Objects/Dog.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/CustomScalars/CustomDate.swift").path,
+      directoryURL.appendingPathComponent("Sources/CustomScalars/Object.swift").path,
 
       operationsOutputURL.appendingPathComponent("Queries/AllAnimalsQuery.graphql.swift").path,
       operationsOutputURL.appendingPathComponent("Queries/DogQuery.graphql.swift").path,
@@ -836,6 +838,7 @@ class ApolloCodegenTests: XCTestCase {
       directoryURL.appendingPathComponent("Sources/Schema/Objects/Crocodile.graphql.swift").path,
 
       directoryURL.appendingPathComponent("Sources/Schema/CustomScalars/CustomDate.swift").path,
+      directoryURL.appendingPathComponent("Sources/Schema/CustomScalars/Object.swift").path,
 
       directoryURL.appendingPathComponent("Sources/Operations/Queries/AllAnimalsQuery.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/Operations/Queries/DogQuery.graphql.swift").path,
@@ -1011,6 +1014,7 @@ class ApolloCodegenTests: XCTestCase {
       directoryURL.appendingPathComponent("RelativePath/Sources/Schema/Objects/Dog.graphql.swift").path,
 
       directoryURL.appendingPathComponent("RelativePath/Sources/Schema/CustomScalars/CustomDate.swift").path,
+      directoryURL.appendingPathComponent("RelativePath/Sources/Schema/CustomScalars/Object.swift").path,
 
       directoryURL.appendingPathComponent("RelativePath/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativePath/Sources/Operations/Queries/DogQuery.graphql.swift").path,
@@ -1112,6 +1116,7 @@ class ApolloCodegenTests: XCTestCase {
       directoryURL.appendingPathComponent("RelativePath/Sources/Objects/Dog.graphql.swift").path,
 
       directoryURL.appendingPathComponent("RelativePath/Sources/CustomScalars/CustomDate.swift").path,
+      directoryURL.appendingPathComponent("RelativePath/Sources/CustomScalars/Object.swift").path,
 
       directoryURL.appendingPathComponent("RelativeOperations/Queries/AllAnimalsQuery.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativeOperations/Queries/DogQuery.graphql.swift").path,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -59,7 +59,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     let expected = """
     public class Dog: MockObject {
-      public static let objectType: Object = TestSchema.Objects.Dog
+      public static let objectType: ApolloAPI.Object = TestSchema.Objects.Dog
       public static let _mockFields = MockFields()
       public typealias MockValueCollectionType = Array<Mock<Dog>>
 
@@ -84,7 +84,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     let expected = """
     public class Dog: MockObject {
-      public static let objectType: Object = TestSchema.Objects.Dog
+      public static let objectType: ApolloAPI.Object = TestSchema.Objects.Dog
       public static let _mockFields = MockFields()
       public typealias MockValueCollectionType = Array<Mock<Dog>>
 
@@ -106,7 +106,7 @@ class MockObjectTemplateTests: XCTestCase {
     buildSubject(schemaNamespace: "lowercased")
 
     let expected = """
-      public static let objectType: Object = Lowercased.Objects.Dog
+      public static let objectType: ApolloAPI.Object = Lowercased.Objects.Dog
     """
 
     // when
@@ -121,7 +121,7 @@ class MockObjectTemplateTests: XCTestCase {
     buildSubject(schemaNamespace: "UPPER")
 
     let expected = """
-      public static let objectType: Object = UPPER.Objects.Dog
+      public static let objectType: ApolloAPI.Object = UPPER.Objects.Dog
     """
 
     // when
@@ -136,7 +136,7 @@ class MockObjectTemplateTests: XCTestCase {
     buildSubject(schemaNamespace: "MySchema")
 
     let expected = """
-      public static let objectType: Object = MySchema.Objects.Dog
+      public static let objectType: ApolloAPI.Object = MySchema.Objects.Dog
     """
 
     // when
@@ -826,7 +826,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     let expectedClassDefinition = """
     public class Dog: MockObject {
-      public static let objectType: Object = TestSchema.Objects.Dog
+      public static let objectType: ApolloAPI.Object = TestSchema.Objects.Dog
       public static let _mockFields = MockFields()
       public typealias MockValueCollectionType = Array<Mock<Dog>>
 
@@ -862,7 +862,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     let expectedClassDefinition = """
     public class Dog: MockObject {
-      public static let objectType: Object = TestSchema.Objects.Dog
+      public static let objectType: ApolloAPI.Object = TestSchema.Objects.Dog
       public static let _mockFields = MockFields()
       public typealias MockValueCollectionType = Array<Mock<Dog>>
 
@@ -898,7 +898,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     let expectedClassDefinition = """
     class Dog: MockObject {
-      static let objectType: Object = TestSchema.Objects.Dog
+      static let objectType: ApolloAPI.Object = TestSchema.Objects.Dog
       static let _mockFields = MockFields()
       typealias MockValueCollectionType = Array<Mock<Dog>>
 
@@ -997,7 +997,7 @@ class MockObjectTemplateTests: XCTestCase {
 
       let expected = """
       public class \(keyword.firstUppercased)_Object: MockObject {
-        public static let objectType: Object = TestSchema.Objects.\(keyword.firstUppercased)_Object
+        public static let objectType: ApolloAPI.Object = TestSchema.Objects.\(keyword.firstUppercased)_Object
         public static let _mockFields = MockFields()
         public typealias MockValueCollectionType = Array<Mock<\(keyword.firstUppercased)_Object>>
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/ObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/ObjectTemplateTests.swift
@@ -56,7 +56,7 @@ class ObjectTemplateTests: XCTestCase {
     buildSubject(name: "dog")
 
     let expected = """
-    static let Dog = Object(
+    static let Dog = ApolloAPI.Object(
       typename: "dog",
     """
 
@@ -140,7 +140,7 @@ class ObjectTemplateTests: XCTestCase {
 
     let expected = """
     /// \(documentation)
-    static let Dog = Object(
+    static let Dog = ApolloAPI.Object(
     """
 
     // when
@@ -160,7 +160,7 @@ class ObjectTemplateTests: XCTestCase {
     )
 
     let expected = """
-    static let Dog = Object(
+    static let Dog = ApolloAPI.Object(
     """
 
     // when
@@ -180,7 +180,7 @@ class ObjectTemplateTests: XCTestCase {
       buildSubject(name: keyword)
 
       let expected = """
-      static let \(keyword.firstUppercased)_Object = Object(
+      static let \(keyword.firstUppercased)_Object = ApolloAPI.Object(
         typename: "\(keyword)",
       """
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaConfigurationTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaConfigurationTemplateTests.swift
@@ -125,7 +125,7 @@ class SchemaConfigurationTemplateTests: XCTestCase {
     // given
     let expected = """
     enum SchemaConfiguration: Apollo.SchemaConfiguration {
-      static func cacheKeyInfo(for type: ApolloAPI.Object, object: ObjectData) -> CacheKeyInfo? {
+      static func cacheKeyInfo(for type: Apollo.Object, object: ObjectData) -> CacheKeyInfo? {
         // Implement this function to configure cache key resolution for your schema types.
         return nil
       }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaConfigurationTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaConfigurationTemplateTests.swift
@@ -60,7 +60,7 @@ class SchemaConfigurationTemplateTests: XCTestCase {
     // given
     let expected = """
     public enum SchemaConfiguration: ApolloAPI.SchemaConfiguration {
-      public static func cacheKeyInfo(for type: Object, object: ObjectData) -> CacheKeyInfo? {
+      public static func cacheKeyInfo(for type: ApolloAPI.Object, object: ObjectData) -> CacheKeyInfo? {
         // Implement this function to configure cache key resolution for your schema types.
         return nil
       }
@@ -83,7 +83,7 @@ class SchemaConfigurationTemplateTests: XCTestCase {
     // given
     let expected = """
     enum SchemaConfiguration: ApolloAPI.SchemaConfiguration {
-      public static func cacheKeyInfo(for type: Object, object: ObjectData) -> CacheKeyInfo? {
+      public static func cacheKeyInfo(for type: ApolloAPI.Object, object: ObjectData) -> CacheKeyInfo? {
         // Implement this function to configure cache key resolution for your schema types.
         return nil
       }
@@ -104,7 +104,7 @@ class SchemaConfigurationTemplateTests: XCTestCase {
     // given
     let expected = """
     enum SchemaConfiguration: ApolloAPI.SchemaConfiguration {
-      static func cacheKeyInfo(for type: Object, object: ObjectData) -> CacheKeyInfo? {
+      static func cacheKeyInfo(for type: ApolloAPI.Object, object: ObjectData) -> CacheKeyInfo? {
         // Implement this function to configure cache key resolution for your schema types.
         return nil
       }
@@ -125,7 +125,7 @@ class SchemaConfigurationTemplateTests: XCTestCase {
     // given
     let expected = """
     enum SchemaConfiguration: Apollo.SchemaConfiguration {
-      static func cacheKeyInfo(for type: Object, object: ObjectData) -> CacheKeyInfo? {
+      static func cacheKeyInfo(for type: ApolloAPI.Object, object: ObjectData) -> CacheKeyInfo? {
         // Implement this function to configure cache key resolution for your schema types.
         return nil
       }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
@@ -388,7 +388,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     )
 
     let expected = """
-      static func objectType(forTypename typename: String) -> Object? {
+      static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
         switch typename {
         case "objA": return ObjectSchema.Objects.ObjA
         case "objB": return ObjectSchema.Objects.ObjB
@@ -422,7 +422,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     )
 
     let expected = """
-      static func objectType(forTypename typename: String) -> Object? {
+      static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
         switch typename {
         case "ObjectA": return ObjectSchema.Objects.ObjectA
         default: return nil

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Tests/TestAppTests/TestAppTests.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Tests/TestAppTests/TestAppTests.swift
@@ -16,6 +16,7 @@ final class TestAppTests: XCTestCase {
             "id": "1",
             "skinCovering": "Fur",
             "species": "Canine",
+            "houseDetails": "Single Level Ranch"
           ]
         ]
       ]])

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/CocoaPodsProject.xcodeproj/project.pbxproj
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/CocoaPodsProject.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1B7ED6E41035FB2A0D763AD8 /* Pods_CocoaPodsProjectTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3E998DF0E4DCCF80C445451 /* Pods_CocoaPodsProjectTests.framework */; };
+		665BDA862AE30BE2004DD21F /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665BDA852AE30BE2004DD21F /* Object.swift */; };
 		B51EE231D8798C8408AB9CD5 /* Pods_CocoaPodsProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C684794938D6314DF12AB411 /* Pods_CocoaPodsProject.framework */; };
 		E607A69C29FB43F80059899E /* CocoaPodsProjectApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E607A69B29FB43F80059899E /* CocoaPodsProjectApp.swift */; };
 		E607A69E29FB43F80059899E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E607A69D29FB43F80059899E /* ContentView.swift */; };
@@ -82,6 +83,7 @@
 
 /* Begin PBXFileReference section */
 		4C671E51FD3FF74D8B077F45 /* Pods-CocoaPodsProjectTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsProjectTests.release.xcconfig"; path = "Target Support Files/Pods-CocoaPodsProjectTests/Pods-CocoaPodsProjectTests.release.xcconfig"; sourceTree = "<group>"; };
+		665BDA852AE30BE2004DD21F /* Object.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Object.swift; sourceTree = "<group>"; };
 		7D6507DAD078EC7A270097F0 /* Pods-CocoaPodsProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsProject.release.xcconfig"; path = "Target Support Files/Pods-CocoaPodsProject/Pods-CocoaPodsProject.release.xcconfig"; sourceTree = "<group>"; };
 		951B5BB1CBB3B06FF1E6F602 /* Pods-CocoaPodsProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsProject.debug.xcconfig"; path = "Target Support Files/Pods-CocoaPodsProject/Pods-CocoaPodsProject.debug.xcconfig"; sourceTree = "<group>"; };
 		C684794938D6314DF12AB411 /* Pods_CocoaPodsProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CocoaPodsProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -334,6 +336,7 @@
 		E607A72C29FB692F0059899E /* CustomScalars */ = {
 			isa = PBXGroup;
 			children = (
+				665BDA852AE30BE2004DD21F /* Object.swift */,
 				E607A72D29FB692F0059899E /* CustomDate.swift */,
 			);
 			path = CustomScalars;
@@ -580,6 +583,7 @@
 				E607A75929FB692F0059899E /* ClassroomPet.graphql.swift in Sources */,
 				E607A75F29FB692F0059899E /* PetRock.graphql.swift in Sources */,
 				E607A76129FB69300059899E /* Height.graphql.swift in Sources */,
+				665BDA862AE30BE2004DD21F /* Object.swift in Sources */,
 				E607A75329FB692F0059899E /* AllAnimalsCCNQuery.graphql.swift in Sources */,
 				E607A76C29FB69300059899E /* SchemaMetadata.graphql.swift in Sources */,
 				E607A76329FB69300059899E /* Query.graphql.swift in Sources */,

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/CocoaPodsProject/AnimalKingdomAPI/Schema/SchemaConfiguration.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/CocoaPodsProject/AnimalKingdomAPI/Schema/SchemaConfiguration.swift
@@ -8,7 +8,7 @@
 import Apollo
 
 public enum SchemaConfiguration: Apollo.SchemaConfiguration {
-  public static func cacheKeyInfo(for type: Object, object: ObjectData) -> CacheKeyInfo? {
+  public static func cacheKeyInfo(for type: Apollo.Object, object: ObjectData) -> CacheKeyInfo? {
     try? CacheKeyInfo(jsonValue: object["id"])
   }
 }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/CocoaPodsProjectTests/CocoaPodsProjectTests.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/CocoaPodsProjectTests/CocoaPodsProjectTests.swift
@@ -15,7 +15,8 @@ final class CocoaPodsProjectTests: XCTestCase {
             "__typename": "Dog",
             "id": "1",
             "skinCovering": "Fur",
-            "species": "Canine"
+            "species": "Canine",
+            "houseDetails": "Single Level Ranch"
           ]
         ]
       ]])

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/CustomTargetProject.xcodeproj/project.pbxproj
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/CustomTargetProject.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		665BDA882AE30E9D004DD21F /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665BDA872AE30E9D004DD21F /* Object.swift */; };
 		DE454BCC28B43262009DC80E /* CustomTargetProject.h in Headers */ = {isa = PBXBuildFile; fileRef = DE454BCB28B43262009DC80E /* CustomTargetProject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E6BACC1C29FC909F008B46F2 /* AnimalKingdomAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E6BACC1B29FC909F008B46F2 /* AnimalKingdomAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E6BACC2129FC90CC008B46F2 /* ApolloAPI in Frameworks */ = {isa = PBXBuildFile; productRef = E6BACC2029FC90CC008B46F2 /* ApolloAPI */; };
@@ -104,6 +105,7 @@
 
 /* Begin PBXFileReference section */
 		663EB6712A58B3C300A63215 /* apollo-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "apollo-ios"; path = "../../../apollo-ios"; sourceTree = "<group>"; };
+		665BDA872AE30E9D004DD21F /* Object.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Object.swift; sourceTree = "<group>"; };
 		DE454BC928B43262009DC80E /* CustomTargetProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CustomTargetProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE454BCB28B43262009DC80E /* CustomTargetProject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomTargetProject.h; sourceTree = "<group>"; };
 		E6BACC1329FC8C8B008B46F2 /* apollo-codegen-config.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "apollo-codegen-config.json"; sourceTree = "<group>"; };
@@ -290,6 +292,7 @@
 		E6BACC2929FC9468008B46F2 /* CustomScalars */ = {
 			isa = PBXGroup;
 			children = (
+				665BDA872AE30E9D004DD21F /* Object.swift */,
 				E6BACC2A29FC9468008B46F2 /* CustomDate.swift */,
 			);
 			path = CustomScalars;
@@ -587,6 +590,7 @@
 				E6BACC5C29FC9468008B46F2 /* SkinCovering.graphql.swift in Sources */,
 				E6BACC6D29FC9468008B46F2 /* SchemaMetadata.graphql.swift in Sources */,
 				E6BACC6A29FC9468008B46F2 /* PetAdoptionInput.graphql.swift in Sources */,
+				665BDA882AE30E9D004DD21F /* Object.swift in Sources */,
 				E6BACC6629FC9468008B46F2 /* Fish.graphql.swift in Sources */,
 				E6BACC7829FC9468008B46F2 /* PetAdoptionMutation.graphql.swift in Sources */,
 				E6BACC7329FC9468008B46F2 /* HeightInMeters.graphql.swift in Sources */,

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Tests/SwiftPackageTests/TestMockUsageTests.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Tests/SwiftPackageTests/TestMockUsageTests.swift
@@ -32,7 +32,8 @@ class TestMockUsageTests: XCTestCase {
                             owner: mockHuman,
                             predators: [mockCrocodile, mockBird],
                             skinCovering: .case(.fur),
-                            species: "Lab")
+                            species: "Lab",
+                            houseDetails: "Single Level Ranch")
 
     // then
     XCTAssertEqual(mockDog.birthdate, "Jan 10")
@@ -47,6 +48,7 @@ class TestMockUsageTests: XCTestCase {
     XCTAssertEqual(mockDog.predators?.count, 2)
     XCTAssertEqual(mockDog.skinCovering, .case(.fur))
     XCTAssertEqual(mockDog.species, "Lab")
+    XCTAssertEqual(mockDog.houseDetails, "Single Level Ranch")
   
   }
 

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Tests/SwiftPackageTests/TestMockUsageTests.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Tests/SwiftPackageTests/TestMockUsageTests.swift
@@ -26,7 +26,7 @@ class TestMockUsageTests: XCTestCase {
                             bodyTemperature: 70,
                             favoriteToy: "Ball",
                             height: mockHeight,
-                            houseDetails: "Single Level Ranch"
+                            houseDetails: "Single Level Ranch",
                             humanName: "Lucky",
                             id: "Dog",
                             laysEggs: false,

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Tests/SwiftPackageTests/TestMockUsageTests.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Tests/SwiftPackageTests/TestMockUsageTests.swift
@@ -26,14 +26,14 @@ class TestMockUsageTests: XCTestCase {
                             bodyTemperature: 70,
                             favoriteToy: "Ball",
                             height: mockHeight,
+                            houseDetails: "Single Level Ranch"
                             humanName: "Lucky",
                             id: "Dog",
                             laysEggs: false,
                             owner: mockHuman,
                             predators: [mockCrocodile, mockBird],
                             skinCovering: .case(.fur),
-                            species: "Lab",
-                            houseDetails: "Single Level Ranch")
+                            species: "Lab")
 
     // then
     XCTAssertEqual(mockDog.birthdate, "Jan 10")

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -41,7 +41,7 @@ struct MockObjectTemplate: TemplateRenderer {
 
     return """
     \(accessControlModifier(for: .parent))class \(objectName): MockObject {
-      \(memberAccessControl)static let objectType: ApolloAPI.Object = \(config.schemaNamespace.firstUppercased).Objects.\(objectName)
+      \(memberAccessControl)static let objectType: \(config.ApolloAPITargetName).Object = \(config.schemaNamespace.firstUppercased).Objects.\(objectName)
       \(memberAccessControl)static let _mockFields = MockFields()
       \(memberAccessControl)typealias MockValueCollectionType = Array<Mock<\(objectName)>>
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -41,7 +41,7 @@ struct MockObjectTemplate: TemplateRenderer {
 
     return """
     \(accessControlModifier(for: .parent))class \(objectName): MockObject {
-      \(memberAccessControl)static let objectType: Object = \(config.schemaNamespace.firstUppercased).Objects.\(objectName)
+      \(memberAccessControl)static let objectType: ApolloAPI.Object = \(config.schemaNamespace.firstUppercased).Objects.\(objectName)
       \(memberAccessControl)static let _mockFields = MockFields()
       \(memberAccessControl)typealias MockValueCollectionType = Array<Mock<\(objectName)>>
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
@@ -15,7 +15,7 @@ struct ObjectTemplate: TemplateRenderer {
   var template: TemplateString {
     """
     \(documentation: graphqlObject.documentation, config: config)
-    static let \(graphqlObject.formattedName) = Object(
+    static let \(graphqlObject.formattedName) = ApolloAPI.Object(
       typename: "\(graphqlObject.name)\",
       implementedInterfaces: \(ImplementedInterfacesTemplate())
     )

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
@@ -15,7 +15,7 @@ struct ObjectTemplate: TemplateRenderer {
   var template: TemplateString {
     """
     \(documentation: graphqlObject.documentation, config: config)
-    static let \(graphqlObject.formattedName) = ApolloAPI.Object(
+    static let \(graphqlObject.formattedName) = \(config.ApolloAPITargetName).Object(
       typename: "\(graphqlObject.name)\",
       implementedInterfaces: \(ImplementedInterfacesTemplate())
     )

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaConfigurationTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaConfigurationTemplate.swift
@@ -21,7 +21,7 @@ struct SchemaConfigurationTemplate: TemplateRenderer {
     \(accessControlModifier(for: .parent))enum SchemaConfiguration: \
     \(config.ApolloAPITargetName).SchemaConfiguration {
       \(accessControlModifier(for: .member))\
-    static func cacheKeyInfo(for type: ApolloAPI.Object, object: ObjectData) -> CacheKeyInfo? {
+    static func cacheKeyInfo(for type: \(config.ApolloAPITargetName).Object, object: ObjectData) -> CacheKeyInfo? {
         // Implement this function to configure cache key resolution for your schema types.
         return nil
       }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaConfigurationTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaConfigurationTemplate.swift
@@ -21,7 +21,7 @@ struct SchemaConfigurationTemplate: TemplateRenderer {
     \(accessControlModifier(for: .parent))enum SchemaConfiguration: \
     \(config.ApolloAPITargetName).SchemaConfiguration {
       \(accessControlModifier(for: .member))\
-    static func cacheKeyInfo(for type: Object, object: ObjectData) -> CacheKeyInfo? {
+    static func cacheKeyInfo(for type: ApolloAPI.Object, object: ObjectData) -> CacheKeyInfo? {
         // Implement this function to configure cache key resolution for your schema types.
         return nil
       }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
@@ -55,7 +55,7 @@ struct SchemaMetadataTemplate: TemplateRenderer {
   var objectTypeFunction: TemplateString {
     return """
     \(accessControlModifier(for: .member))\
-    static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
+    static func objectType(forTypename typename: String) -> \(config.ApolloAPITargetName).Object? {
       switch typename {
       \(schema.referencedTypes.objects.map {
         "case \"\($0.name)\": return \(schemaNamespace).Objects.\($0.formattedName)"

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
@@ -55,7 +55,7 @@ struct SchemaMetadataTemplate: TemplateRenderer {
   var objectTypeFunction: TemplateString {
     return """
     \(accessControlModifier(for: .member))\
-    static func objectType(forTypename typename: String) -> Object? {
+    static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
       switch typename {
       \(schema.referencedTypes.objects.map {
         "case \"\($0.name)\": return \(schemaNamespace).Objects.\($0.formattedName)"


### PR DESCRIPTION
-Name spacing our usage of ApolloAPI.Object in generated code in order to avoid conflicts with potential user defined custom scalar named 'Object'

Closes apollographql/apollo-ios#3258