### PR TITLE
Adding fetch to subtree job

### DIFF
--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -65,4 +65,5 @@ jobs:
       if: always()
       shell: bash
       run: |
+        git fetch
         git push


### PR DESCRIPTION
Adding a fetch before pushing subtree split commits to main to help avoid potential conflicts when pushing.