### PR TITLE
Escape quotation marks in operation manifest body

### DIFF
--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/OperationDescriptor.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/OperationDescriptor.swift
@@ -1,34 +1,32 @@
 import IR
 import GraphQLCompiler
 
-private func formatFragmentForRawSourceText(_ fragment: CompilationResult.FragmentDefinition) -> String {
-    "\n\(fragment.source.convertedToSingleLine())"
-}
-
-private func formatFragmentForManifestJSONBody(_ fragment: CompilationResult.FragmentDefinition) -> String {
-    #"\n\#(fragment.source.convertedToSingleLine())"#
-}
-
-private func append(
-    to source: inout String,
-    set: inout Set<String>,
-    fragments: [CompilationResult.FragmentDefinition],
-    format: (CompilationResult.FragmentDefinition) -> String
-) {
-  for fragment in fragments {
-    if !set.contains(fragment.name) {
-      set.insert(fragment.name)
-      source += format(fragment)
-      append(to: &source, set: &set, fragments: fragment.referencedFragments, format: format)
-    }
-  }
-}
-
 public struct OperationDescriptor: Sendable {
   public enum OperationType: String, Hashable {
     case query
     case mutation
     case subscription
+  }
+
+  public enum SourceFormat {
+    /// The source text for the operation formatted exactly as it will be sent via network
+    /// transport when executed by an `ApolloClient`. This value should be used to calculate
+    /// the operation identifier for a persisted queries manifest.
+    ///
+    /// This format includes:
+    /// - The operation's source, minimized to a single line
+    /// - The source of each fragment referenced by the operation, each minimized to a
+    ///   single line. There will be a `\n` character between the operation and each
+    ///   fragment.
+    case rawSource
+
+    /// The source text formatted for inclusion as the "body" field in a JSON object
+    /// written into a `OperationManifestTemplate`. It provides the
+    /// exact data that will be sent by the Apollo network transport when the
+    /// operation is executed in a format that can be written to a file.
+    ///
+    /// This escapes the newline characters between fragments.
+    case manifestJSONBody
   }
 
   let underlyingDefinition: CompilationResult.OperationDefinition
@@ -44,13 +42,6 @@ public struct OperationDescriptor: Sendable {
     return type
   }
 
-  private func formattedSourceText(_ format: (CompilationResult.FragmentDefinition) -> String) -> String {
-    var source = underlyingDefinition.source.convertedToSingleLine()
-    var set = Set<String>()
-    append(to: &source, set: &set, fragments: underlyingDefinition.referencedFragments, format: format)
-    return source
-  }
-
   /// The source text for the operation formatted exactly as it will be sent via network
   /// transport when executed by an `ApolloClient`. This value should be used to calculate
   /// the operation identifier for a persisted queries manifest.
@@ -60,7 +51,9 @@ public struct OperationDescriptor: Sendable {
   /// - The source of each fragment referenced by the operation, each minimized to a
   ///   single line. There will be a `\n` character between the operation and each
   ///   fragment.
-  public var rawSourceText: String { formattedSourceText(formatFragmentForRawSourceText) }
+  public var rawSourceText: String {
+    sourceText(withFormat: .rawSource)
+  }
 
   // MARK: - Internal
 
@@ -68,12 +61,52 @@ public struct OperationDescriptor: Sendable {
     self.underlyingDefinition = operation
   }
 
-  /// The source text formatted for inclusion as the "body" field in a JSON object
-  /// written into a `OperationManifestTemplate`. It provides the
-  /// exact data that will be sent by the Apollo network transport when the
-  /// operation is executed in a format that can be written to a file.
-  ///
-  /// This escapes the newline characters between fragments.
-  var sourceTextFormattedForManifestJSONBody: String { formattedSourceText(formatFragmentForManifestJSONBody) }
+  func sourceText(withFormat format: SourceFormat) -> String {
+    format.formatted(underlyingDefinition)
+  }
+  
+}
 
+// MARK: - Formatting
+
+fileprivate extension OperationDescriptor.SourceFormat {
+  func formatted(_ operation: CompilationResult.OperationDefinition) -> String {
+    var source = operation.source.convertedToSingleLine()
+    var set = Set<String>()
+    append(
+      to: &source,
+      set: &set,
+      fragments: operation.referencedFragments
+    )
+    switch self {
+    case .rawSource:
+      return source
+    case .manifestJSONBody:
+      return source.replacingOccurrences(of: #"""#, with: #"\""#)
+    }
+  }
+
+  private func append(
+    to source: inout String,
+    set: inout Set<String>,
+    fragments: [CompilationResult.FragmentDefinition]
+  ) {
+    for fragment in fragments {
+      if !set.contains(fragment.name) {
+        set.insert(fragment.name)
+        source += formatted(fragment)
+        append(to: &source, set: &set, fragments: fragment.referencedFragments)
+      }
+    }
+  }
+
+  private func formatted(_ fragment: CompilationResult.FragmentDefinition) -> String {
+    switch self {
+    case .rawSource:
+      return "\n\(fragment.source.convertedToSingleLine())"
+
+    case .manifestJSONBody:
+      return #"\n\#(fragment.source.convertedToSingleLine())"#
+    }
+  }
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/OperationIdentifierFactory.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/OperationIdentifierFactory.swift
@@ -56,7 +56,7 @@ let DefaultOperationIdentifierProvider =
       hasher.update(bufferPointer: UnsafeRawBufferPointer(buffer))
     })
   }
-  var definitionSource = operation.rawSourceText
+  var definitionSource = operation.sourceText(withFormat: .rawSource)
   updateHash(with: &definitionSource)
 
   let digest = hasher.finalize()

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/LegacyAPQOperationManifestTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/LegacyAPQOperationManifestTemplate.swift
@@ -16,7 +16,7 @@ struct LegacyAPQOperationManifestTemplate: OperationManifestTemplate {
           return """
             "\($0.identifier)" : {
               "name": "\($0.operation.name)",
-              "source": "\($0.operation.sourceTextFormattedForManifestJSONBody)"
+              "source": "\($0.operation.sourceText(withFormat: .manifestJSONBody))"
             }
             """
         })

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/PersistedQueriesOperationManifestTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/PersistedQueriesOperationManifestTemplate.swift
@@ -22,7 +22,7 @@ struct PersistedQueriesOperationManifestTemplate: OperationManifestTemplate {
             return """
             {
               "id": "\($0.identifier)",
-              "body": "\($0.operation.sourceTextFormattedForManifestJSONBody)",
+              "body": "\($0.operation.sourceText(withFormat: .manifestJSONBody))",
               "name": "\($0.operation.name)",
               "type": "\($0.operation.type.rawValue)"
             }


### PR DESCRIPTION
Fixes [#apollo-ios/3268](https://github.com/apollographql/apollo-ios/issues/3268)

- Refactor source formatting to improve readability and isolate escaping of characters to JSON manifest format.
- Escape `"` in JSON manifest operation body text