### PR TITLE
ci: Adds frontend bundle validation job

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -207,6 +207,31 @@ jobs:
       shell: bash
       run: |
         ./scripts/run-test-codegen-configurations.sh -t
+  
+  verify-frontend-bundle-latest:
+    runs-on: macos-13
+    needs: [changes]
+    if: ${{ needs.changes.outputs.codegen  == 'true' }}
+    timeout-minutes: 5
+    name: Verify Frontend Bundle Latest - macOS
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Install Node packages
+      shell: bash
+      working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript
+      run: |
+        npm install
+    - name: Rollup Bundle
+      shell: bash
+      working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript
+      run: |
+        npm install --global rollup
+        sh ./auto_rollup.sh
+    - name: Verify Latest
+      shell: bash
+      run: |
+        git diff --exit-code
 
   run-cocoapods-integration-tests:
     runs-on: macos-13

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/auto_rollup.sh
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/auto_rollup.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 output_file="$SCRIPT_DIR/../ApolloCodegenFrontendBundle.swift"
-$( cd "$SCRIPT_DIR" && rollup -c )
+$( cd "$SCRIPT_DIR" && rollup -c --bundleConfigAsCjs )
 minJS=$(cat "$SCRIPT_DIR/dist/ApolloCodegenFrontend.bundle.js")
 printf "%s%s%s" "let ApolloCodegenFrontendBundle: String = #\"" "$minJS" "\"#" > $output_file
 exit 0


### PR DESCRIPTION
With dependency updates being automated and having a few to deal with lately it's easy to miss something in the JS bundle, aka.  GraphQLCompiler; especially since it is a manual process to build and compile the changes into Swift.

This PR adds a bundle validation step that will install all the requisite node packages, build the bundle and then fail if there is a git diff which would indicate that there are changes we haven't included that should be.