### PR TITLE
Fix warnings in codegen configuration documentation

### DIFF
--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -669,7 +669,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   /// schema in generated code.
   public struct ConversionStrategies: Codable, Equatable {
 
-    /// ``ApolloCodegenConfiguration/ConversionStrategies/EnumCase`` is used to specify the strategy
+    /// ``ApolloCodegenConfiguration/ConversionStrategies/EnumCases`` is used to specify the strategy
     /// used to convert the casing of enum cases in a GraphQL schema into generated Swift code.
     public enum EnumCases: String, Codable, Equatable {
       /// Generates swift code using the exact name provided in the GraphQL schema
@@ -695,12 +695,12 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     
     /// Determines how the names of enum cases in the GraphQL schema will be converted into
     /// cases on the generated Swift enums.
-    /// Defaultss to ``ApolloCodegenConfiguration/CaseConversionStrategy/camelCase``
+    /// Defaults to ``ApolloCodegenConfiguration/ConversionStrategies/CaseConversionStrategy/camelCase``
     public let enumCases: EnumCases
     
     /// Determines how the names of fields in the GraphQL schema will be converted into
     /// properties in the generated Swift code.
-    /// Defaults to ``ApolloCodegenConfiguration/CaseConversionStrategy/camelCase``
+    /// Defaults to ``ApolloCodegenConfiguration/ConversionStrategies/FieldAccessors/idiomatic``
     public let fieldAccessors: FieldAccessors
 
     /// Default property values
@@ -1478,7 +1478,7 @@ extension ApolloCodegenConfiguration.ConversionStrategies {
   
   /// ``CaseConversionStrategy`` is used to specify the strategy used to convert the casing of
   /// GraphQL schema values into generated Swift code.
-  @available(*, deprecated, message: "Use EnumCaseConversionStrategy instead.")
+  @available(*, deprecated, message: "Use EnumCases instead.")
     public enum CaseConversionStrategy: String, Codable, Equatable {
       /// Generates swift code using the exact name provided in the GraphQL schema
       /// performing no conversion.

--- a/docs/docc/Apollo.doccarchive/data/documentation/apolloapi/graphqloperation/operationtype-14lsi.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apolloapi/graphqloperation/operationtype-14lsi.json
@@ -2,9 +2,9 @@
   "defaultImplementationsSections" : [
     {
       "identifiers" : [
-        "doc:\/\/ApolloAPI\/documentation\/ApolloAPI\/GraphQLOperation\/operationType-370r3",
         "doc:\/\/ApolloAPI\/documentation\/ApolloAPI\/GraphQLOperation\/operationType-90ybj",
-        "doc:\/\/ApolloAPI\/documentation\/ApolloAPI\/GraphQLOperation\/operationType-5e63x"
+        "doc:\/\/ApolloAPI\/documentation\/ApolloAPI\/GraphQLOperation\/operationType-5e63x",
+        "doc:\/\/ApolloAPI\/documentation\/ApolloAPI\/GraphQLOperation\/operationType-370r3"
       ],
       "title" : "GraphQLOperation Implementations"
     }

--- a/docs/docc/Apollo.doccarchive/data/documentation/apolloapi/jsonencodable.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apolloapi/jsonencodable.json
@@ -901,7 +901,7 @@
         "type" : "text"
       },
       {
-        "code" : "AnyScalarType",
+        "code" : "JSONEncodable",
         "type" : "codeVoice"
       },
       {

--- a/docs/docc/Apollo.doccarchive/data/documentation/apolloapi/swift/optional.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apolloapi/swift/optional.json
@@ -446,7 +446,7 @@
         "type" : "text"
       },
       {
-        "code" : "AnyScalarType",
+        "code" : "JSONEncodable",
         "type" : "codeVoice"
       },
       {

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies.json
@@ -323,6 +323,59 @@
   "type" : "topic",
   "url" : "\/documentation\/apollocodegenlib\/apollocodegenconfiguration\/conversionstrategies\/caseconversionstrategy"
 },
+"doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/CaseConversionStrategy/camelCase": {
+  "abstract" : [
+    {
+      "text" : "Convert to lower camel case from ",
+      "type" : "text"
+    },
+    {
+      "code" : "snake_case",
+      "type" : "codeVoice"
+    },
+    {
+      "text" : ", ",
+      "type" : "text"
+    },
+    {
+      "code" : "UpperCamelCase",
+      "type" : "codeVoice"
+    },
+    {
+      "text" : ", or ",
+      "type" : "text"
+    },
+    {
+      "code" : "UPPERCASE",
+      "type" : "codeVoice"
+    },
+    {
+      "text" : ".",
+      "type" : "text"
+    }
+  ],
+  "deprecated" : true,
+  "fragments" : [
+    {
+      "kind" : "keyword",
+      "text" : "case"
+    },
+    {
+      "kind" : "text",
+      "text" : " "
+    },
+    {
+      "kind" : "identifier",
+      "text" : "camelCase"
+    }
+  ],
+  "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/CaseConversionStrategy\/camelCase",
+  "kind" : "symbol",
+  "role" : "symbol",
+  "title" : "ApolloCodegenConfiguration.ConversionStrategies.CaseConversionStrategy.camelCase",
+  "type" : "topic",
+  "url" : "\/documentation\/apollocodegenlib\/apollocodegenconfiguration\/conversionstrategies\/caseconversionstrategy\/camelcase"
+},
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/CodingKeys": {
   "abstract" : [
 
@@ -391,8 +444,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",
@@ -500,6 +554,34 @@
   "type" : "topic",
   "url" : "\/documentation\/apollocodegenlib\/apollocodegenconfiguration\/conversionstrategies\/fieldaccessors-swift.enum"
 },
+"doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/FieldAccessors-swift.enum/idiomatic": {
+  "abstract" : [
+    {
+      "text" : "This conversion strategy will:",
+      "type" : "text"
+    }
+  ],
+  "fragments" : [
+    {
+      "kind" : "keyword",
+      "text" : "case"
+    },
+    {
+      "kind" : "text",
+      "text" : " "
+    },
+    {
+      "kind" : "identifier",
+      "text" : "idiomatic"
+    }
+  ],
+  "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/FieldAccessors-swift.enum\/idiomatic",
+  "kind" : "symbol",
+  "role" : "symbol",
+  "title" : "ApolloCodegenConfiguration.ConversionStrategies.FieldAccessors.idiomatic",
+  "type" : "topic",
+  "url" : "\/documentation\/apollocodegenlib\/apollocodegenconfiguration\/conversionstrategies\/fieldaccessors-swift.enum\/idiomatic"
+},
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/enumCases-swift.property": {
   "abstract" : [
     {
@@ -519,12 +601,13 @@
       "type" : "text"
     },
     {
-      "text" : "Defaultss to ",
+      "text" : "Defaults to ",
       "type" : "text"
     },
     {
-      "code" : "ApolloCodegenConfiguration\/CaseConversionStrategy\/camelCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/CaseConversionStrategy\/camelCase",
+      "isActive" : true,
+      "type" : "reference"
     }
   ],
   "fragments" : [
@@ -598,8 +681,9 @@
       "type" : "text"
     },
     {
-      "code" : "ApolloCodegenConfiguration\/CaseConversionStrategy\/camelCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/FieldAccessors-swift.enum\/idiomatic",
+      "isActive" : true,
+      "type" : "reference"
     }
   ],
   "fragments" : [

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/caseconversionstrategy.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/caseconversionstrategy.json
@@ -22,7 +22,7 @@
     {
       "inlineContent" : [
         {
-          "text" : "Use EnumCaseConversionStrategy instead.",
+          "text" : "Use EnumCases instead.",
           "type" : "text"
         }
       ],

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/caseconversionstrategy/camelcase.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/caseconversionstrategy/camelcase.json
@@ -33,7 +33,7 @@
     {
       "inlineContent" : [
         {
-          "text" : "Use EnumCaseConversionStrategy instead.",
+          "text" : "Use EnumCases instead.",
           "type" : "text"
         }
       ],

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/caseconversionstrategy/init(rawvalue:).json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/caseconversionstrategy/init(rawvalue:).json
@@ -17,7 +17,7 @@
     {
       "inlineContent" : [
         {
-          "text" : "Use EnumCaseConversionStrategy instead.",
+          "text" : "Use EnumCases instead.",
           "type" : "text"
         }
       ],

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/caseconversionstrategy/none.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/caseconversionstrategy/none.json
@@ -17,7 +17,7 @@
     {
       "inlineContent" : [
         {
-          "text" : "Use EnumCaseConversionStrategy instead.",
+          "text" : "Use EnumCases instead.",
           "type" : "text"
         }
       ],

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/default/enumcases.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/default/enumcases.json
@@ -356,8 +356,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum.json
@@ -1,8 +1,9 @@
 {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",
@@ -274,8 +275,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/!=(_:_:).json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/!=(_:_:).json
@@ -298,8 +298,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/camelcase.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/camelcase.json
@@ -219,8 +219,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/encode(to:).json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/encode(to:).json
@@ -314,8 +314,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/equatable-implementations.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/equatable-implementations.json
@@ -152,8 +152,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/hash(into:).json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/hash(into:).json
@@ -322,8 +322,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/hashvalue.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/hashvalue.json
@@ -286,8 +286,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/init(from:).json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/init(from:).json
@@ -298,8 +298,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/init(rawvalue:).json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/init(rawvalue:).json
@@ -229,8 +229,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/none.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/none.json
@@ -203,8 +203,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/rawrepresentable-implementations.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.enum/rawrepresentable-implementations.json
@@ -167,8 +167,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.property.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/enumcases-swift.property.json
@@ -17,12 +17,13 @@
       "type" : "text"
     },
     {
-      "text" : "Defaultss to ",
+      "text" : "Defaults to ",
       "type" : "text"
     },
     {
-      "code" : "ApolloCodegenConfiguration\/CaseConversionStrategy\/camelCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/CaseConversionStrategy\/camelCase",
+      "isActive" : true,
+      "type" : "reference"
     }
   ],
   "hierarchy" : {
@@ -268,11 +269,65 @@
   "type" : "topic",
   "url" : "\/documentation\/apollocodegenlib\/apollocodegenconfiguration\/conversionstrategies"
 },
+"doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/CaseConversionStrategy/camelCase": {
+  "abstract" : [
+    {
+      "text" : "Convert to lower camel case from ",
+      "type" : "text"
+    },
+    {
+      "code" : "snake_case",
+      "type" : "codeVoice"
+    },
+    {
+      "text" : ", ",
+      "type" : "text"
+    },
+    {
+      "code" : "UpperCamelCase",
+      "type" : "codeVoice"
+    },
+    {
+      "text" : ", or ",
+      "type" : "text"
+    },
+    {
+      "code" : "UPPERCASE",
+      "type" : "codeVoice"
+    },
+    {
+      "text" : ".",
+      "type" : "text"
+    }
+  ],
+  "deprecated" : true,
+  "fragments" : [
+    {
+      "kind" : "keyword",
+      "text" : "case"
+    },
+    {
+      "kind" : "text",
+      "text" : " "
+    },
+    {
+      "kind" : "identifier",
+      "text" : "camelCase"
+    }
+  ],
+  "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/CaseConversionStrategy\/camelCase",
+  "kind" : "symbol",
+  "role" : "symbol",
+  "title" : "ApolloCodegenConfiguration.ConversionStrategies.CaseConversionStrategy.camelCase",
+  "type" : "topic",
+  "url" : "\/documentation\/apollocodegenlib\/apollocodegenconfiguration\/conversionstrategies\/caseconversionstrategy\/camelcase"
+},
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",
@@ -333,12 +388,13 @@
       "type" : "text"
     },
     {
-      "text" : "Defaultss to ",
+      "text" : "Defaults to ",
       "type" : "text"
     },
     {
-      "code" : "ApolloCodegenConfiguration\/CaseConversionStrategy\/camelCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/CaseConversionStrategy\/camelCase",
+      "isActive" : true,
+      "type" : "reference"
     }
   ],
   "fragments" : [

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/fieldaccessors-swift.property.json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/fieldaccessors-swift.property.json
@@ -21,8 +21,9 @@
       "type" : "text"
     },
     {
-      "code" : "ApolloCodegenConfiguration\/CaseConversionStrategy\/camelCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/FieldAccessors-swift.enum\/idiomatic",
+      "isActive" : true,
+      "type" : "reference"
     }
   ],
   "hierarchy" : {
@@ -323,6 +324,34 @@
   "type" : "topic",
   "url" : "\/documentation\/apollocodegenlib\/apollocodegenconfiguration\/conversionstrategies\/fieldaccessors-swift.enum"
 },
+"doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/FieldAccessors-swift.enum/idiomatic": {
+  "abstract" : [
+    {
+      "text" : "This conversion strategy will:",
+      "type" : "text"
+    }
+  ],
+  "fragments" : [
+    {
+      "kind" : "keyword",
+      "text" : "case"
+    },
+    {
+      "kind" : "text",
+      "text" : " "
+    },
+    {
+      "kind" : "identifier",
+      "text" : "idiomatic"
+    }
+  ],
+  "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/FieldAccessors-swift.enum\/idiomatic",
+  "kind" : "symbol",
+  "role" : "symbol",
+  "title" : "ApolloCodegenConfiguration.ConversionStrategies.FieldAccessors.idiomatic",
+  "type" : "topic",
+  "url" : "\/documentation\/apollocodegenlib\/apollocodegenconfiguration\/conversionstrategies\/fieldaccessors-swift.enum\/idiomatic"
+},
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/fieldAccessors-swift.property": {
   "abstract" : [
     {
@@ -346,8 +375,9 @@
       "type" : "text"
     },
     {
-      "code" : "ApolloCodegenConfiguration\/CaseConversionStrategy\/camelCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/FieldAccessors-swift.enum\/idiomatic",
+      "isActive" : true,
+      "type" : "reference"
     }
   ],
   "fragments" : [

--- a/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/init(enumcases:fieldaccessors:).json
+++ b/docs/docc/Apollo.doccarchive/data/documentation/apollocodegenlib/apollocodegenconfiguration/conversionstrategies/init(enumcases:fieldaccessors:).json
@@ -326,8 +326,9 @@
 "doc://ApolloCodegenLib/documentation/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies/EnumCases-swift.enum": {
   "abstract" : [
     {
-      "code" : "ApolloCodegenConfiguration\/ConversionStrategies\/EnumCase",
-      "type" : "codeVoice"
+      "identifier" : "doc:\/\/ApolloCodegenLib\/documentation\/ApolloCodegenLib\/ApolloCodegenConfiguration\/ConversionStrategies\/EnumCases-swift.enum",
+      "isActive" : true,
+      "type" : "reference"
     },
     {
       "text" : " is used to specify the strategy",


### PR DESCRIPTION
ApolloCodegenConfiguration's documentation had invalid references, which was causing the GenerateDocumentation command to fail.

```
[DEBUG - ApolloCodegenLib:main.swift:77] - Generating documentation for 'ApolloCodegenLib'...
Converting documentation...
/Users/t201595/src/apollo-ios-dev/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift:672:59: warning: 'EnumCase' doesn't exist at '/ApolloCodegenLib/ApolloCodegenConfiguration/ConversionStrategies'
/Users/t201595/src/apollo-ios-dev/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift:698:51: warning: 'CaseConversionStrategy' doesn't exist at '/ApolloCodegenLib/ApolloCodegenConfiguration'
/Users/t201595/src/apollo-ios-dev/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift:703:50: warning: 'CaseConversionStrategy' doesn't exist at '/ApolloCodegenLib/ApolloCodegenConfiguration'
Conversion complete! (0.29s)
Generated DocC archive at '/Users/t201595/src/apollo-ios-dev/docs/docc/ApolloCodegenLib.doccarchive'
```

The header docs were pointing to EnumCase and were missing an additional path component. This fixes those invalid references and re-generates the documentation.

Current state:
<img width="726" alt="Screenshot 2023-11-07 at 13 59 08" src="https://github.com/apollographql/apollo-ios-dev/assets/32947659/5e26118e-f418-4e9c-a344-bdaf48a71c02">
<img width="744" alt="Screenshot 2023-11-07 at 13 59 35" src="https://github.com/apollographql/apollo-ios-dev/assets/32947659/fe31097b-f923-48b2-b607-b952bf7cbaad">

Updated:
<img width="730" alt="Screenshot 2023-11-07 at 14 00 11" src="https://github.com/apollographql/apollo-ios-dev/assets/32947659/086bdc44-f1d6-4b94-a454-3c916a3aeca6">
<img width="742" alt="Screenshot 2023-11-07 at 14 00 07" src="https://github.com/apollographql/apollo-ios-dev/assets/32947659/fc60a23d-067f-4660-a4af-049c552478c4">
