### PR TITLE
import directive

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -51,7 +51,7 @@ class SelectionSetTemplateTests: XCTestCase {
       )
     ))
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile(importModules: nil),
+      target: .operationFile(moduleImports: nil),
       template: "",
       config: config
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -51,7 +51,7 @@ class SelectionSetTemplateTests: XCTestCase {
       )
     ))
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile,
+      target: .operationFile(importModules: nil),
       template: "",
       config: config
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_ErrorHandling_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_ErrorHandling_Tests.swift
@@ -41,7 +41,7 @@ class SelectionSetTemplate_ErrorHandling_Tests: XCTestCase {
       options: .init()
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile(importModules: nil),
+      target: .operationFile(moduleImports: nil),
       template: "",
       config: .init(config: config)
     )
@@ -64,7 +64,7 @@ class SelectionSetTemplate_ErrorHandling_Tests: XCTestCase {
       options: .init()
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile(importModules: nil),
+      target: .operationFile(moduleImports: nil),
       template: "",
       config: .init(config: config)
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_ErrorHandling_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_ErrorHandling_Tests.swift
@@ -41,7 +41,7 @@ class SelectionSetTemplate_ErrorHandling_Tests: XCTestCase {
       options: .init()
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile,
+      target: .operationFile(importModules: nil),
       template: "",
       config: .init(config: config)
     )
@@ -64,7 +64,7 @@ class SelectionSetTemplate_ErrorHandling_Tests: XCTestCase {
       options: .init()
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile,
+      target: .operationFile(importModules: nil),
       template: "",
       config: .init(config: config)
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -42,7 +42,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
       options: .init()
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile,
+      target: .operationFile(importModules: nil),
       template: "",
       config: .init(config: config)
     )
@@ -70,7 +70,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
       options: .init()
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile,
+      target: .operationFile(importModules: nil),
       template: "",
       config: .init(config: config)
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -42,7 +42,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
       options: .init()
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile(importModules: nil),
+      target: .operationFile(moduleImports: nil),
       template: "",
       config: .init(config: config)
     )
