### PR TITLE
Updating docs publish job

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,17 +1,19 @@
 name: Deploy docs to production
 
 on:
-  push:
+  pull_request_target:
     branches:
       - main
     paths:
       - docs/**
+    types: [closed]
 
 permissions:
   contents: read
 
 jobs:
   publish:
+    if: ${{ github.event.pull_request.merged }}
     permissions:
       contents: read
     uses: apollographql/docs/.github/workflows/publish.yml@main


### PR DESCRIPTION
Currently the docs publish job triggers twice for every update because its based on pushes to the main branch and our workflow updates and pushes the commit message when PRs are merged triggering a second run. Updating this to be based on merged PRs so that it will only trigger once like our subtree job.