### PR TITLE
refactor: Multipart parsers

### DIFF
--- a/Tests/ApolloTests/Interceptors/MultipartResponseDeferParserTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseDeferParserTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+import Nimble
+@testable import Apollo
+import ApolloAPI
+import ApolloInternalTestHelpers
+
+final class MultipartResponseDeferParserTests: XCTestCase {
+
+  let defaultTimeout = 0.5
+
+  // MARK: - Error tests
+
+  func test__error__givenChunk_withIncorrectContentType_shouldReturnError() throws {
+    let subject = InterceptorTester(interceptor: MultipartResponseParsingInterceptor())
+
+    let expectation = expectation(description: "Received callback")
+
+    subject.intercept(
+      request: .mock(operation: MockQuery.mock()),
+      response: .mock(
+        headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;deferSpec=20220824"],
+        data: """
+          --graphql
+          content-type: test/custom
+
+          {
+            "data" : {Ï
+              "key" : "value"
+            }
+          }
+          --graphql
+          """.crlfFormattedData()
+      )
+    ) { result in
+      defer {
+        expectation.fulfill()
+      }
+
+      expect(result).to(beFailure { error in
+        expect(error).to(
+          matchError(MultipartResponseDeferParser.ParsingError.unsupportedContentType(type: "test/custom"))
+        )
+      })
+    }
+
+    wait(for: [expectation], timeout: defaultTimeout)
+  }
+
+  func test__error__givenUnrecognizableChunk_shouldReturnError() throws {
+    let subject = InterceptorTester(interceptor: MultipartResponseParsingInterceptor())
+
+    let expectation = expectation(description: "Received callback")
+
+    subject.intercept(
+      request: .mock(operation: MockQuery.mock()),
+      response: .mock(
+        headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;deferSpec=20220824"],
+        data: """
+          --graphql
+          content-type: application/json
+
+          not_a_valid_json_object
+          --graphql
+          """.crlfFormattedData()
+      )
+    ) { result in
+      defer {
+        expectation.fulfill()
+      }
+
+      expect(result).to(beFailure { error in
+        expect(error).to(
+          matchError(MultipartResponseDeferParser.ParsingError.cannotParseChunkData)
+        )
+      })
+    }
+
+    wait(for: [expectation], timeout: defaultTimeout)
+  }
+
+  func test__error__givenChunk_withMissingPayload_shouldReturnError() throws {
+    let subject = InterceptorTester(interceptor: MultipartResponseParsingInterceptor())
+
+    let expectation = expectation(description: "Received callback")
+
+    subject.intercept(
+      request: .mock(operation: MockQuery.mock()),
+      response: .mock(
+        headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;deferSpec=20220824"],
+        data: """
+          --graphql
+          content-type: application/json
+
+          {
+            "key": "value"
+          }
+          --graphql
+          """.crlfFormattedData()
+      )
+    ) { result in
+      defer {
+        expectation.fulfill()
+      }
+
+      expect(result).to(beFailure { error in
+        expect(error).to(
+          matchError(MultipartResponseDeferParser.ParsingError.cannotParsePayloadData)
+        )
+      })
+    }
+
+    wait(for: [expectation], timeout: defaultTimeout)
+  }
+
+  // MARK: Parsing tests
+
+  #warning("Need parsing tests - to be done after #3147")
+}

--- a/Tests/ApolloTests/Interceptors/MultipartResponseParsingInterceptorTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseParsingInterceptorTests.swift
@@ -98,4 +98,30 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
 
     wait(for: [expectation], timeout: defaultTimeout)
   }
+
+  func test__error__givenResponse_withInvalidData_shouldReturnError() throws {
+    let subject = InterceptorTester(interceptor: MultipartResponseParsingInterceptor())
+
+    let expectation = expectation(description: "Received callback")
+
+    subject.intercept(
+      request: .mock(operation: MockSubscription.mock()),
+      response: .mock(
+        headerFields: ["Content-Type": "multipart/mixed;boundary=\"graphql\";deferSpec=20220824"],
+        data: "🙃".data(using: .unicode)!
+      )
+    ) { result in
+      defer {
+        expectation.fulfill()
+      }
+
+      expect(result).to(beFailure { error in
+        expect(error).to(
+          matchError(MultipartResponseParsingInterceptor.ParsingError.cannotParseResponseData)
+        )
+      })
+    }
+
+    wait(for: [expectation], timeout: defaultTimeout)
+  }
 }

--- a/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
@@ -4,7 +4,7 @@ import Nimble
 import ApolloAPI
 import ApolloInternalTestHelpers
 
