### PR TITLE
chore(deps): Renovate dependency updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  secops: apollo/circleci-secops-orb@2.0.2
+  secops: apollo/circleci-secops-orb@2.0.3
 
 workflows:
   security-scans:

--- a/apollo-ios-codegen/.circleci/config.yml
+++ b/apollo-ios-codegen/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  secops: apollo/circleci-secops-orb@2.0.2
+  secops: apollo/circleci-secops-orb@2.0.3
 
 workflows:
   security-scans:

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package.json
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "15.2.3",
     "@rollup/plugin-replace": "5.0.5",
-    "@rollup/plugin-typescript": "8.5.0",
+    "@rollup/plugin-typescript": "11.1.5",
     "@types/common-tags": "1.8.4",
     "@types/jest": "26.0.24",
     "common-tags": "1.8.2",

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package.json
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "15.2.3",
-    "@rollup/plugin-replace": "2.4.2",
+    "@rollup/plugin-replace": "5.0.5",
     "@rollup/plugin-typescript": "8.5.0",
     "@types/common-tags": "1.8.4",
     "@types/jest": "26.0.24",

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package.json
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package.json
@@ -17,7 +17,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "11.2.1",
+    "@rollup/plugin-node-resolve": "15.2.3",
     "@rollup/plugin-replace": "2.4.2",
     "@rollup/plugin-typescript": "8.5.0",
     "@types/common-tags": "1.8.4",

--- a/apollo-ios/.circleci/config.yml
+++ b/apollo-ios/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  secops: apollo/circleci-secops-orb@2.0.2
+  secops: apollo/circleci-secops-orb@2.0.3
 
 workflows:
   security-scans:

--- a/docs/renderer/package.json
+++ b/docs/renderer/package.json
@@ -36,7 +36,7 @@
     "@vue/cli-service": "4.5.19",
     "@vue/eslint-config-airbnb": "5.3.0",
     "@vue/test-utils": "1.3.6",
-    "babel-eslint": "10.1.0",
+    "@babel/eslint-parser": "7.11.0",
     "eslint": "6.8.0",
     "eslint-plugin-import": "2.29.0",
     "eslint-plugin-vue": "7.20.0",

--- a/docs/renderer/package.json
+++ b/docs/renderer/package.json
@@ -37,7 +37,7 @@
     "@vue/eslint-config-airbnb": "7.0.0",
     "@vue/test-utils": "2.4.2",
     "@babel/eslint-parser": "7.11.0",
-    "eslint": "6.8.0",
+    "eslint": "8.54.0",
     "eslint-plugin-import": "2.29.0",
     "eslint-plugin-vue": "7.20.0",
     "html-loader": "1.3.2",

--- a/docs/renderer/package.json
+++ b/docs/renderer/package.json
@@ -43,12 +43,12 @@
     "html-loader": "1.3.2",
     "node-sass": "7.0.3",
     "sass-loader": "10.4.1",
-    "vue": "2.6.14",
+    "vue": "2.7.15",
     "vue-router": "3.6.5",
-    "vue-template-compiler": "2.6.14"
+    "vue-template-compiler": "2.7.15"
   },
   "peerDependencies": {
-    "vue": "2.6.12",
+    "vue": "2.7.15",
     "vue-router": "^3.4.9"
   },
   "engines": {

--- a/docs/renderer/package.json
+++ b/docs/renderer/package.json
@@ -34,7 +34,7 @@
     "@vue/cli-plugin-eslint": "4.5.19",
     "@vue/cli-plugin-unit-jest": "4.5.19",
     "@vue/cli-service": "4.5.19",
-    "@vue/eslint-config-airbnb": "5.3.0",
+    "@vue/eslint-config-airbnb": "7.0.0",
     "@vue/test-utils": "1.3.6",
     "@babel/eslint-parser": "7.11.0",
     "eslint": "6.8.0",

--- a/docs/renderer/package.json
+++ b/docs/renderer/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-import": "2.29.0",
     "eslint-plugin-vue": "7.20.0",
     "html-loader": "1.3.2",
-    "node-sass": "7.0.0",
+    "node-sass": "7.0.3",
     "sass-loader": "10.4.1",
     "vue": "2.6.14",
     "vue-router": "3.6.5",

--- a/docs/renderer/package.json
+++ b/docs/renderer/package.json
@@ -35,7 +35,7 @@
     "@vue/cli-plugin-unit-jest": "4.5.19",
     "@vue/cli-service": "4.5.19",
     "@vue/eslint-config-airbnb": "7.0.0",
-    "@vue/test-utils": "1.3.6",
+    "@vue/test-utils": "2.4.2",
     "@babel/eslint-parser": "7.11.0",
     "eslint": "6.8.0",
     "eslint-plugin-import": "2.29.0",


### PR DESCRIPTION
This is a collection of the following dependency update PRs to avoid multiple subtree push/pulls and having to update each dependency PR once `main` is updated due to the merge rules.
* https://github.com/apollographql/apollo-ios-dev/pull/160
* https://github.com/apollographql/apollo-ios-dev/pull/161
* https://github.com/apollographql/apollo-ios-dev/pull/162
* https://github.com/apollographql/apollo-ios-dev/pull/163
* https://github.com/apollographql/apollo-ios-dev/pull/164
* https://github.com/apollographql/apollo-ios-dev/pull/165
* https://github.com/apollographql/apollo-ios-dev/pull/166
* https://github.com/apollographql/apollo-ios-dev/pull/167
* https://github.com/apollographql/apollo-ios-dev/pull/168
* https://github.com/apollographql/apollo-ios-dev/pull/169