### PR TITLE
Make `ResultNormalizerFactory` a caseless enum

### DIFF
--- a/apollo-ios/Sources/Apollo/GraphQLResultNormalizer.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLResultNormalizer.swift
@@ -3,8 +3,7 @@ import Foundation
 import ApolloAPI
 #endif
 
-struct ResultNormalizerFactory {
-  private init() {}
+enum ResultNormalizerFactory {
 
   static func selectionSetDataNormalizer() -> SelectionSetDataResultNormalizer {
     SelectionSetDataResultNormalizer()


### PR DESCRIPTION
`ResultNormalizerFactory` stateless container for static methods. This is better modeled as an `enum` rather than a `struct`, which better guarantees that the type cannot be initialized.