### PR TITLE
chore: Removes boundary from accept header

### DIFF
--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -380,7 +380,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;boundary=\"graphql\";\(MultipartResponseDeferParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json")
       expectation.fulfill()
     }
 
@@ -405,7 +405,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;boundary=\"graphql\";\(MultipartResponseDeferParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json")
       expectation.fulfill()
     }
 
@@ -430,7 +430,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;boundary=\"graphql\";\(MultipartResponseDeferParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json")
       XCTAssertNotNil(request.allHTTPHeaderFields?["Random"])
       expectation.fulfill()
     }
@@ -460,7 +460,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;boundary=\"graphql\";\(MultipartResponseDeferParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json")
       XCTAssertNotNil(request.allHTTPHeaderFields?["Random"])
       expectation.fulfill()
     }

--- a/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -109,7 +109,7 @@ open class RequestChainNetworkTransport: NetworkTransport {
     } else {
       request.addHeader(
         name: "Accept",
-        value: "multipart/mixed;boundary=\"graphql\";\(MultipartResponseDeferParser.protocolSpec),application/json"
+        value: "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json"
       )
     }
 


### PR DESCRIPTION
This is the same as https://github.com/apollographql/apollo-ios-dev/pull/232 but limited to non-subscription operations and to be merged into the `feature/defer-execution-networking` branch to only be applicable once all the defer work is merged into `main`.

> The `boundary` portion of the `accept` header has no effect on the `boundary` in the received multipart response so we can remove it and send less data in the request. The multipart response handler is already built to handle any value sent back as the `boundary` and use that to parse the chunks.

> More details in https://github.com/apollographql/router/pull/4395 and https://github.com/apollographql/router/pull/4447.