### PR TITLE
docs: Fix tutorial code for 1.3 migration

### DIFF
--- a/docs/source/tutorial/tutorial-authenticate-operations.mdx
+++ b/docs/source/tutorial/tutorial-authenticate-operations.mdx
@@ -24,6 +24,7 @@ import Apollo
 import ApolloAPI
 
 class AuthorizationInterceptor: ApolloInterceptor {
+    public var id: String = UUID().uuidString
     
     func interceptAsync<Operation>(
         chain: RequestChain,
@@ -51,9 +52,11 @@ if let token = keychain.get(LoginView.loginKeychainKey) {
     request.addHeader(name: "Authorization", value: token)
 }
 
-chain.proceedAsync(request: request,
-                    response: response,
-                    completion: completion)
+chain.proceedAsync(
+    request: request,
+    response: response,
+    interceptor: self,
+    completion: completion)
 ```
 
 An array of `ApolloInterceptor`s which are handed off to each request to perform in order is set up by an object conforming to the `InterceptorProvider` protocol. There's a `DefaultInterceptorProvider` which has an array with most of the Interceptors you'd want to use.


### PR DESCRIPTION
Fixes the tutorial sample code for the `AuthorizationInterceptor` to be compatible with the `1.3` migration.

_From https://apollograph.slack.com/archives/C01BMLR2YBG/p1698955643166659._