### PR TITLE
Add session and task descriptions

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockURLSession.swift
+++ b/Tests/ApolloInternalTestHelpers/MockURLSession.swift
@@ -28,6 +28,7 @@ public final class MockURLSessionClient: URLSessionClient {
   }
 
   public override func sendRequest(_ request: URLRequest,
+                                   taskDescription: String? = nil,
                                    rawTaskCompletionHandler: URLSessionClient.RawCompletion? = nil,
                                    completion: @escaping URLSessionClient.Completion) -> URLSessionTask {
     self.$lastRequest.mutate { $0 = request }

--- a/Tests/ApolloTests/Network/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/Network/URLSessionClientTests.swift
@@ -303,6 +303,39 @@ class URLSessionClientTests: XCTestCase {
       
     client2.invalidate()
   }
+    
+  func testTaskDescription() {
+    let url = URL(string: "http://www.test.com/taskDesciption")!
+    
+    let request = request(for: url,
+                          responseData: nil,
+                          statusCode: -1)
+
+    let expectation = self.expectation(description: "Described task completed")
+    expectation.isInverted = true
+    
+    let task = self.client.sendRequest(request) { result in
+      // This shouldn't get hit since we cancel the task immediately
+      expectation.fulfill()
+    }
+    self.client.cancel(task: task)
+    
+    // Should be nil by default.
+    XCTAssertNil(task.taskDescription)
+    
+    let expected = "test task description"
+    let describedTask = self.client.sendRequest(request,
+                                                taskDescription: expected) { result in
+      // This shouldn't get hit since we cancel the task immediately
+      expectation.fulfill()
+    }
+    self.client.cancel(task: describedTask)
+    
+    // The returned task should have the provided taskDescription.
+    XCTAssertEqual(expected, describedTask.taskDescription)
+
+    self.wait(for: [expectation], timeout: 5)
+  }
 }
 
 extension URLSessionClientTests: MockRequestProvider {

--- a/Tests/ApolloTests/Network/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/Network/URLSessionClientTests.swift
@@ -291,6 +291,18 @@ class URLSessionClientTests: XCTestCase {
     self.wait(for: [expectation], timeout: 5)
   }
   
+  func testSessionDescription() {
+    // Should be nil by default.
+    XCTAssertNil(client.session.sessionDescription)
+            
+    // Should set the sessionDescription of the URLSession.
+    let expected = "test description"
+    let client2 = URLSessionClient(sessionConfiguration: sessionConfiguration,
+                                   sessionDescription: expected)
+    XCTAssertEqual(expected, client2.session.sessionDescription)
+      
+    client2.invalidate()
+  }
 }
 
 extension URLSessionClientTests: MockRequestProvider {

--- a/apollo-ios/Sources/Apollo/URLSessionClient.swift
+++ b/apollo-ios/Sources/Apollo/URLSessionClient.swift
@@ -117,12 +117,14 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// - Parameters:
   ///   - request: The request to perform.
+  ///   - taskDescription: [optional] A description to add to the `URLSessionTask` for debugging purposes.
   ///   - rawTaskCompletionHandler: [optional] A completion handler to call once the raw task is done, so if an Error requires access to the headers, the user can still access these.
   ///   - completion: A completion handler to call when the task has either completed successfully or failed.
   ///
   /// - Returns: The created URLSession task, already resumed, because nobody ever remembers to call `resume()`.
   @discardableResult
   open func sendRequest(_ request: URLRequest,
+                        taskDescription: String? = nil,
                         rawTaskCompletionHandler: RawCompletion? = nil,
                         completion: @escaping Completion) -> URLSessionTask {
     guard self.hasNotBeenInvalidated else {
@@ -131,6 +133,8 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     }
     
     let task = self.session.dataTask(with: request)
+    task.taskDescription = taskDescription
+      
     let taskData = TaskData(rawCompletion: rawTaskCompletionHandler,
                             completionBlock: completion)
     

--- a/apollo-ios/Sources/Apollo/URLSessionClient.swift
+++ b/apollo-ios/Sources/Apollo/URLSessionClient.swift
@@ -61,12 +61,17 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   /// - Parameters:
   ///   - sessionConfiguration: The `URLSessionConfiguration` to use to set up the URL session.
   ///   - callbackQueue: [optional] The `OperationQueue` to tell the URL session to call back to this class on, which will in turn call back to your class. Defaults to `.main`.
+  ///   - sessionDescription: [optional] A human-readable string that you can use for debugging purposes.
   public init(sessionConfiguration: URLSessionConfiguration = .default,
-              callbackQueue: OperationQueue? = .main) {
+              callbackQueue: OperationQueue? = .main,
+              sessionDescription: String? = nil) {
     super.init()
-    self.session = URLSession(configuration: sessionConfiguration,
-                              delegate: self,
-                              delegateQueue: callbackQueue)
+      
+    let session = URLSession(configuration: sessionConfiguration, 
+                             delegate: self,
+                             delegateQueue: callbackQueue)
+    session.sessionDescription = sessionDescription
+    self.session = session
   }
   
   /// Cleans up and invalidates everything related to this session client.


### PR DESCRIPTION
This pull request updates the Apollo `URLSessionClient` adding the ability to optionally provide a session description and/or task description to the `URLSession`, and any subsequent `URLSessionTask`'s created by the session.

These are helpful when debugging, especially when [analyzing HTTP traffic with Instruments](https://developer.apple.com/documentation/foundation/url_loading_system/analyzing_http_traffic_with_instruments).

See also:

- [sessionDescription](https://developer.apple.com/documentation/foundation/urlsession/1408277-sessiondescription)
- [taskDescription](https://developer.apple.com/documentation/foundation/urlsessiontask/1409798-taskdescription)