### PR TITLE
[ApolloPagination] Update variable mapping logic to use a Set instead of an Array

### DIFF
--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -124,7 +124,7 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
     ]
 
     let expectedVariables = Set(nextQuery.__variables?.values.compactMap { $0._jsonEncodableValue?._jsonValue } ?? [])
-    let actualVariables = try await XCTUnwrapping(await pager.nextPageVarMap.keys.first as? Set<JSONValue>)
+    let actualVariables = try await XCTUnwrapping(await pager.nextPageVarMap.keys.first)
 
     XCTAssertEqual(expectedVariables.count, actualVariables.count)
     XCTAssertEqual(expectedVariables.count, 3)

--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -123,13 +123,13 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
       "after": "Y3Vyc29yMg==",
     ]
 
-    let expectedVariables = nextQuery.__variables?.values.compactMap { $0._jsonEncodableValue?._jsonValue } ?? []
-    let actualVariables = try await XCTUnwrapping(await pager.nextPageVarMap.keys.first as? [JSONValue])
+    let expectedVariables = Set(nextQuery.__variables?.values.compactMap { $0._jsonEncodableValue?._jsonValue } ?? [])
+    let actualVariables = try await XCTUnwrapping(await pager.nextPageVarMap.keys.first as? Set<JSONValue>)
 
     XCTAssertEqual(expectedVariables.count, actualVariables.count)
     XCTAssertEqual(expectedVariables.count, 3)
 
-    XCTAssertEqual(Set(expectedVariables), Set(actualVariables))
+    XCTAssertEqual(expectedVariables, actualVariables)
   }
 
   func test_paginationState() async throws {

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
@@ -35,9 +35,9 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
   }
 
   var publishers: (
-    previousPageVarMap: Published<OrderedDictionary<AnyHashable, PaginatedQuery.Data>>.Publisher,
+    previousPageVarMap: Published<OrderedDictionary<Set<JSONValue>, PaginatedQuery.Data>>.Publisher,
     initialPageResult: Published<InitialQuery.Data?>.Publisher,
-    nextPageVarMap: Published<OrderedDictionary<AnyHashable, PaginatedQuery.Data>>.Publisher
+    nextPageVarMap: Published<OrderedDictionary<Set<JSONValue>, PaginatedQuery.Data>>.Publisher
   ) {
     return ($previousPageVarMap, $initialPageResult, $nextPageVarMap)
   }
@@ -56,8 +56,8 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
   }
 
   /// Maps each query variable set to latest results from internal watchers.
-  @Published var nextPageVarMap: OrderedDictionary<AnyHashable, PaginatedQuery.Data> = [:]
-  @Published var previousPageVarMap: OrderedDictionary<AnyHashable, PaginatedQuery.Data> = [:]
+  @Published var nextPageVarMap: OrderedDictionary<Set<JSONValue>, PaginatedQuery.Data> = [:]
+  @Published var previousPageVarMap: OrderedDictionary<Set<JSONValue>, PaginatedQuery.Data> = [:]
   private var tasks: Set<Task<Void, Error>> = []
   private var taskGroup: ThrowingTaskGroup<Void, Error>?
   private var watcherCallbackQueue: DispatchQueue

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
@@ -321,7 +321,7 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
       case .paginated(let direction, let query):
         guard let pageData = pageData as? PaginatedQuery.Data else { return }
 
-        let variables = query.__variables?.underlyingJson ?? []
+        let variables = Set(query.__variables?.underlyingJson ?? [])
         switch direction {
         case .next:
           nextPageVarMap[variables] = pageData


### PR DESCRIPTION
A special thank you to @ralph-101-dev for finding this issue in a pre-release build of `ApolloPagination`. 

Closes https://github.com/apollographql/apollo-ios/issues/3331

_____

This pull request primarily focuses on modifying how variables are handled in `AsyncGraphQLQueryPagerCoordinator.swift`. The changes involve altering the data types of variables from arrays to sets, which should eliminate the possibility of a mismatch between mis-ordered array outputs. This is especially needed, because the underlying values being pulled from are an unordered dictionary, so multiple invocations of the same function can result in a key-miss. 

The change to production code is a one-liner: We've updated the value of the `variables` variable – which houses the input variables of a given `GraphQLQuery` – from an `Array<JSONValue` to a `Set<JSONValue`. 

The tests were updated to unwrap the `AnyHashable` key-value of the `nextPageVarMap` property as a `Set` instead of as an `Array`. Notably, the tests were masking this error, as they were previously taking the `Array` outputs, wrapping them in a `Set`, and then comparing the sets!