### PR TITLE
Updating git config on action runner

### DIFF
--- a/.github/actions/configure-git/action.yml
+++ b/.github/actions/configure-git/action.yml
@@ -1,0 +1,8 @@
+name: "Configure Git Settings"
+description: Configures appropriate git settings for the github action workflows.
+runs:
+  using: "composite"
+  shell: bash
+  run: |
+    git config --global user.name "gh-action-runner"
+    

--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -28,6 +28,8 @@ jobs:
           ${{ secrets.APOLLO_IOS_CODEGEN_DEPLOY_KEY }}
           ${{ secrets.APOLLO_IOS_DEV_DEPLOY_KEY }}
           ${{ secrets.APOLLO_IOS_PAGINATION_DEPLOY_KEY }}
+    - name: Configure Git
+      uses: ./.github/actions/configure-git
     - name: Update Merge Commit Message
       shell: bash
       run: |


### PR DESCRIPTION
Attempting to fix an issue where the UI on PRs shows me as the person committing subtree changes from CI, but the commits themselves show as coming from "runner" as they should.