### PR TITLE
[docs] small tweaks to apollo-ios-cli doc

### DIFF
--- a/docs/source/code-generation/codegen-cli.mdx
+++ b/docs/source/code-generation/codegen-cli.mdx
@@ -107,13 +107,13 @@ The default configuration will:
 
 #### Command:
 
-`apollo-ios-cli init [--schema-name <schema name>] [--module-type <module type>] [--target-name <target name>]`
+`apollo-ios-cli init --schema-namespace <namespace> --module-type <type> [--target-name <target name>]`
 
 #### Options:
 
 | Option     | Description |
 | ---------- | ----------- |
-| `--schema-name`     | **[Required]** The name you would like to be used as the namespace for your generated schema files. |
+| `--schema-namespace`     | **[Required]** The name you would like to be used as the namespace for your generated schema files. |
 | `--module-type`     | **[Required]** How to package the schema types for dependency management. Possible types are `embeddedInTarget`, `swiftPackageManager`, `other`. |
 | `--target-name`     | Name of the target in which the schema types files will be manually embedded.<br/><br/>*Note: This is required for the "embeddedInTarget" module type and will be ignored for all other module types.* |
 | `-p, --path <path>` | Write the configuration to a file at the path. (default: `./apollo-codegen-config.json`) |


### PR DESCRIPTION
* `--schema-name` => `--schema-namespace`
* remove square brackets for required arguments. See https://stackoverflow.com/a/47026846/752630