### PR TITLE
refactor: HTTP `Accept` header

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -43,16 +43,6 @@ open class MockSubscription<SelectionSet: RootSelectionSet>: MockOperation<Selec
   }
 }
 
-open class MockDeferredQuery<SelectionSet: RootSelectionSet>: MockOperation<SelectionSet>, GraphQLQuery {
-
-  public override class var operationType: GraphQLOperationType { .query }
-  public override class var hasDeferredFragments: Bool { true }
-
-  public static func mock() -> MockDeferredQuery<MockSelectionSet> where SelectionSet == MockSelectionSet {
-    MockDeferredQuery<MockSelectionSet>()
-  }
-}
-
 // MARK: - MockSelectionSets
 
 @dynamicMemberLookup

--- a/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -105,9 +105,8 @@ open class RequestChainNetworkTransport: NetworkTransport {
         name: "Accept",
         value: "multipart/mixed;boundary=\"graphql\";\(MultipartResponseSubscriptionParser.protocolSpec),application/json"
       )
-    }
 
-    if Operation.hasDeferredFragments {
+    } else {
       request.addHeader(
         name: "Accept",
         value: "multipart/mixed;boundary=\"graphql\";\(MultipartResponseDeferParser.protocolSpec),application/json"


### PR DESCRIPTION
This change is to standardize on the HTTP `accept` header being sent by Apollo iOS and Kotlin clients.

The difference is that the `multipart/mixed` and `application/json` accept types will be included with every query and mutation operation to simplify the request generation and since the response parsing can handle both. This is related to https://github.com/apollographql/apollo-ios/issues/3277.