@@ -70,7 +70,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
       options: .init()
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile(importModules: nil),
+      target: .operationFile(moduleImports: nil),
       template: "",
       config: .init(config: config)
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
@@ -43,7 +43,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
       )
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile(importModules: nil),
+      target: .operationFile(moduleImports: nil),
       template: "",
       config: config
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
@@ -43,7 +43,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
       )
     )
     let mockTemplateRenderer = MockTemplateRenderer(
-      target: .operationFile,
+      target: .operationFile(importModules: nil),
       template: "",
       config: config
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -22,7 +22,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
   }
 
   private func buildSubject(config: ApolloCodegenConfiguration = .mock()) -> MockFileTemplate {
-    MockFileTemplate(target: .operationFile, config: ApolloCodegen.ConfigurationContext(config: config))
+    MockFileTemplate(target: .operationFile(importModules: nil), config: ApolloCodegen.ConfigurationContext(config: config))
   }
 
   // MARK: Render Target .operationFile Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -22,7 +22,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
   }
 
   private func buildSubject(config: ApolloCodegenConfiguration = .mock()) -> MockFileTemplate {
-    MockFileTemplate(target: .operationFile(importModules: nil), config: ApolloCodegen.ConfigurationContext(config: config))
+    MockFileTemplate(target: .operationFile(moduleImports: nil), config: ApolloCodegen.ConfigurationContext(config: config))
   }
 
   // MARK: Render Target .operationFile Tests

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -10,7 +10,11 @@ struct FragmentTemplate: TemplateRenderer {
 
   let config: ApolloCodegen.ConfigurationContext
 
-  let target: TemplateTarget = .operationFile
+  var target: TemplateTarget {
+    .operationFile(importModules: fragment.definition.importDirectives.map {
+      $0.moduleName
+    })
+  }
 
   func renderBodyTemplate(
     nonFatalErrorRecorder: ApolloCodegen.NonFatalError.Recorder

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -11,9 +11,7 @@ struct FragmentTemplate: TemplateRenderer {
   let config: ApolloCodegen.ConfigurationContext
 
   var target: TemplateTarget {
-    .operationFile(importModules: fragment.definition.importDirectives.map {
-      $0.moduleName
-    })
+    .operationFile(moduleImports: fragment.definition.moduleImports)
   }
 
   func renderBodyTemplate(

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -8,7 +8,11 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
 
   let config: ApolloCodegen.ConfigurationContext
 
-  let target: TemplateTarget = .operationFile
+  var target: TemplateTarget {
+    .operationFile(importModules: operation.definition.importDirectives.map {
+      $0.moduleName
+    })
+  }
 
   func renderBodyTemplate(
     nonFatalErrorRecorder: ApolloCodegen.NonFatalError.Recorder

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -9,9 +9,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
   let config: ApolloCodegen.ConfigurationContext
 
   var target: TemplateTarget {
-    .operationFile(importModules: operation.definition.importDirectives.map {
-      $0.moduleName
-    })
+    .operationFile(moduleImports: operation.definition.moduleImports)
   }
 
   func renderBodyTemplate(

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -14,7 +14,11 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
 
   let config: ApolloCodegen.ConfigurationContext
 
-  let target: TemplateTarget = .operationFile
+  var target: TemplateTarget {
+    .operationFile(importModules: operation.definition.importDirectives.map {
+      $0.moduleName
+    })
+  }
 
   func renderBodyTemplate(
     nonFatalErrorRecorder: ApolloCodegen.NonFatalError.Recorder
@@ -45,7 +49,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
 
     """)
   }
-
+    
   private func OperationDeclaration() -> TemplateString {
     return """
     \(accessControlModifier(for: .parent))\

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -15,9 +15,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
   let config: ApolloCodegen.ConfigurationContext
 
   var target: TemplateTarget {
-    .operationFile(importModules: operation.definition.importDirectives.map {
-      $0.moduleName
-    })
+    .operationFile(moduleImports: operation.definition.moduleImports)
   }
 
   func renderBodyTemplate(

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -7,7 +7,7 @@ enum TemplateTarget: Equatable {
   /// Used in schema types files; enum, input object, union, etc.
   case schemaFile(type: SchemaFileType)
   /// Used in operation files; query, mutation, fragment, etc.
-  case operationFile
+  case operationFile(importModules: [String])
   /// Used in files that define a module; Swift Package Manager, etc.
   case moduleFile
   /// Used in test mock files; schema object `Mockable` extensions
@@ -23,7 +23,7 @@ enum TemplateTarget: Equatable {
     case customScalar
     case inputObject
 
-    var namespaceComponent: String? {      
+    var namespaceComponent: String? {
       switch self {
       case .schemaMetadata, .enum, .customScalar, .inputObject, .schemaConfiguration:
         return nil
@@ -103,7 +103,7 @@ extension TemplateRenderer {
     let body = {
       switch target {
       case let .schemaFile(type): return renderSchemaFile(type, errorRecorder)
-      case .operationFile: return renderOperationFile(errorRecorder)
+      case let .operationFile(importModules): return renderOperationFile(importModules, errorRecorder)
       case .moduleFile: return renderModuleFile(errorRecorder)
       case .testMockFile: return renderTestMockFile(errorRecorder)
       }
@@ -153,12 +153,14 @@ extension TemplateRenderer {
   }
 
   private func renderOperationFile(
+    _ importModules: [String],
     _ errorRecorder: ApolloCodegen.NonFatalError.Recorder
   ) -> String {
     TemplateString(
     """
     \(ifLet: renderHeaderTemplate(nonFatalErrorRecorder: errorRecorder), { "\($0)\n" })
     \(ImportStatementTemplate.Operation.template(for: config))
+    \(AdditionalImportStatementTemplate.template(importModules: importModules))
 
     \(if: config.output.operations.isInModule && !config.output.schemaTypes.isInModule,
       renderBodyTemplate(nonFatalErrorRecorder: errorRecorder)
@@ -348,6 +350,23 @@ struct ImportStatementTemplate {
       """
     }
   }
+}
+
+/// Provides the format to import additional Swift modules required by the template type.
+struct AdditionalImportStatementTemplate {
+
+  static func template(
+    importModules: [String]
+  ) -> TemplateString {
+    return """
+    \(forEachIn: importModules, {
+      return """
+      import \($0)
+      """
+    })
+    """
+  }
+    
 }
 
 fileprivate extension ApolloCodegenConfiguration {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -360,11 +360,7 @@ struct ModuleImportStatementTemplate {
   ) -> TemplateString? {
     guard let moduleImports else  { return nil }
     return """
-    \(forEachIn: moduleImports, {
-      return """
-      import \($0)
-      """
-    })
+    \(moduleImports.map { "import \($0)" }.joined(separator: "\n"))
     """
   }
     

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/CompilationResult.swift
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/CompilationResult.swift
@@ -110,7 +110,7 @@ public final class CompilationResult: JavaScriptObjectDecodable {
 
     public let isLocalCacheMutation: Bool
       
-    public let importDirectives: [ImportDirective]
+    public let moduleImports: [String]
 
     static func fromJSValue(_ jsValue: JSValue, bridge: isolated JavaScriptBridge) -> Self {
       self.init(
@@ -148,8 +148,8 @@ public final class CompilationResult: JavaScriptObjectDecodable {
       self.filePath = filePath
       self.isLocalCacheMutation = directives?
         .contains { $0.name == Constants.DirectiveNames.LocalCacheMutation } ?? false
-      self.importDirectives = directives?
-        .compactMap { ImportDirective(directive: $0) } ?? []
+      self.moduleImports = directives?
+        .compactMap { ImportDirective(directive: $0)?.moduleName } ?? []
     }
 
     public var debugDescription: String {
@@ -220,8 +220,8 @@ public final class CompilationResult: JavaScriptObjectDecodable {
       directives?.contains { $0.name == Constants.DirectiveNames.LocalCacheMutation } ?? false
     }
       
-    public var importDirectives: [ImportDirective] {
-      directives?.compactMap { ImportDirective(directive: $0) } ?? []
+    public var moduleImports: [String] {
+      directives?.compactMap { ImportDirective(directive: $0)?.moduleName } ?? []
     }
 
     init(_ jsValue: JSValue, bridge: isolated JavaScriptBridge) {
@@ -660,18 +660,15 @@ public final class CompilationResult: JavaScriptObjectDecodable {
     }
   }
     
-    public struct ImportDirective: Hashable, CustomDebugStringConvertible, Sendable {
+    fileprivate struct ImportDirective: Hashable, CustomDebugStringConvertible, Sendable, Equatable {
       /// String constants used to match JavaScriptObject instances.
-      fileprivate enum Constants {
+      enum Constants {
           enum ArgumentNames {
             static let Module = "module"
           }
       }
         
-      public var debugDescription: String {
-        return "Import \"\(moduleName)\""
-      }
-      public let moduleName: String
+      let moduleName: String
         
       init?(directive: Directive) {
         guard directive.name == CompilationResult.Constants.DirectiveNames.Import else {
@@ -684,6 +681,10 @@ public final class CompilationResult: JavaScriptObjectDecodable {
           return nil
         }
         moduleName = moduleValue
+      }
+    
+      var debugDescription: String {
+        return "Import \"\(moduleName)\""
       }
     }
 }


### PR DESCRIPTION
This PR handles the import directive.
If a graphql operation adds this directive, an import statement to the corresponding generated operation file will be added.

Open question:

How should the import directive work for nested fragments?
 
When adding the directive to a fragment C in the case of
`Query A { ...B }  Fragment B { ...C } Fragment C @import(module: "MyModule") { ...FragmentFromMyModule}`

The enclosing fragments and queries (A,B) will reference fragments from inside C, which would be included in the imported module. Should the codegen add the import statement automatically to the Fragment B and Query A, or should the dev explicitly add the import directive in A and B?

This PR implements the case of explicitly adding the import directives to any operation which includes any fragment from the imported module.