### PR TITLE
tests: TestCodegenConfigurations projects should fail on warnings

### DIFF
--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Package.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Package.swift
@@ -23,9 +23,6 @@ let package = Package(
       name: "TestApp",
       dependencies: [
         .product(name: "ApolloAPI", package: "apollo-ios")
-      ],
-      swiftSettings: [
-        .unsafeFlags(["-warnings-as-errors"])
       ]),
     .testTarget(
       name: "TestAppTests",

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/test-project.sh
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/test-project.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-swift test
+swift test -Xswiftc -warnings-as-errors

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Package.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Package.swift
@@ -45,9 +45,6 @@ let package = Package(
         "graphql/PetDetails.graphql",
         "graphql/AllAnimalsIncludeSkipQuery.graphql",
         "graphql/PetAdoptionMutation.graphql"
-      ],
-      swiftSettings: [
-        .unsafeFlags(["-warnings-as-errors"])
       ]),
     .testTarget(
       name: "PackageOneTests",

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageTwo/Package.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageTwo/Package.swift
@@ -22,9 +22,6 @@ let package = Package(
       name: "PackageTwo",
       dependencies: [
         .product(name: "ApolloAPI", package: "apollo-ios"),
-      ],
-      swiftSettings: [
-        .unsafeFlags(["-warnings-as-errors"])
       ]),
     .target(
       name: "TestMocks",

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/test-project.sh
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/test-project.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -e
 
 echo "Testing PackageOne.."
 cd PackageOne
-swift test
+swift test -Xswiftc -warnings-as-errors
 
 echo "Testing PackageTwo.."
 cd ../PackageTwo
-swift test
+swift test -Xswiftc -warnings-as-errors

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Package.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Package.swift
@@ -23,9 +23,6 @@ let package = Package(
       dependencies: [
         .product(name: "Apollo", package: "apollo-ios"),
         .product(name: "AnimalKingdomAPI", package: "AnimalKingdomAPI")
-      ],
-      swiftSettings: [
-        .unsafeFlags(["-warnings-as-errors"])
       ]
     ),
     .testTarget(

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/test-project.sh
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/test-project.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-swift test
+swift test -Xswiftc -warnings-as-errors

--- a/apollo-ios/Sources/ApolloAPI/DataDict.swift
+++ b/apollo-ios/Sources/ApolloAPI/DataDict.swift
@@ -48,7 +48,6 @@ public struct DataDict: Hashable {
     _storage.deferredFragments
   }
 
-  #warning("TODO, remove deferredFragments default value when we set these up in executor")
   public init(
     data: [String: AnyHashable],
     fulfilledFragments: Set<ObjectIdentifier>,


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3301.

I don't know when this stopped working in our test configuration projects but this behaviour is essential to avoid exposing inconvenience warnings to users projects.

I can't find any mention of why the `unsafeFlags` configuration no longer works but I do prefer that the flag is now set on the test script command which is more explicit to the workflow we want for the test - [reference](https://forums.swift.org/t/warnings-as-errors-for-libraries-frameworks/58393).

_I haven't managed to get the behaviour back for Xcode-based projects yet though._