### PR TITLE
feat: SECOPS-2525 - add semgrep job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,9 @@ workflows:
             - secops-oidc
           git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
           git-revision: << pipeline.git.revision >>
+      - secops/semgrep:
+          context:
+            - secops-oidc
+            - github-orb
+          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+          fail-on-findings: true


### PR DESCRIPTION
This adds the semgrep job to the base CircleCI configuration whereas #230 and #233 only made the change for the subtree configurations.