### PR TITLE
Remove import module for Test Mock when output schemeType is not in Module

### DIFF
--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -295,7 +295,7 @@ struct ImportStatementTemplate {
     static func template(for config: ApolloCodegen.ConfigurationContext) -> TemplateString {
       return """
       import ApolloTestSupport
-      import \(config.schemaModuleName)
+      \(if: config.output.schemaTypes.isInModule, "import \(config.schemaModuleName)")
       """
     }
   }


### PR DESCRIPTION
Related to the issue reported here https://github.com/apollographql/apollo-ios/issues/3262