### PR TITLE
[📚docs] fix typo in file-uploads.mdx

### DIFF
--- a/docs/source/file-uploads.mdx
+++ b/docs/source/file-uploads.mdx
@@ -6,7 +6,7 @@ description: Enabling file uploads in Apollo Client for iOS
 Apollo iOS supports file uploads via the [GraphQL multipart request specification](https://github.com/jaydenseric/graphql-multipart-request-spec) with a few caveats:
 
 - Uploading files with GraphQL is most often suitable for proof-of-concept applications. In production, using purpose-built tools for file uploads may be preferable. Refer to this [blog post](https://www.apollographql.com/blog/backend/file-uploads/file-upload-best-practices/) for the advantages and disadvantages of multiple approaches.
-- The [Apollo Router](/router/) doesn't support `multipart-form` uploads.
+- The [Apollo Router](/router/) doesn't support `multipart/form-data` uploads.
 
 ### Uploading files with Apollo iOS
 


### PR DESCRIPTION
I don't think there's such a thing as `multipart-form`? ([Matching apollo-kotlin PR](https://github.com/apollographql/apollo-kotlin/pull/5566))

Also heads up that the router is prepping for file uploads (see https://github.com/apollographql/router/issues/4496). So we should probably remove this sentence at some point in the future.