### PR TITLE
refactor: Selection Set Template - Basic

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -6935,7 +6935,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(rendered_allAnimals_deferredAsRoot).to(equalLineByLine(
       """
       /// AllAnimal.Root
-      public struct Root: TestSchema.InlineFragment {
+      public struct Root: TestSchema.InlineFragment, ApolloAPI.Deferrable {
         public let __data: DataDict
         public init(_dataDict: DataDict) { __data = _dataDict }
 
@@ -6987,7 +6987,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(rendered_allAnimals_deferredAsRoot).to(equalLineByLine(
       """
       /// AllAnimal.Root
-      public struct Root: TestSchema.InlineFragment {
+      public struct Root: TestSchema.InlineFragment, ApolloAPI.Deferrable {
         public let __data: DataDict
         public init(_dataDict: DataDict) { __data = _dataDict }
 
@@ -7044,7 +7044,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(rendered_allAnimals_asDog_deferredAsRoot).to(equalLineByLine(
       """
       /// AllAnimal.AsDog.Root
-      public struct Root: TestSchema.InlineFragment {
+      public struct Root: TestSchema.InlineFragment, ApolloAPI.Deferrable {
         public let __data: DataDict
         public init(_dataDict: DataDict) { __data = _dataDict }
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -950,10 +950,15 @@ fileprivate struct SelectionSetNameGenerator {
 fileprivate extension IR.ScopeCondition {
 
   var selectionSetNameComponent: String {
-    return TemplateString("""
-    \(ifLet: type, { "As\($0.formattedName)" })\
-    \(ifLet: conditions, { "If\($0.typeNameComponents)"})
-    """).description
+    if let deferCondition {
+      return deferCondition.renderedTypeName
+
+    } else {
+      return TemplateString("""
+      \(ifLet: type, { "As\($0.formattedName)" })\
+      \(ifLet: conditions, { "If\($0.typeNameComponents)"})
+      """).description
+    }
   }
   
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -54,8 +54,9 @@ struct SelectionSetTemplate {
     \(SelectionSetNameDocumentation(inlineFragment))
     \(renderAccessControl())\
     struct \(inlineFragment.renderedTypeName): \(SelectionSetType(asInlineFragment: true))\
-    \(if: inlineFragment.isCompositeSelectionSet, ", \(config.ApolloAPITargetName).CompositeInlineFragment") \
-    {
+    \(if: inlineFragment.isCompositeSelectionSet, ", \(config.ApolloAPITargetName).CompositeInlineFragment")\
+    \(if: inlineFragment.isDeferred, ", \(config.ApolloAPITargetName).Deferrable")\
+     {
       \(BodyTemplate(inlineFragment))
     }
     """

--- a/apollo-ios-codegen/Sources/IR/IR+ScopeDescriptor.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+ScopeDescriptor.swift
@@ -31,7 +31,7 @@ public struct ScopeCondition: Hashable, CustomDebugStringConvertible {
     type == nil && (conditions?.isEmpty ?? true) && deferCondition == nil
   }
 
-  var isDeferred: Bool { deferCondition != nil }
+  public var isDeferred: Bool { deferCondition != nil }
 }
 
 public typealias TypeScope = OrderedSet<GraphQLCompositeType>
@@ -74,6 +74,8 @@ public struct ScopeDescriptor: Hashable, CustomDebugStringConvertible {
   let matchingConditions: InclusionConditions?
 
   let allTypesInSchema: Schema.ReferencedTypes
+
+  public var isDeferred: Bool { scopePath.last.value.isDeferred }
 
   private init(
     typePath: LinkedList<ScopeCondition>,

--- a/apollo-ios-codegen/Sources/IR/IR+SelectionSet.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+SelectionSet.swift
@@ -28,6 +28,9 @@ public class SelectionSet: Hashable, CustomDebugStringConvertible {
     public var deferCondition: CompilationResult.DeferCondition? {
       scope.scopePath.last.value.deferCondition
     }
+//    public var isDeferred: Bool {
+//      deferCondition != nil
+//    }
 
     /// Indicates if the `SelectionSet` represents a root selection set.
     /// If `true`, the `SelectionSet` belongs to a field directly.

--- a/apollo-ios-codegen/Sources/IR/IR+SelectionSet.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+SelectionSet.swift
@@ -28,9 +28,7 @@ public class SelectionSet: Hashable, CustomDebugStringConvertible {
     public var deferCondition: CompilationResult.DeferCondition? {
       scope.scopePath.last.value.deferCondition
     }
-//    public var isDeferred: Bool {
-//      deferCondition != nil
-//    }
+    public var isDeferred: Bool { deferCondition != nil }
 
     /// Indicates if the `SelectionSet` represents a root selection set.
     /// If `true`, the `SelectionSet` belongs to a field directly.


### PR DESCRIPTION
This PR refactors the selection set template to correctly render **basic** deferred inline fragments. By 'basic' I mean a simple `@defer` directive on an inline fragment with and without a type case specification, on the same and on a different type case.

_This is not intended to be a complete change set for all deferred fragments. Instead this will allow generation of a complete model for a simple deferred fragment operation so I can move on to the next piece of the stack - the executor. There are warnings in place to mark where more complex test cases are needed._

This will generate the following sections of an operation model for deferred inline fragments:
* selections
* field accessor
* fragment accessor
* root type entity

The selection set template test diff still looks like a bit of a mess so the tests to focus on are:
* [Selections - Deferred Inline Fragment](https://github.com/apollographql/apollo-ios-dev/blob/defer/selection-set-template-basic/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift#L1491)
* [Field Accessors - Deferred Inline Fragment](https://github.com/apollographql/apollo-ios-dev/blob/defer/selection-set-template-basic/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift#L4540)
* [Fragment Accessors - Deferred Inline Fragment](https://github.com/apollographql/apollo-ios-dev/blob/defer/selection-set-template-basic/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift#L5380)
* Root Type Entity
  * [`test__render_deferredTypeCase__givenDeferredInlineFragmentWithoutTypeCase_rendersRootEntityType`](https://github.com/apollographql/apollo-ios-dev/blob/defer/selection-set-template-basic/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift#L6898)
  * [`test__render_deferredTypeCase__givenDeferredInlineFragmentOnSameTypeCase_rendersRootEntityType`](https://github.com/apollographql/apollo-ios-dev/blob/defer/selection-set-template-basic/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift#L6950)
  * [`test__render_deferredTypeCase__givenDeferredInlineFragmentOnDifferentTypeCase_rendersRootEntityType`](https://github.com/apollographql/apollo-ios-dev/blob/defer/selection-set-template-basic/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift#L7002)