### PR TITLE
docs: Clarify test mocks `absolute` configuration

### DIFF
--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -391,9 +391,10 @@ This option outputs all of your generated test mocks in a single directory.
 
 Specify the directory for your test mocks using the `path` parameter. This is resolved as a relative path from the directory containing your `apollo-codegen-config.json` file when using the CLI. Use the `accessModifier` property to control the visibility of the generated code.
 
-> **Note:** When using this option, you are responsible for ensuring the generated test mocks are linked to your test target.
->
-> Test mocks generated this way may also be manually embedded in a test utility module that is imported by your test target.
+> **Note:** 
+> * When using this option, you are responsible for ensuring the generated test mocks are linked to your test target.
+> * Test mocks generated this way may also be manually embedded in a test utility module that is imported by your test target.
+> * Test mocks are required to be in a target or module that is separate from the schema module and will always include `import` statements linking the schema module.
 
 ## Output options
 

--- a/docs/source/testing/test-mocks.mdx
+++ b/docs/source/testing/test-mocks.mdx
@@ -6,7 +6,7 @@ When unit testing code that uses your generated operation models, you will often
 
 ## Purpose
 
-Generated test mocks provide a type-safe way to mock your response models. Rather than dealing with cumbersome and error prone JSON data, test mocks make mocking safer,more concise, and reusable. They are mutable, offer code completion in Xcode, and update with new fields automatically as your schema and operations change.
+Generated test mocks provide a type-safe way to mock your response models. Rather than dealing with cumbersome and error prone JSON data, test mocks make mocking safer, more concise, and reusable. They are mutable, offer code completion in Xcode, and update with new fields automatically as your schema and operations change.
 
 ### Mocking GraphQL responses with JSON
 


### PR DESCRIPTION
Related to https://github.com/apollographql/apollo-ios/issues/3262.