### PR TITLE
[ApolloPagination] Additional conveniences for offset pagination

### DIFF
--- a/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/Bidirectional.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/Bidirectional.swift
@@ -1,0 +1,13 @@
+extension OffsetPagination {
+  public struct Bidirectional: PaginationInfo, Hashable {
+    public let offset: Int
+    public var canLoadNext: Bool
+    public let canLoadPrevious: Bool
+
+    public init(offset: Int, canLoadNext: Bool, canLoadPrevious: Bool) {
+      self.offset = offset
+      self.canLoadNext = canLoadNext
+      self.canLoadPrevious = canLoadPrevious
+    }
+  }
+}

--- a/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/ForwardOffset.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/ForwardOffset.swift
@@ -1,0 +1,13 @@
+extension OffsetPagination {
+  public struct Forward: PaginationInfo, Hashable {
+    public let offset: Int
+    public let canLoadNext: Bool
+    public var canLoadPrevious: Bool { false }
+
+    public init(offset: Int, canLoadNext: Bool) {
+      self.offset = offset
+      self.canLoadNext = canLoadNext
+    }
+  }
+
+}

--- a/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/OffsetPagination.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/OffsetPagination.swift
@@ -1,10 +1,1 @@
-public struct OffsetPagination: PaginationInfo, Hashable {
-  public let offset: Int
-  public let canLoadNext: Bool
-  public var canLoadPrevious: Bool { false }
-
-  public init(offset: Int, canLoadNext: Bool) {
-    self.offset = offset
-    self.canLoadNext = canLoadNext
-  }
-}
+public enum OffsetPagination { }

--- a/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/ReverseOffset.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/ReverseOffset.swift
@@ -1,0 +1,13 @@
+extension OffsetPagination {
+  public struct Reverse: PaginationInfo, Hashable {
+    public let offset: Int
+    public var canLoadNext: Bool { false }
+    public let canLoadPrevious: Bool
+
+    public init(offset: Int, canLoadPrevious: Bool) {
+      self.offset = offset
+      self.canLoadPrevious = canLoadPrevious
+    }
+  }
+
+}


### PR DESCRIPTION
While writing docs in https://github.com/apollographql/apollo-ios-dev/pull/262, I recognized that support for offset pagination could be better. Specifically:

- We could support bidirectional and reverse pagination
- We could have additional convenience methods for that pagination type

As such, this pull request modifies the `OffsetPagination` class to be a namespace, just like `CursorBasedPagination`. We introduce three new structs to facilitate pagination:

* [`OffsetPagination.Forward`](diffhunk://#diff-87d71a0a39b618ebc441f849bc785e628e5a5c585fb21b8a28b3b9194338de7aR1-R13): Introduced `OffsetPagination.Forward` structure to represent a forward pagination state. **This is identical to the previous contents of `OffsetPagination`.** 
* [`OffsetPagination.Reverse`](diffhunk://#diff-9d88cb9967dbd3a7063dfd4b6d7947301fc666ac945c231a9a15dd9395950f63R1-R13): Introduced `OffsetPagination.Reverse` structure to represent a reverse pagination state.
* [`OffsetPagination.Bidirectional`](diffhunk://#diff-30019aa440e541b16afcc25eb229e6b0992bd5617faa669c01b3927f0b644b45R1-R13): Introduced `OffsetPagination.Bidirectional` structure to represent a bidirectional pagination state.

With the addition of these new structures, we could now add and update convenience `make` functions for offset pagination, which add support for `Bidirectional` pagination – as well as add additional `transform` options, supporting both single-model output and `Collection` output. 

____

cc: @AnthonyMDev I'm glad that you pointed out the need for offset pagination docs. I've focused almost entirely on cursors, as that's what we use at GitHub. Once this is merged, I'll look into:

- Updating the docs to accommodate for these changes
- Introducing a test suite around offsets, as I realize that our existing test suite is similarly focused on cursors. 
- I could additionally implement convenience functions for multi-query pagination using offsets, but I'm a bit hesitant. The number of convenience `make` functions is quite large, and I'm concerned that it would be confusing for users to parse through them. Yes, they could filter by typing: `make` followed by their direction `Forward`, and their pagination type `Offset` or `Cursor`, which will then present them with a further _six possibilities_: (single-query, single-query collection transform, single-query single-model transform, multi-query, multi-query collection transform, multi-query single-model transform). Perhaps for now, it's best to add it and then re-think the way that convenience initializers are exposed. Perhaps we can do something silly and make use of namespaces? Imagine a case-less `CursorPager` and `OffsetPager`, with further namespaces for direction (`Forward`, `Reverse`, and `Bidirectional`, that then had the specific convenience functions available? This can be an improvement for later. 