### PR TITLE
[Codegen] Fix retain cycle between Entity and TypeInfo

### DIFF
--- a/Tests/ApolloCodegenInternalTestHelpers/IRBuilder+Mocking.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/IRBuilder+Mocking.swift
@@ -100,11 +100,12 @@ extension IR.Operation {
     containsDeferredFragment: Bool = false
   ) -> IR.Operation {
     let definition = definition ?? .mock()
+    let entity = IR.Entity(
+      location: .init(source: .operation(definition), fieldPath: nil),
+      rootTypePath: [.mock()]
+    )
     let typeInfo = SelectionSet.TypeInfo(
-      entity: .init(
-        location: .init(source: .operation(definition), fieldPath: nil),
-        rootTypePath: [.mock()]
-      ),
+      entity: entity,
       scopePath: [.descriptor(
         forType: .mock(),
         inclusionConditions: nil,
@@ -123,7 +124,7 @@ extension IR.Operation {
       definition: definition,
       rootField: rootField,
       referencedFragments: referencedFragments,
-      entityStorage: .init(rootEntity: rootField.entity),
+      entityStorage: .init(rootEntity: entity),
       containsDeferredFragment: containsDeferredFragment
     )
   }

--- a/apollo-ios-codegen/Sources/IR/IR+SelectionSet.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+SelectionSet.swift
@@ -8,7 +8,7 @@ public class SelectionSet: Hashable, CustomDebugStringConvertible {
     /// The entity that the `selections` are being selected on.
     ///
     /// Multiple `SelectionSet`s may reference the same `Entity`
-    public let entity: Entity
+    public unowned let entity: Entity
 
     /// A list of the scopes for the `SelectionSet` and its enclosing entities.
     ///


### PR DESCRIPTION
This fixes a retain cycle that was causing memory leaks. This was manually tested to verify that TypeInfo and Entity objects are now properly released when their operations are complete.