### PR TITLE
Update Nimble to 13.2.0

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
       "state" : {
-        "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
-        "version" : "2.1.2"
+        "revision" : "dc9af4781f2afdd1e68e90f80b8603be73ea7abc",
+        "version" : "2.2.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "edaedc1ec86f14ac6e2ca495b94f0ff7150d98d0",
-        "version" : "12.3.0"
+        "revision" : "c1f3dd66222d5e7a1a20afc237f7e7bc432c564f",
+        "version" : "13.2.0"
       }
     },
     {

--- a/Project.swift
+++ b/Project.swift
@@ -7,7 +7,7 @@ let project = Project(
     name: "ApolloDev",
     organizationName: "apollographql",
     packages: [
-        .package(url: "https://github.com/Quick/Nimble.git", from: "12.3.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "13.2.0"),
         .package(path: "apollo-ios"),
         .package(path: "apollo-ios-codegen"),
         .package(path: "apollo-ios-pagination"),


### PR DESCRIPTION
Nimble 13.2.0 has VisionOS support, which will make our adoption of VisionOS support easier.