### PR TITLE
Selectively run Tuist Generation when there are changes to the Tuist configuration

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -8,8 +8,25 @@ env:
   XCODE_VERSION: "15.0.0"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      project: ${{ steps.filter.outputs.project }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            project:
+              - 'Workspace.swift'
+              - 'Tuist/**'
+              - 'Project.swift'
+
   tuist-generation:
     runs-on: macos-13
+    needs: changes
+    if: ${{ needs.changes.outputs.project == 'true' }}
     timeout-minutes: 8
     name: Run Tuist Generation
     steps:


### PR DESCRIPTION
The purpose of this pull request is to speed up CI & to save y'all some actions runner minutes.

Running `Tuist generate` as a step testing the validity of the project shouldn't be necessary if there have been no changes to the configuration. To verify proper function: I will branch off of this PR with a change to Tuist. This pull request, having no changes to the configuration shouldn't run the action. The other, with changes to the configuration, should run the action.

cc: @BobaFetters, since you have the most context on the configuration: Is the filter I've setup sufficient? 

Edit: See #104 for an example of a pull request that triggers running `Run Tuist Generation`. 

EDIT2: I see that the broader matrix for testing this is reliant on the Tuist generate step. 🤔 Another thought would be to selectively filter & run tests based on the filter. I'll give it some more thought.