### PR TITLE
[codegen] add additionalImportedModulesNames to apollo codegen config

### DIFF
--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -986,7 +986,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   ///  - experimentalFeatures: Allows users to enable experimental features.
   public init(
     schemaNamespace: String,
-    additionalImportedModuleNamespaces: [String] = [],
+    additionalImportedModuleNames: [String] = [],
     input: FileInput,
     output: FileOutput,
     options: OutputOptions = Default.options,
@@ -995,7 +995,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     operationManifest: OperationManifestConfiguration? = Default.operationManifest
   ) {
     self.schemaNamespace = schemaNamespace
-    self.additionalImportedModuleNamespaces = additionalImportedModuleNamespaces
+    self.additionalImportedModuleNames = additionalImportedModuleNames
     self.input = input
     self.output = output
     self.options = options

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -945,6 +945,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
   /// Name used to scope the generated schema type files.
   public let schemaNamespace: String
+  /// Names used to add additional scopes to the generated schema type files.
+  public let additionalImportedModuleNamespaces: [String]
   /// The input files required for code generation.
   public let input: FileInput
   /// The paths and files output by code generation.
@@ -984,6 +986,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   ///  - experimentalFeatures: Allows users to enable experimental features.
   public init(
     schemaNamespace: String,
+    additionalImportedModuleNamespaces: [String] = [],
     input: FileInput,
     output: FileOutput,
     options: OutputOptions = Default.options,
@@ -992,6 +995,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     operationManifest: OperationManifestConfiguration? = Default.operationManifest
   ) {
     self.schemaNamespace = schemaNamespace
+    self.additionalImportedModuleNamespaces = additionalImportedModuleNamespaces
     self.input = input
     self.output = output
     self.options = options

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -986,7 +986,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   ///  - experimentalFeatures: Allows users to enable experimental features.
   public init(
     schemaNamespace: String,
-    additionalImportedModuleNames: [String] = [],
+    additionalImportedModulesNames: [String] = [],
     input: FileInput,
     output: FileOutput,
     options: OutputOptions = Default.options,
@@ -995,7 +995,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     operationManifest: OperationManifestConfiguration? = Default.operationManifest
   ) {
     self.schemaNamespace = schemaNamespace
-    self.additionalImportedModuleNames = additionalImportedModuleNames
+    self.additionalImportedModulesNames = additionalImportedModulesNames
     self.input = input
     self.output = output
     self.options = options

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -946,7 +946,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   /// Name used to scope the generated schema type files.
   public let schemaNamespace: String
   /// Names used to add additional scopes to the generated schema type files.
-  public let additionalImportedModuleNamespaces: [String]
+  public let additionalImportedModulesNames: [String]
   /// The input files required for code generation.
   public let input: FileInput
   /// The paths and files output by code generation.

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -311,10 +311,4 @@ fileprivate extension ApolloCodegenConfiguration {
     case .swiftPackageManager, .other: return schemaNamespace.firstUppercased
     }
   }
-  var additionalImportedModulesNames: [String] {
-    switch output.schemaTypes.moduleType {
-    case .embeddedInTarget: return []
-    case .swiftPackageManager, .other: return additionalImportedModuleNamespaces.map { $0.firstUppercased }
-    }
-  }
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -287,6 +287,9 @@ struct ImportStatementTemplate {
       return """
       @_exported import \(apolloAPITargetName)
       \(if: config.output.operations != .inSchemaModule, "import \(config.schemaModuleName)")
+      \(forEachIn: config.additionalImportedModulesNames, {
+        return "import \($0)"
+      })
       """
     }
   }
@@ -306,6 +309,12 @@ fileprivate extension ApolloCodegenConfiguration {
     switch output.schemaTypes.moduleType {
     case let .embeddedInTarget(targetName, _): return targetName
     case .swiftPackageManager, .other: return schemaNamespace.firstUppercased
+    }
+  }
+  var additionalImportedModulesNames: [String] {
+    switch output.schemaTypes.moduleType {
+    case .embeddedInTarget: return []
+    case .swiftPackageManager, .other: return additionalImportedModuleNamespaces.map { $0.firstUppercased }
     }
   }
 }


### PR DESCRIPTION
The purpose of this change is to give codegen the capability to add custom import statements to generated operations.
This change would enable the consumer to share fragments across generated packages.

Addresses this thread:

https://github.com/apollographql/apollo-ios/issues/3284