### PR TITLE
Adjusting codegen config test usage

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -191,8 +191,6 @@ jobs:
 
   run-codegen-test-configurations:
     runs-on: macos-13
-    needs: [changes]
-    if: ${{ needs.changes.outputs.codegen  == 'true' }}
     timeout-minutes: 20
     name: Codegen Test Configurations - macOS
     steps:


### PR DESCRIPTION
Changing codegen config tests to run with every PR.

Closes apollographql/apollo-ios#3295