-final class MultipartResponseSubscriptionTests: XCTestCase {
+final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   let defaultTimeout = 0.5
 

--- a/apollo-ios/Sources/Apollo/MultipartResponseDeferParser.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseDeferParser.swift
@@ -4,14 +4,111 @@ import ApolloAPI
 #endif
 
 struct MultipartResponseDeferParser: MultipartResponseSpecificationParser {
+  public enum ParsingError: Swift.Error, LocalizedError, Equatable {
+    case unsupportedContentType(type: String)
+    case cannotParseChunkData
+    case cannotParsePayloadData
+
+    public var errorDescription: String? {
+      switch self {
+
+      case let .unsupportedContentType(type):
+        return "Unsupported content type: application/json is required but got \(type)."
+      case .cannotParseChunkData:
+        return "The chunk data could not be parsed."
+      case .cannotParsePayloadData:
+        return "The payload data could not be parsed."
+      }
+    }
+  }
+
+  private enum DataLine {
+    case contentHeader(type: String)
+    case json(object: JSONObject)
+    case unknown
+
+    init(_ value: String) {
+      self = Self.parse(value)
+    }
+
+    private static func parse(_ dataLine: String) -> DataLine {
+      var contentTypeHeader: StaticString { "content-type:" }
+
+      if dataLine.starts(with: contentTypeHeader.description) {
+        let contentType = (dataLine
+          .components(separatedBy: ":").last ?? dataLine
+        ).trimmingCharacters(in: .whitespaces)
+
+        return .contentHeader(type: contentType)
+      }
+
+      if
+        let data = dataLine.data(using: .utf8),
+        let jsonObject = try? JSONSerializationFormat.deserialize(data: data) as? JSONObject
+      {
+        return .json(object: jsonObject)
+      }
+
+      return .unknown
+    }
+  }
+
   static let protocolSpec: String = "deferSpec=20220824"
 
-  static func parse(
-    data: Data,
-    boundary: String,
-    dataHandler: ((Data) -> Void),
-    errorHandler: ((Error) -> Void)
-  ) {
-    // TODO: Will be implemented in #3146
+  static func parse(_ chunk: String) -> Result<Data?, Error> {
+    for dataLine in chunk.components(separatedBy: Self.dataLineSeparator.description) {
+      switch DataLine(dataLine.trimmingCharacters(in: .newlines)) {
+      case let .contentHeader(type):
+        guard type == "application/json" else {
+          return .failure(ParsingError.unsupportedContentType(type: type))
+        }
+
+      case let .json(object):
+        if let hasNext = object.hasNext {
+          preconditionFailure("This will be done in #3147")
+        }
+
+        if let incremental = object.incremental {
+          preconditionFailure("This will be done in #3147")
+
+        } else {
+          guard
+            let _ = object.data,
+            let serialized: Data = try? JSONSerializationFormat.serialize(value: object)
+          else {
+            return .failure(ParsingError.cannotParsePayloadData)
+          }
+
+          return .success(serialized)
+        }
+
+      case .unknown:
+        return .failure(ParsingError.cannotParseChunkData)
+      }
+    }
+
+    return .success(nil)
+  }
+}
+
+fileprivate extension JSONObject {
+  var label: String? {
+    self["label"] as? String
+  }
+
+  var path: [String]? {
+    self["path"] as? [String]
+  }
+
+  var hasNext: Bool? {
+    self["hasNext"] as? Bool
+  }
+
+  var data: JSONObject? {
+    self["data"] as? JSONObject
+  }
+
+  var incremental: [JSONObject]? {
+    self["incremental"] as? [JSONObject]
   }
 }

--- a/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -126,7 +126,13 @@ protocol MultipartResponseSpecificationParser {
   /// in an HTTP response.
   static var protocolSpec: String { get }
 
-  /// Function called to process each data line of the chunked response.
+  /// Called to process each chunk in a multipart response.
+  ///
+  /// The return value is a `Result` type that indicates whether the chunk was successfully parsed
+  /// or not. It is possible to return `.success` with a `nil` data value. This should only happen
+  /// when the chunk was successfully parsed but there is no action to take on the message, such as
+  /// a heartbeat message. Successful results with a `nil` data value will not be returned to the
+  /// user.
   static func parse(_ chunk: String) -> Result<Data?, Error>
 }
 

--- a/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -24,7 +24,8 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
   }
 
   private static let responseParsers: [String: MultipartResponseSpecificationParser.Type] = [
-    MultipartResponseSubscriptionParser.protocolSpec: MultipartResponseSubscriptionParser.self
+    MultipartResponseSubscriptionParser.protocolSpec: MultipartResponseSubscriptionParser.self,
+    MultipartResponseDeferParser.protocolSpec: MultipartResponseDeferParser.self,
   ]
 
   public var id: String = UUID().uuidString


### PR DESCRIPTION
This refactors the multipart response parsers so that each can be built to focus on just their parser data specification logic and common shared logic to process the general multipart response format.
* `MultipartResponseParsingInterceptor` now handles the mechanics of the multipart message chunk parsing.
* `MultipartResponseSpecificationParser` now just requires each specification parser to handle the logic for parsing each data line for a single specification.

_This only includes error based-tests for `MultipartResponseDeferParser` because the executor is not complete. Only once the executor is able to handle deferred fragments will the parsing based-tests be able to succeed._ 