### PR TITLE
ApolloPagination: Fix bug where pages were keyed by initial query

### DIFF
--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -155,7 +155,7 @@ public class GraphQLQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: Graph
           } else {
             shouldUpdate = true
           }
-          let variables = initialQuery.__variables?.values.compactMap { $0._jsonEncodableValue?._jsonValue } ?? []
+          let variables = nextPageQuery.__variables?.values.compactMap { $0._jsonEncodableValue?._jsonValue } ?? []
           if shouldUpdate {
             self.pageOrder.append(variables)
           }


### PR DESCRIPTION
This is a bug. Page storage should be keyed by the variables of the query that generated them, not by the initial query.