### PR TITLE
Make ApolloInterceptor id requirement read-only

### DIFF
--- a/apollo-ios/Sources/Apollo/ApolloInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/ApolloInterceptor.swift
@@ -10,7 +10,7 @@ public protocol ApolloInterceptor {
   /// Each operation request has it's own interceptor request chain so the interceptors do not
   /// need to be uniquely identifiable between each and every request, only unique between the
   /// list of interceptors in a single request.
-  var id: String { get set }
+  var id: String { get }
   
   /// Called when this interceptor should do its work.
   ///


### PR DESCRIPTION
As far as I understand, there is no real need for interceptors' ids to be mutable, at least not by the library itself. I decided to leave ids as `var` in all default interceptors though as they're randomly generated and maybe someone has a need to change them to something more descriptive. 