### PR TITLE
[ApolloPagination] Fix memory leak in `GraphQLQueryPager`'s `Publisher` implementation

### DIFF
--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
@@ -171,27 +171,6 @@ public class AsyncGraphQLQueryPager<Model>: Publisher {
   public func receive<S>(
     subscriber: S
   ) where S: Subscriber, Never == S.Failure, Result<(Model, UpdateSource), Error> == S.Input {
-    let subscription = PagerSubscription(pager: self, subscriber: subscriber)
-    subscriber.receive(subscription: subscription)
-  }
-}
-
-private class PagerSubscription<SubscriberType: Subscriber, Pager: AsyncGraphQLQueryPager<Model>, Model>: Subscription where SubscriberType.Input == Pager.Output {
-  private var subscriber: SubscriberType?
-  private var pager: Pager
-  private var cancellable: AnyCancellable?
-
-  init(pager: Pager, subscriber: SubscriberType) {
-    self.subscriber = subscriber
-    self.pager = pager
-    cancellable = pager.publisher.sink(receiveValue: {
-      _ = subscriber.receive($0)
-    })
-  }
-
-  func request(_ demand: Subscribers.Demand) { }
-
-  func cancel() {
-    subscriber = nil
+    publisher.subscribe(subscriber)
   }
 }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -178,27 +178,6 @@ public class GraphQLQueryPager<Model>: Publisher {
   public func receive<S>(
     subscriber: S
   ) where S: Subscriber, Never == S.Failure, Result<(Model, UpdateSource), Error> == S.Input {
-    let subscription = PagerSubscription(pager: self, subscriber: subscriber)
-    subscriber.receive(subscription: subscription)
-  }
-}
-
-private class PagerSubscription<SubscriberType: Subscriber, Pager: GraphQLQueryPager<Model>, Model>: Subscription where SubscriberType.Input == Pager.Output {
-  private var subscriber: SubscriberType?
-  private var pager: Pager
-  private var cancellable: AnyCancellable?
-
-  init(pager: Pager, subscriber: SubscriberType) {
-    self.subscriber = subscriber
-    self.pager = pager
-    cancellable = pager.publisher.sink(receiveValue: {
-      _ = subscriber.receive($0)
-    })
-  }
-
-  func request(_ demand: Subscribers.Demand) { }
-
-  func cancel() {
-    subscriber = nil
+    publisher.subscribe(subscriber)
   }
 }


### PR DESCRIPTION
We've detected a memory leak in the implementation of the `Publisher` protocol within `GraphQLQueryPager`. 

Instead of treating this as a custom publisher – which the previous implementation certainly did – we just pare it down and forward to the internal `publisher` property.

A special thank you to @esahmed21 for confirming the leak and making note that it didn't exist in the previous version.

> [!NOTE]
> **Why am I electing to call `subscribe(_:)` instead of `receive(_:)`?**
>
> `subscribe(_:)` in Combine has some additional observation logic that gets triggered before it forwards a subscription, which will ultimately invoke `receive(subscription:)` directly. That logic is important, as it prevents memory cycles & other unexpected outcomes. Apple's Combine docs include the incredible line: `/// Always call this function instead of Publisher/receive(subscriber:)`