### PR TITLE
[ApolloPagination] Remove convenience functions, improved Offset-pagination support

### DIFF
--- a/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerCoordinatorTests.swift
+++ b/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerCoordinatorTests.swift
@@ -172,7 +172,7 @@ final class AsyncGraphQLQueryPagerCoordinatorTests: XCTestCase, CacheDependentTe
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Reverse(
             hasPrevious: data.hero.friendsConnection.pageInfo.hasPreviousPage,
             startCursor: data.hero.friendsConnection.pageInfo.startCursor
@@ -201,7 +201,7 @@ final class AsyncGraphQLQueryPagerCoordinatorTests: XCTestCase, CacheDependentTe
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Forward(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor

--- a/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
@@ -22,24 +22,31 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
   }
 
   func test_forwardInit_simple() async throws {
-    let pager = await AsyncGraphQLQueryPager.makeForwardCursorQueryPager(
-      client: client,
-      queryProvider: { pageInfo in
+    let initialQuery = Query()
+    initialQuery.__variables = [
+      "id": "2001",
+      "first": 2,
+      "after": GraphQLNullable<String>.null
+    ]
+    let pager = await AsyncGraphQLQueryPager.makeQueryPager(client: client, initialQuery: initialQuery) { page, direction in
+      switch direction {
+      case .next:
         let nextQuery = Query()
         nextQuery.__variables = [
           "id": "2001",
           "first": 2,
-          "after": pageInfo?.endCursor ?? GraphQLNullable<String>.null
+          "after": page.endCursor
         ]
         return nextQuery
-      },
-      extractPageInfo: { data in
-        CursorBasedPagination.Forward(
-          hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
-          endCursor: data.hero.friendsConnection.pageInfo.endCursor
-        )
+      case .previous:
+        return nil
       }
-    )
+    } extractPageInfo: { data in
+      CursorBasedPagination.Forward(
+        hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
+        endCursor: data.hero.friendsConnection.pageInfo.endCursor
+      )
+    }
 
     let serverExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
     await pager.fetch()
@@ -66,24 +73,31 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       let name: String
     }
 
-    let pager = await AsyncGraphQLQueryPager.makeForwardCursorQueryPager(
-      client: client,
-      queryProvider: { pageInfo in
+    let initialQuery = Query()
+    initialQuery.__variables = [
+      "id": "2001",
+      "first": 2,
+      "after": GraphQLNullable<String>.null
+    ]
+    let pager = await AsyncGraphQLQueryPager.makeQueryPager(client: client, initialQuery: initialQuery) { page, direction in
+      switch direction {
+      case .next:
         let nextQuery = Query()
         nextQuery.__variables = [
           "id": "2001",
           "first": 2,
-          "after": pageInfo?.endCursor ?? GraphQLNullable<String>.null
+          "after": page.endCursor
         ]
         return nextQuery
-      },
-      extractPageInfo: { data in
-        CursorBasedPagination.Forward(
-          hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
-          endCursor: data.hero.friendsConnection.pageInfo.endCursor
-        )
+      case .previous:
+        return nil
       }
-    )
+    } extractPageInfo: { data in
+      CursorBasedPagination.Forward(
+        hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
+        endCursor: data.hero.friendsConnection.pageInfo.endCursor
+      )
+    }
 
     let serverExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
     await pager.fetch()
@@ -116,30 +130,36 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
   }
 
   func test_forwardInit_singleQuery_transform() async throws {
-    let pager = await AsyncGraphQLQueryPager.makeForwardCursorQueryPager(
-      client: client,
-      queryProvider: { pageInfo in
+    let initialQuery = Query()
+    initialQuery.__variables = [
+      "id": "2001",
+      "first": 2,
+      "after": GraphQLNullable<String>.null
+    ]
+    let pager = await AsyncGraphQLQueryPager.makeQueryPager(client: client, initialQuery: initialQuery) { page, direction in
+      switch direction {
+      case .next:
         let nextQuery = Query()
         nextQuery.__variables = [
           "id": "2001",
           "first": 2,
-          "after": pageInfo?.endCursor ?? GraphQLNullable<String>.null
+          "after": page.endCursor
         ]
         return nextQuery
-      },
-      extractPageInfo: { data in
-        CursorBasedPagination.Forward(
-          hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
-          endCursor: data.hero.friendsConnection.pageInfo.endCursor
-        )
-      },
-      transform: { previous, first, next in
-        let inOrderData = previous + [first] + next
-        return inOrderData.flatMap { data in
-          data.hero.friendsConnection.friends.map { friend in friend.name }
-        }
+      case .previous:
+        return nil
       }
-    )
+    } extractPageInfo: { data in
+      CursorBasedPagination.Forward(
+        hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
+        endCursor: data.hero.friendsConnection.pageInfo.endCursor
+      )
+    } transform: { previous, first, next in
+      let inOrderData = previous + [first] + next
+      return inOrderData.flatMap { data in
+        data.hero.friendsConnection.friends.map { friend in friend.name }
+      }
+    }
 
     let serverExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
     await pager.fetch()
@@ -166,30 +186,36 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       let name: String
     }
 
-    let pager = await AsyncGraphQLQueryPager.makeForwardCursorQueryPager(
-      client: client,
-      queryProvider: { pageInfo in
+    let initialQuery = Query()
+    initialQuery.__variables = [
+      "id": "2001",
+      "first": 2,
+      "after": GraphQLNullable<String>.null
+    ]
+    let pager = await AsyncGraphQLQueryPager.makeQueryPager(client: client, initialQuery: initialQuery) { page, direction in
+      switch direction {
+      case .next:
         let nextQuery = Query()
         nextQuery.__variables = [
           "id": "2001",
           "first": 2,
-          "after": pageInfo?.endCursor ?? GraphQLNullable<String>.null
+          "after": page.endCursor
         ]
         return nextQuery
-      },
-      extractPageInfo: { data in
-        CursorBasedPagination.Forward(
-          hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
-          endCursor: data.hero.friendsConnection.pageInfo.endCursor
-        )
-      },
-      transform: { previous, first, next in
-        let inOrderData = previous + [first] + next
-        return inOrderData.flatMap { data in
-          data.hero.friendsConnection.friends.map { friend in friend.name }
-        }
+      case .previous:
+        return nil
       }
-    )
+    } extractPageInfo: { data in
+      CursorBasedPagination.Forward(
+        hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
+        endCursor: data.hero.friendsConnection.pageInfo.endCursor
+      )
+    } transform: { previous, first, next in
+      let inOrderData = previous + [first] + next
+      return inOrderData.flatMap { data in
+        data.hero.friendsConnection.friends.map { friend in friend.name }
+      }
+    }
 
     let serverExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
     await pager.fetch()

--- a/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
@@ -317,7 +317,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Forward(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor

--- a/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
@@ -52,7 +52,7 @@ final class BidirectionalPaginationTests: XCTestCase, CacheDependentTesting {
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Bidirectional(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor,

--- a/Tests/ApolloPaginationTests/ConcurrencyTest.swift
+++ b/Tests/ApolloPaginationTests/ConcurrencyTest.swift
@@ -78,7 +78,7 @@ final class ConcurrencyTests: XCTestCase {
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Forward(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor
@@ -107,7 +107,7 @@ final class ConcurrencyTests: XCTestCase {
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Forward(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor

--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -255,7 +255,7 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
       initialQuery: initialQuery,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Forward(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor
@@ -292,7 +292,7 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Forward(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor

--- a/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
+++ b/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
@@ -302,3 +302,68 @@ extension Mocks.Hero.BidirectionalFriendsQuery {
     }
   }
 }
+
+extension Mocks.Hero.OffsetFriendsQuery {
+  static func expectationForFirstPage(server: MockGraphQLServer) -> XCTestExpectation {
+    let query = MockQuery<Mocks.Hero.OffsetFriendsQuery>()
+    query.__variables = ["id": "2001", "offset": 0, "limit": 2]
+    return server.expect(query) { _ in
+      let friends: [[String: AnyHashable]] = [
+        [
+          "__typename": "Human",
+          "name": "Luke Skywalker",
+          "id": "1000",
+        ],
+        [
+          "__typename": "Human",
+          "name": "Han Solo",
+          "id": "1002",
+        ],
+      ]
+
+      let hero: [String: AnyHashable] = [
+        "__typename": "Droid",
+        "id": "2001",
+        "name": "R2-D2",
+        "friends": friends,
+      ]
+
+      let data: [String: AnyHashable] = [
+        "hero": hero
+      ]
+
+      return [
+        "data": data
+      ]
+    }
+  }
+
+  static func expectationForLastPage(server: MockGraphQLServer) -> XCTestExpectation {
+    let query = MockQuery<Mocks.Hero.OffsetFriendsQuery>()
+    query.__variables = ["id": "2001", "offset": 2, "limit": 2]
+    return server.expect(query) { _ in
+      let friends: [[String: AnyHashable]] = [
+        [
+          "__typename": "Human",
+          "name": "Leia Organa",
+          "id": "1003",
+        ],
+      ]
+
+      let hero: [String: AnyHashable] = [
+        "__typename": "Droid",
+        "id": "2001",
+        "name": "R2-D2",
+        "friends": friends,
+      ]
+
+      let data: [String: AnyHashable] = [
+        "hero": hero
+      ]
+
+      return [
+        "data": data
+      ]
+    }
+  }
+}

--- a/Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift
@@ -40,7 +40,7 @@ final class GraphQLQueryPagerTests: XCTestCase {
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Forward(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor
@@ -69,7 +69,7 @@ final class GraphQLQueryPagerTests: XCTestCase {
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Reverse(
             hasPrevious: data.hero.friendsConnection.pageInfo.hasPreviousPage,
             startCursor: data.hero.friendsConnection.pageInfo.startCursor

--- a/Tests/ApolloPaginationTests/GraphQLQueryPagerTestsCoordinator.swift
+++ b/Tests/ApolloPaginationTests/GraphQLQueryPagerTestsCoordinator.swift
@@ -127,7 +127,7 @@ final class GraphQLQueryPagerTestsCoordinator: XCTestCase, CacheDependentTesting
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Forward(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor

--- a/Tests/ApolloPaginationTests/Mocks.swift
+++ b/Tests/ApolloPaginationTests/Mocks.swift
@@ -185,6 +185,41 @@ enum Mocks {
       }
     }
 
+    class OffsetFriendsQuery: MockSelectionSet {
+      override class var __selections: [Selection] { [
+        .field("hero", Hero?.self, arguments: ["id": .variable("id")])
+      ]}
+
+      var hero: Hero { __data["hero"] }
+
+      class Hero: MockSelectionSet {
+        override class var __selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friends", [Character].self, arguments: [
+            "offset": .variable("offset"),
+            "limit": .variable("limit"),
+          ]),
+        ]}
+
+        var name: String { __data["name"] }
+        var id: String { __data["id"] }
+        var friends: [Character] { __data["friends"] }
+
+        class Character: MockSelectionSet {
+          override class var __selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("name", String.self),
+            .field("id", String.self),
+          ]}
+
+          var name: String { __data["name"] }
+          var id: String { __data["id"] }
+        }
+      }
+    }
+
     struct NameCacheMutation: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
       init(_dataDict: DataDict) { __data = _dataDict }

--- a/Tests/ApolloPaginationTests/OffsetTests.swift
+++ b/Tests/ApolloPaginationTests/OffsetTests.swift
@@ -1,0 +1,130 @@
+import Apollo
+import ApolloAPI
+import ApolloInternalTestHelpers
+import Combine
+import XCTest
+
+@testable import ApolloPagination
+
+final class OffsetTests: XCTestCase {
+  private typealias Query = MockQuery<Mocks.Hero.OffsetFriendsQuery>
+
+  private var store: ApolloStore!
+  private var server: MockGraphQLServer!
+  private var networkTransport: MockNetworkTransport!
+  private var client: ApolloClient!
+  private var cancellables: [AnyCancellable] = []
+
+  override func setUp() {
+    super.setUp()
+    store = ApolloStore(cache: InMemoryNormalizedCache())
+    server = MockGraphQLServer()
+    networkTransport = MockNetworkTransport(server: server, store: store)
+    client = ApolloClient(networkTransport: networkTransport, store: store)
+  }
+
+  private func createPager() async -> AsyncGraphQLQueryPager<PaginationOutput<Query, Query>> {
+    let pageSize = 2
+    let initialQuery = Query()
+    initialQuery.__variables = ["id": "2001", "offset": 0, "limit": pageSize]
+    let pager = AsyncGraphQLQueryPagerCoordinator<Query, Query>(
+      client: client,
+      initialQuery: initialQuery,
+      watcherDispatchQueue: .main,
+      extractPageInfo: { data in
+        switch data {
+        case .initial(let data, let output), .paginated(let data, let output):
+          var totalOffset: Int = 0
+          if let output {
+            let pages = (output.previousPages + [output.initialPage] + output.nextPages)
+            pages.forEach { page in
+              totalOffset += page.hero.friends.count
+            }
+          }
+          return OffsetPagination.Forward(
+            offset: totalOffset,
+            canLoadNext: !data.hero.friends.isEmpty || data.hero.friends.count % pageSize != 0
+          )
+        }
+      },
+      pageResolver: { pageInfo, direction in
+        guard direction == .next else { return nil }
+        let nextQuery = Query()
+        nextQuery.__variables = [
+          "id": "2001",
+          "offset": pageInfo.offset,
+          "limit": pageSize
+        ]
+        return nextQuery
+      }
+    )
+    return await AsyncGraphQLQueryPager(pager: pager)
+  }
+
+  // This is due to a timing issue in unit tests only wherein we deinit immediately after waiting for expectations
+  private func ignoringCancellations(error: Error?) {
+    if PaginationError.isCancellation(error: error as? PaginationError) {
+      return
+    } else {
+      XCTAssertNil(error)
+    }
+  }
+
+
+  private func fetchFirstPage<T>(pager: AsyncGraphQLQueryPager<T>) async {
+    let serverExpectation = Mocks.Hero.OffsetFriendsQuery.expectationForFirstPage(server: server)
+    await pager.fetch()
+    await fulfillment(of: [serverExpectation], timeout: 1.0)
+  }
+
+  private func fetchSecondPage<T>(pager: AsyncGraphQLQueryPager<T>) async throws {
+    let serverExpectation = Mocks.Hero.OffsetFriendsQuery.expectationForLastPage(server: server)
+    try await pager.loadNext()
+    await fulfillment(of: [serverExpectation], timeout: 1.0)
+  }
+
+  // MARK: - Tests
+
+  func test_concatenatesPages_matchingInitialAndPaginated() async throws {
+    struct ViewModel {
+      let name: String
+    }
+
+    let pager = await createPager()
+    var results: [ViewModel]?
+    let cancellable = pager.map { value in
+      switch value {
+      case .success((let output, _)):
+        let pages = output.previousPages + [output.initialPage] + output.nextPages
+
+        let friends = pages.flatMap { data in
+          data.hero.friends.map { friend in
+            ViewModel(name: friend.name)
+          }
+        }
+        return Result<[ViewModel], Error>.success(friends)
+      case .failure(let error):
+        return .failure(error)
+      }
+    }.sink { result in
+      switch result {
+      case .success((let viewModels)):
+        results = viewModels
+      default:
+        XCTFail("Failed to get view models from pager.")
+      }
+    }
+
+    await fetchFirstPage(pager: pager)
+    XCTAssertEqual(results?.count, 2)
+    XCTAssertEqual(results?.map(\.name), ["Luke Skywalker", "Han Solo"])
+    let canLoadNext = await pager.canLoadNext
+    XCTAssertTrue(canLoadNext)
+
+    try await fetchSecondPage(pager: pager)
+    XCTAssertEqual(results?.count, 3)
+    XCTAssertEqual(results?.map(\.name), ["Luke Skywalker", "Han Solo", "Leia Organa"])
+    cancellable.cancel()
+  }
+
+}

--- a/Tests/ApolloPaginationTests/ReversePaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ReversePaginationTests.swift
@@ -118,7 +118,7 @@ final class ReversePaginationTests: XCTestCase, CacheDependentTesting {
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Reverse(
             hasPrevious: data.hero.friendsConnection.pageInfo.hasPreviousPage,
             startCursor: data.hero.friendsConnection.pageInfo.startCursor

--- a/Tests/ApolloPaginationTests/SubscribeTests.swift
+++ b/Tests/ApolloPaginationTests/SubscribeTests.swift
@@ -80,7 +80,7 @@ final class SubscribeTest: XCTestCase, CacheDependentTesting {
       watcherDispatchQueue: .main,
       extractPageInfo: { data in
         switch data {
-        case .initial(let data), .paginated(let data):
+        case .initial(let data, _), .paginated(let data, _):
           return CursorBasedPagination.Forward(
             hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
             endCursor: data.hero.friendsConnection.pageInfo.endCursor

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
@@ -80,15 +80,6 @@ public class AsyncGraphQLQueryPager<Model>: Publisher {
     )
   }
 
-  /// For most use-cases, it's recommended to use the static `make...` functions instead of this initializer.
-  /// - Parameters:
-  ///   - client: The Apollo client
-  ///   - initialQuery: The initial query to be performed.
-  ///   - watcherDispatchQueue: The queue that the internal `GraphQLQueryWatcher`s dispatch their results to. Defaults to `main`.
-  ///   - extractPageInfo: This transforming function extracts a `PaginationInfo` from either `InitialQuery.Data` or `PaginatedQuery.Data`, represented in the form of `PageExtractionData`.
-  ///   - pageResolver: This transforming function initializes a new `PaginatedQuery` given a `PagiantionInfo` and `PaginationDirection`.
-  ///   - initialTransform: Transforms the `InitialQuery.Data` to a `Model` type.
-  ///   - pageTransform: Transforms the `PaginatedQuery.Data` to a `Model` type.
   public convenience init<
     P: PaginationInfo,
     InitialQuery: GraphQLQuery,
@@ -134,6 +125,29 @@ public class AsyncGraphQLQueryPager<Model>: Publisher {
       }
       return try? transform(result.previousPages, result.initialPage, result.nextPages)
     }
+  }
+
+  public convenience init<
+    P: PaginationInfo,
+    InitialQuery: GraphQLQuery,
+    PaginatedQuery: GraphQLQuery
+  >(
+    client: ApolloClientProtocol,
+    initialQuery: InitialQuery,
+    watcherDispatchQueue: DispatchQueue = .main,
+    extractPageInfo: @escaping (PageExtractionData<InitialQuery, PaginatedQuery, Model?>) -> P,
+    pageResolver: ((P, PaginationDirection) -> PaginatedQuery?)?
+  ) async where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
+    let pager = AsyncGraphQLQueryPagerCoordinator(
+      client: client,
+      initialQuery: initialQuery,
+      watcherDispatchQueue: watcherDispatchQueue,
+      extractPageInfo: extractPageInfo,
+      pageResolver: pageResolver
+    )
+    await self.init(
+      pager: pager
+    )
   }
 
   public convenience init<

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
@@ -98,7 +98,7 @@ public class AsyncGraphQLQueryPager<Model>: Publisher {
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     watcherDispatchQueue: DispatchQueue = .main,
-    extractPageInfo: @escaping (PageExtractionData<InitialQuery, PaginatedQuery>) -> P,
+    extractPageInfo: @escaping (PageExtractionData<InitialQuery, PaginatedQuery, Model?>) -> P,
     pageResolver: ((P, PaginationDirection) -> PaginatedQuery?)?,
     initialTransform: @escaping (InitialQuery.Data) throws -> Model,
     pageTransform: @escaping (PaginatedQuery.Data) throws -> Model
@@ -107,7 +107,14 @@ public class AsyncGraphQLQueryPager<Model>: Publisher {
       client: client,
       initialQuery: initialQuery,
       watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: extractPageInfo,
+      extractPageInfo: { data in
+        switch data {
+        case .initial(let data, let output):
+          return extractPageInfo(.initial(data, convertOutput(result: output)))
+        case .paginated(let data, let output):
+          return extractPageInfo(.paginated(data, convertOutput(result: output)))
+        }
+      },
       pageResolver: pageResolver
     )
     await self.init(
@@ -115,6 +122,18 @@ public class AsyncGraphQLQueryPager<Model>: Publisher {
       initialTransform: initialTransform,
       pageTransform: pageTransform
     )
+
+    func convertOutput(result: PaginationOutput<InitialQuery, PaginatedQuery>?) -> Model? {
+      guard let result else { return nil }
+
+      let transform: ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> Model = { previousData, initialData, nextData in
+        let previous = try previousData.flatMap { try pageTransform($0) }
+        let initial = try initialTransform(initialData)
+        let next = try nextData.flatMap { try pageTransform($0) }
+        return previous + initial + next
+      }
+      return try? transform(result.previousPages, result.initialPage, result.nextPages)
+    }
   }
 
   /// Subscribe to the results of the pager, with the management of the subscriber being stored internally to the `AnyGraphQLQueryPager`.

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
@@ -5,632 +5,135 @@ import Foundation
 // MARK: - GraphQLQueryPager Convenience Functions
 
 public extension GraphQLQueryPager {
-
-  // MARK: Offset initializers
-
-  static func makeForwardOffsetQueryPager<InitialQuery: GraphQLQuery>(
+  /// Convenience function for creating a pager that has a single query and does not transform output responses.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, P: PaginationInfo>(
     client: ApolloClientProtocol,
     watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Forward
+    initialQuery: InitialQuery,
+    pageResolver: @escaping (P, PaginationDirection) -> InitialQuery,
+    extractPageInfo: @escaping (InitialQuery.Data) -> P
   ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
     GraphQLQueryPager(pager: GraphQLQueryPagerCoordinator(
-      client: client,
-      initialQuery: queryProvider(nil),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        guard direction == .next else { return nil }
-        return queryProvider(page)
-      }
-    ))
-  }
-
-  static func makeForwardOffsetQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Forward,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) -> GraphQLQueryPager {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeForwardOffsetQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Forward,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  static func makeReverseOffsetQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Reverse
-  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    GraphQLQueryPager(pager: GraphQLQueryPagerCoordinator(
-      client: client,
-      initialQuery: queryProvider(nil),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        guard direction == .previous else { return nil }
-        return queryProvider(page)
-      }
-    ))
-  }
-
-  static func makeReverseOffsetQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Reverse,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) -> GraphQLQueryPager {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeReverseOffsetQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Reverse,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  static func makeBidirectionalOffsetQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    start: OffsetPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Bidirectional
-  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    GraphQLQueryPager(pager: GraphQLQueryPagerCoordinator(
-      client: client,
-      initialQuery: queryProvider(start),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        switch direction {
-        case .next:
-          return queryProvider(page)
-        case .previous:
-          return previousQueryProvider(page)
-        }
-      }
-    ))
-  }
-
-  static func makeBidirectionalOffsetQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    start: OffsetPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Bidirectional,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) -> GraphQLQueryPager {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(start),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          switch direction {
-          case .next:
-            return queryProvider(page)
-          case .previous:
-            return previousQueryProvider(page)
-          }
-        }
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeBidirectionalOffsetQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    start: OffsetPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Bidirectional,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(start),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          switch direction {
-          case .next:
-            return queryProvider(page)
-          case .previous:
-            return previousQueryProvider(page)
-          }
-        }
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  // MARK: CursorBasedPagination.Forward Initializers
-
-  /// This convenience function creates an `GraphQLQueryPager` that paginates forward with only one query and has an output type of `Result<(PaginationOutput<InitialQuery, InitialQuery>, UpdateSource), Error>`.
-  /// - Parameters:
-  ///   - client: The Apollo client
-  ///   - watcherDispatchQueue: The preferred dispatch queue for the internal `GraphQLQueryWatcher`s to operate on. Defaults to `main`.
-  ///   - queryProvider: The transform from `CursorBasedPagination.Forward` to `InitialQuery`.
-  ///   - extractPageInfo: The transform from `InitialQuery.Data` to `CursorBasedPagination.Forward`
-  /// - Returns: `GraphQLQueryPager`
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward
-  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    GraphQLQueryPager(pager: GraphQLQueryPagerCoordinator(
-      client: client,
-      initialQuery: queryProvider(nil),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        guard direction == .next else { return nil }
-        return queryProvider(page)
-      }
-    ))
-  }
-
-  /// This convenience function creates an `GraphQLQueryPager` that paginates forward with only one query and has a custom output model.
-  /// - Parameters:
-  ///   - client: The Apollo client
-  ///   - watcherDispatchQueue: The preferred dispatch queue for the internal `GraphQLQueryWatcher`s to operate on. Defaults to `main`.
-  ///   - queryProvider: The transform from `CursorBasedPagination.Forward` to `InitialQuery`.
-  ///   - extractPageInfo: The transform from `InitialQuery.Data` to `CursorBasedPagination.Forward`
-  ///   - transform: The transform from `([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data])` to a custom `Model` type.
-  /// - Returns: `GraphQLQueryPager`
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) -> GraphQLQueryPager {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Forward,
-    nextPageResolver: @escaping (CursorBasedPagination.Forward) -> PaginatedQuery
-  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
-    GraphQLQueryPager(
-      pager: .init(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(
-          initialTransfom: extractInitialPageInfo,
-          paginatedTransform: extractNextPageInfo
-        ),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return nextPageResolver(page)
-        }
-      )
-    )
-  }
-
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Forward,
-    nextPageResolver: @escaping (CursorBasedPagination.Forward) -> PaginatedQuery,
-    transform: @escaping ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> Model
-  ) -> GraphQLQueryPager {
-    GraphQLQueryPager(
-      pager: .makeForwardCursorQueryPager(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractNextPageInfo: extractNextPageInfo,
-        nextPageResolver: nextPageResolver
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Forward,
-    nextPageResolver: @escaping (CursorBasedPagination.Forward) -> PaginatedQuery,
-    initialTransform: @escaping (InitialQuery.Data) throws -> Model,
-    pageTransform: @escaping (PaginatedQuery.Data) throws -> Model
-  ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    GraphQLQueryPager(
-      pager: .makeForwardCursorQueryPager(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractNextPageInfo: extractNextPageInfo,
-        nextPageResolver: nextPageResolver
-      ),
-      initialTransform: initialTransform,
-      pageTransform: pageTransform
-    )
-  }
-
-  // MARK: CursorBasedPagination.Reverse Initializers
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse
-  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    GraphQLQueryPager(pager: GraphQLQueryPagerCoordinator(
-      client: client,
-      initialQuery: queryProvider(nil),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        guard direction == .previous else { return nil }
-        return queryProvider(page)
-      }
-    ))
-  }
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) -> GraphQLQueryPager {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    GraphQLQueryPager(
-      pager: GraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Reverse,
-    nextPageResolver: @escaping (CursorBasedPagination.Reverse) -> PaginatedQuery
-  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
-    GraphQLQueryPager(
-      pager: .init(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(
-          initialTransfom: extractInitialPageInfo,
-          paginatedTransform: extractNextPageInfo
-        ),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return nextPageResolver(page)
-        }
-      )
-    )
-  }
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    extractPreviousPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Reverse,
-    previousPageResolver: @escaping (CursorBasedPagination.Reverse) -> PaginatedQuery,
-    transform: @escaping ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> Model
-  ) -> GraphQLQueryPager {
-    GraphQLQueryPager(
-      pager: .makeReverseCursorQueryPager(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractPreviousPageInfo: extractPreviousPageInfo,
-        previousPageResolver: previousPageResolver
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    extractPreviousPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Reverse,
-    previousPageResolver: @escaping (CursorBasedPagination.Reverse) -> PaginatedQuery,
-    initialTransform: @escaping (InitialQuery.Data) throws -> Model,
-    pageTransform: @escaping (PaginatedQuery.Data) throws -> Model
-  ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    GraphQLQueryPager(
-      pager: .makeReverseCursorQueryPager(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractPreviousPageInfo: extractPreviousPageInfo,
-        previousPageResolver: previousPageResolver
-      ),
-      initialTransform: initialTransform,
-      pageTransform: pageTransform
-    )
-  }
-
-  // MARK: CursorBasedPagination.Bidirectional Initializers
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    start: CursorBasedPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional
-  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    GraphQLQueryPager(pager: .makeBidirectionalCursorQueryPager(
-      client: client,
-      start: start,
-      watcherDispatchQueue: watcherDispatchQueue,
-      queryProvider: queryProvider,
-      previousQueryProvider: previousQueryProvider,
-      extractPageInfo: extractPageInfo
-    ))
-  }
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    start: CursorBasedPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) -> GraphQLQueryPager {
-    GraphQLQueryPager(
-      pager: .makeBidirectionalCursorQueryPager(
-        client: client,
-        start: start,
-        watcherDispatchQueue: watcherDispatchQueue,
-        queryProvider: queryProvider,
-        previousQueryProvider: previousQueryProvider,
-        extractPageInfo: extractPageInfo
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    start: CursorBasedPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    GraphQLQueryPager(
-      pager: .makeBidirectionalCursorQueryPager(
-        client: client,
-        start: start,
-        watcherDispatchQueue: watcherDispatchQueue,
-        queryProvider: queryProvider,
-        previousQueryProvider: previousQueryProvider,
-        extractPageInfo: extractPageInfo
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    extractPaginatedPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Bidirectional
-  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
-    GraphQLQueryPager(pager: .makeBidirectionalCursorQueryPager(
       client: client,
       initialQuery: initialQuery,
       watcherDispatchQueue: watcherDispatchQueue,
-      queryProvider: queryProvider,
-      previousQueryProvider: previousQueryProvider,
-      extractInitialPageInfo: extractInitialPageInfo,
-      extractPaginatedPageInfo: extractPaginatedPageInfo
+      extractPageInfo: pageExtraction(transform: extractPageInfo),
+      pageResolver: pageResolver
     ))
   }
 
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
+  /// Convenience function for creating a pager that has a single query and transforms output responses.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, P: PaginationInfo>(
     client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
     watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    extractPaginatedPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Bidirectional,
-    transform: @escaping ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> Model
+    initialQuery: InitialQuery,
+    pageResolver: @escaping (P, PaginationDirection) -> InitialQuery,
+    extractPageInfo: @escaping (InitialQuery.Data) -> P,
+    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
   ) -> GraphQLQueryPager {
     GraphQLQueryPager(
-      pager: .makeBidirectionalCursorQueryPager(
+      pager: GraphQLQueryPagerCoordinator(
         client: client,
         initialQuery: initialQuery,
         watcherDispatchQueue: watcherDispatchQueue,
-        queryProvider: queryProvider,
-        previousQueryProvider: previousQueryProvider,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractPaginatedPageInfo: extractPaginatedPageInfo
+        extractPageInfo: pageExtraction(transform: extractPageInfo),
+        pageResolver: pageResolver
       ),
       transform: transform
     )
   }
 
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, T>(
+  /// Convenience function for creating a pager that has a single query and transforms output responses into a collection.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, T, P: PaginationInfo>(
+    client: ApolloClientProtocol,
+    watcherDispatchQueue: DispatchQueue = .main,
+    initialQuery: InitialQuery,
+    pageResolver: @escaping (P, PaginationDirection) -> InitialQuery,
+    extractPageInfo: @escaping (InitialQuery.Data) -> P,
+    transform: @escaping (InitialQuery.Data) throws -> Model
+  ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
+    GraphQLQueryPager(
+      pager: GraphQLQueryPagerCoordinator(
+        client: client,
+        initialQuery: initialQuery,
+        watcherDispatchQueue: watcherDispatchQueue,
+        extractPageInfo: pageExtraction(transform: extractPageInfo),
+        pageResolver: pageResolver
+      ),
+      initialTransform: transform,
+      pageTransform: transform
+    )
+  }
+
+  /// Convenience function for creating a multi-query pager that does not transform output responses.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, P: PaginationInfo>(
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    extractPaginatedPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Bidirectional,
+    extractInitialPageInfo: @escaping (InitialQuery.Data) -> P,
+    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
+    pageResolver: @escaping (P, PaginationDirection) -> PaginatedQuery
+  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
+    GraphQLQueryPager(
+      pager: .init(
+        client: client,
+        initialQuery: initialQuery,
+        watcherDispatchQueue: watcherDispatchQueue,
+        extractPageInfo: pageExtraction(
+          initialTransfom: extractInitialPageInfo,
+          paginatedTransform: extractNextPageInfo
+        ),
+        pageResolver: pageResolver
+      )
+    )
+  }
+
+  /// Convenience function for creating a multi-query pager that does transforms output responses.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, P: PaginationInfo>(
+    client: ApolloClientProtocol,
+    initialQuery: InitialQuery,
+    watcherDispatchQueue: DispatchQueue = .main,
+    extractInitialPageInfo: @escaping (InitialQuery.Data) -> P,
+    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
+    pageResolver: @escaping (P, PaginationDirection) -> PaginatedQuery,
+    transform: @escaping ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> Model
+  ) -> GraphQLQueryPager where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
+    GraphQLQueryPager(
+      pager: .init(
+        client: client,
+        initialQuery: initialQuery,
+        watcherDispatchQueue: watcherDispatchQueue,
+        extractPageInfo: pageExtraction(
+          initialTransfom: extractInitialPageInfo,
+          paginatedTransform: extractNextPageInfo
+        ),
+        pageResolver: pageResolver
+      ),
+      transform: transform
+    )
+  }
+
+  /// Convenience function for creating a multi-query pager that transforms output responses into collections
+  static func makeQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, T, P: PaginationInfo>(
+    client: ApolloClientProtocol,
+    initialQuery: InitialQuery,
+    watcherDispatchQueue: DispatchQueue = .main,
+    extractInitialPageInfo: @escaping (InitialQuery.Data) -> P,
+    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
+    pageResolver: @escaping (P, PaginationDirection) -> PaginatedQuery,
     initialTransform: @escaping (InitialQuery.Data) throws -> Model,
     pageTransform: @escaping (PaginatedQuery.Data) throws -> Model
   ) -> GraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
     GraphQLQueryPager(
-      pager: .makeBidirectionalCursorQueryPager(
+      pager: .init(
         client: client,
         initialQuery: initialQuery,
         watcherDispatchQueue: watcherDispatchQueue,
-        queryProvider: queryProvider,
-        previousQueryProvider: previousQueryProvider,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractPaginatedPageInfo: extractPaginatedPageInfo
+        extractPageInfo: pageExtraction(
+          initialTransfom: extractInitialPageInfo,
+          paginatedTransform: extractNextPageInfo
+        ),
+        pageResolver: pageResolver
       ),
       initialTransform: initialTransform,
       pageTransform: pageTransform
@@ -641,303 +144,74 @@ public extension GraphQLQueryPager {
 // MARK: - AsyncGraphQLQueryPager Convenience Functions
 
 public extension AsyncGraphQLQueryPager {
-
-  // MARK: Offset Initializers
-
-  static func makeForwardOffsetQueryPager<InitialQuery: GraphQLQuery>(
+  /// Convenience function for creating a pager that has a single query and does not transform output responses.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, P: PaginationInfo>(
     client: ApolloClientProtocol,
     watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Forward
+    initialQuery: InitialQuery,
+    pageResolver: @escaping (P, PaginationDirection) -> InitialQuery?,
+    extractPageInfo: @escaping (InitialQuery.Data) -> P
   ) async -> AsyncGraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
     await AsyncGraphQLQueryPager(pager: AsyncGraphQLQueryPagerCoordinator(
       client: client,
-      initialQuery: queryProvider(nil),
+      initialQuery: initialQuery,
       watcherDispatchQueue: watcherDispatchQueue,
       extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        guard direction == .next else { return nil }
-        return queryProvider(page)
-      }
+      pageResolver: pageResolver
     ))
   }
 
-  static func makeForwardOffsetQueryPager<InitialQuery: GraphQLQuery>(
+  /// Convenience function for creating a pager that has a single query and transforms output responses.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, P: PaginationInfo>(
     client: ApolloClientProtocol,
     watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Forward,
+    initialQuery: InitialQuery,
+    pageResolver: @escaping (P, PaginationDirection) -> InitialQuery?,
+    extractPageInfo: @escaping (InitialQuery.Data) -> P,
     transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
   ) async -> AsyncGraphQLQueryPager {
     await AsyncGraphQLQueryPager(
       pager: AsyncGraphQLQueryPagerCoordinator(
         client: client,
-        initialQuery: queryProvider(nil),
+        initialQuery: initialQuery,
         watcherDispatchQueue: watcherDispatchQueue,
         extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return queryProvider(page)
-        }
+        pageResolver: pageResolver
       ),
       transform: transform
     )
   }
 
-  static func makeForwardOffsetQueryPager<InitialQuery: GraphQLQuery, T>(
+  /// Convenience function for creating a pager that has a single query and transforms output responses into a collection.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, T, P: PaginationInfo>(
     client: ApolloClientProtocol,
     watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Forward,
+    initialQuery: InitialQuery,
+    pageResolver: @escaping (P, PaginationDirection) -> InitialQuery?,
+    extractPageInfo: @escaping (InitialQuery.Data) -> P,
     transform: @escaping (InitialQuery.Data) throws -> Model
   ) async -> AsyncGraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
     await AsyncGraphQLQueryPager(
       pager: AsyncGraphQLQueryPagerCoordinator(
         client: client,
-        initialQuery: queryProvider(nil),
+        initialQuery: initialQuery,
         watcherDispatchQueue: watcherDispatchQueue,
         extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return queryProvider(page)
-        }
+        pageResolver: pageResolver
       ),
       initialTransform: transform,
       pageTransform: transform
     )
   }
 
-  static func makeReverseOffsetQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Reverse
-  ) async -> AsyncGraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    await AsyncGraphQLQueryPager(pager: AsyncGraphQLQueryPagerCoordinator(
-      client: client,
-      initialQuery: queryProvider(nil),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        guard direction == .previous else { return nil }
-        return queryProvider(page)
-      }
-    ))
-  }
-
-  static func makeReverseOffsetQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Reverse,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) async -> AsyncGraphQLQueryPager {
-    await AsyncGraphQLQueryPager(
-      pager: AsyncGraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeReverseOffsetQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Reverse,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) async -> AsyncGraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    await AsyncGraphQLQueryPager(
-      pager: AsyncGraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  static func makeBidirectionalOffsetQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    start: OffsetPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Bidirectional
-  ) async -> AsyncGraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    await AsyncGraphQLQueryPager(pager: AsyncGraphQLQueryPagerCoordinator(
-      client: client,
-      initialQuery: queryProvider(start),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        switch direction {
-        case .next:
-          return queryProvider(page)
-        case .previous:
-          return previousQueryProvider(page)
-        }
-      }
-    ))
-  }
-
-  static func makeBidirectionalOffsetQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    start: OffsetPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Bidirectional,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) async -> AsyncGraphQLQueryPager {
-    await AsyncGraphQLQueryPager(
-      pager: AsyncGraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(start),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          switch direction {
-          case .next:
-            return queryProvider(page)
-          case .previous:
-            return previousQueryProvider(page)
-          }
-        }
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeBidirectionalOffsetQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    start: OffsetPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (OffsetPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> OffsetPagination.Bidirectional,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) async -> AsyncGraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    await AsyncGraphQLQueryPager(
-      pager: AsyncGraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(start),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          switch direction {
-          case .next:
-            return queryProvider(page)
-          case .previous:
-            return previousQueryProvider(page)
-          }
-        }
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  // MARK: CursorBasedPagination.Forward Initializers
-
-  /// This convenience function creates an `AsyncGraphQLQueryPager` that paginates forward with only one query and has an output type of `Result<(PaginationOutput<InitialQuery, InitialQuery>, UpdateSource), Error>`.
-  /// - Parameters:
-  ///   - client: The Apollo client
-  ///   - watcherDispatchQueue: The preferred dispatch queue for the internal `GraphQLQueryWatcher`s to operate on. Defaults to `main`.
-  ///   - queryProvider: The transform from `CursorBasedPagination.Forward` to `InitialQuery`.
-  ///   - extractPageInfo: The transform from `InitialQuery.Data` to `CursorBasedPagination.Forward`
-  /// - Returns: `AsyncGraphQLQueryPager`
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward
-  ) async -> AsyncGraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    await AsyncGraphQLQueryPager(pager: AsyncGraphQLQueryPagerCoordinator(
-      client: client,
-      initialQuery: queryProvider(nil),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        guard direction == .next else { return nil }
-        return queryProvider(page)
-      }
-    ))
-  }
-
-  /// This convenience function creates an `AsyncGraphQLQueryPager` that paginates forward with only one query and has a custom output model.
-  /// - Parameters:
-  ///   - client: The Apollo client
-  ///   - watcherDispatchQueue: The preferred dispatch queue for the internal `GraphQLQueryWatcher`s to operate on. Defaults to `main`.
-  ///   - queryProvider: The transform from `CursorBasedPagination.Forward` to `InitialQuery`.
-  ///   - extractPageInfo: The transform from `InitialQuery.Data` to `CursorBasedPagination.Forward`
-  ///   - transform: The transform from `([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data])` to a custom `Model` type.
-  /// - Returns: `AsyncGraphQLQueryPager`
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) async -> AsyncGraphQLQueryPager {
-    await AsyncGraphQLQueryPager(
-      pager: AsyncGraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Forward?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) async -> AsyncGraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    await AsyncGraphQLQueryPager(
-      pager: AsyncGraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
+  /// Convenience function for creating a multi-query pager that does not transform output responses.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, P: PaginationInfo>(
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Forward,
-    nextPageResolver: @escaping (CursorBasedPagination.Forward) -> PaginatedQuery
+    extractInitialPageInfo: @escaping (InitialQuery.Data) -> P,
+    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
+    pageResolver: @escaping (P, PaginationDirection) -> PaginatedQuery?
   ) async -> AsyncGraphQLQueryPager where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
     await AsyncGraphQLQueryPager(
       pager: .init(
@@ -948,132 +222,20 @@ public extension AsyncGraphQLQueryPager {
           initialTransfom: extractInitialPageInfo,
           paginatedTransform: extractNextPageInfo
         ),
-        pageResolver: { page, direction in
-          guard direction == .next else { return nil }
-          return nextPageResolver(page)
-        }
+        pageResolver: pageResolver
       )
     )
   }
 
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
+  /// Convenience function for creating a multi-query pager that does transforms output responses.
+  static func makeQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, P: PaginationInfo>(
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Forward,
-    nextPageResolver: @escaping (CursorBasedPagination.Forward) -> PaginatedQuery,
+    extractInitialPageInfo: @escaping (InitialQuery.Data) -> P,
+    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
+    pageResolver: @escaping (P, PaginationDirection) -> PaginatedQuery?,
     transform: @escaping ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> Model
-  ) async -> AsyncGraphQLQueryPager {
-    await AsyncGraphQLQueryPager(
-      pager: .makeForwardCursorQueryPager(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractNextPageInfo: extractNextPageInfo,
-        nextPageResolver: nextPageResolver
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeForwardCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Forward,
-    nextPageResolver: @escaping (CursorBasedPagination.Forward) -> PaginatedQuery,
-    initialTransform: @escaping (InitialQuery.Data) throws -> Model,
-    pageTransform: @escaping (PaginatedQuery.Data) throws -> Model
-  ) async -> AsyncGraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    await AsyncGraphQLQueryPager(
-      pager: .makeForwardCursorQueryPager(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractNextPageInfo: extractNextPageInfo,
-        nextPageResolver: nextPageResolver
-      ),
-      initialTransform: initialTransform,
-      pageTransform: pageTransform
-    )
-  }
-
-  // MARK: CursorBasedPagination.Reverse Initializers
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse
-  ) async -> AsyncGraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    await AsyncGraphQLQueryPager(pager: AsyncGraphQLQueryPagerCoordinator(
-      client: client,
-      initialQuery: queryProvider(nil),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        guard direction == .previous else { return nil }
-        return queryProvider(page)
-      }
-    ))
-  }
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) async -> AsyncGraphQLQueryPager {
-    await AsyncGraphQLQueryPager(
-      pager: AsyncGraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Reverse?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) async -> AsyncGraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    await AsyncGraphQLQueryPager(
-      pager: AsyncGraphQLQueryPagerCoordinator(
-        client: client,
-        initialQuery: queryProvider(nil),
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractPageInfo: pageExtraction(transform: extractPageInfo),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return queryProvider(page)
-        }
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Reverse,
-    nextPageResolver: @escaping (CursorBasedPagination.Reverse) -> PaginatedQuery
   ) async -> AsyncGraphQLQueryPager where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
     await AsyncGraphQLQueryPager(
       pager: .init(
@@ -1084,398 +246,39 @@ public extension AsyncGraphQLQueryPager {
           initialTransfom: extractInitialPageInfo,
           paginatedTransform: extractNextPageInfo
         ),
-        pageResolver: { page, direction in
-          guard direction == .previous else { return nil }
-          return nextPageResolver(page)
-        }
-      )
-    )
-  }
-
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    extractPreviousPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Reverse,
-    previousPageResolver: @escaping (CursorBasedPagination.Reverse) -> PaginatedQuery,
-    transform: @escaping ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> Model
-  ) async -> AsyncGraphQLQueryPager {
-    await AsyncGraphQLQueryPager(
-      pager: .makeReverseCursorQueryPager(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractPreviousPageInfo: extractPreviousPageInfo,
-        previousPageResolver: previousPageResolver
+        pageResolver: pageResolver
       ),
       transform: transform
     )
   }
 
-  static func makeReverseCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, T>(
+  /// Convenience function for creating a multi-query pager that transforms output responses into collections
+  static func makeQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, T, P: PaginationInfo>(
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    extractPreviousPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Reverse,
-    previousPageResolver: @escaping (CursorBasedPagination.Reverse) -> PaginatedQuery,
+    extractInitialPageInfo: @escaping (InitialQuery.Data) -> P,
+    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
+    pageResolver: @escaping (P, PaginationDirection) -> PaginatedQuery?,
     initialTransform: @escaping (InitialQuery.Data) throws -> Model,
     pageTransform: @escaping (PaginatedQuery.Data) throws -> Model
   ) async -> AsyncGraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
     await AsyncGraphQLQueryPager(
-      pager: .makeReverseCursorQueryPager(
+      pager: .init(
         client: client,
         initialQuery: initialQuery,
         watcherDispatchQueue: watcherDispatchQueue,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractPreviousPageInfo: extractPreviousPageInfo,
-        previousPageResolver: previousPageResolver
-      ),
-      initialTransform: initialTransform,
-      pageTransform: pageTransform
-    )
-  }
-
-  // MARK: CursorBasedPagination.Bidirectional Initializers
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    start: CursorBasedPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional
-  ) async -> AsyncGraphQLQueryPager where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    await AsyncGraphQLQueryPager(pager: .makeBidirectionalCursorQueryPager(
-      client: client,
-      start: start,
-      watcherDispatchQueue: watcherDispatchQueue,
-      queryProvider: queryProvider,
-      previousQueryProvider: previousQueryProvider,
-      extractPageInfo: extractPageInfo
-    ))
-  }
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    start: CursorBasedPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) async -> AsyncGraphQLQueryPager {
-    await AsyncGraphQLQueryPager(
-      pager: .makeBidirectionalCursorQueryPager(
-        client: client,
-        start: start,
-        watcherDispatchQueue: watcherDispatchQueue,
-        queryProvider: queryProvider,
-        previousQueryProvider: previousQueryProvider,
-        extractPageInfo: extractPageInfo
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    start: CursorBasedPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    transform: @escaping (InitialQuery.Data) throws -> Model
-  ) async -> AsyncGraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    await AsyncGraphQLQueryPager(
-      pager: .makeBidirectionalCursorQueryPager(
-        client: client,
-        start: start,
-        watcherDispatchQueue: watcherDispatchQueue,
-        queryProvider: queryProvider,
-        previousQueryProvider: previousQueryProvider,
-        extractPageInfo: extractPageInfo
-      ),
-      initialTransform: transform,
-      pageTransform: transform
-    )
-  }
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    extractPaginatedPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Bidirectional
-  ) async -> AsyncGraphQLQueryPager where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
-    await AsyncGraphQLQueryPager(pager: .makeBidirectionalCursorQueryPager(
-      client: client,
-      initialQuery: initialQuery,
-      watcherDispatchQueue: watcherDispatchQueue,
-      queryProvider: queryProvider,
-      previousQueryProvider: previousQueryProvider,
-      extractInitialPageInfo: extractInitialPageInfo,
-      extractPaginatedPageInfo: extractPaginatedPageInfo
-    ))
-  }
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    extractPaginatedPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Bidirectional,
-    transform: @escaping ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> Model
-  ) async -> AsyncGraphQLQueryPager {
-    await AsyncGraphQLQueryPager(
-      pager: .makeBidirectionalCursorQueryPager(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        queryProvider: queryProvider,
-        previousQueryProvider: previousQueryProvider,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractPaginatedPageInfo: extractPaginatedPageInfo
-      ),
-      transform: transform
-    )
-  }
-
-  static func makeBidirectionalCursorQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, T>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    extractPaginatedPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Bidirectional,
-    initialTransform: @escaping (InitialQuery.Data) throws -> Model,
-    pageTransform: @escaping (PaginatedQuery.Data) throws -> Model
-  ) async -> AsyncGraphQLQueryPager where Model: RangeReplaceableCollection, T == Model.Element {
-    await AsyncGraphQLQueryPager(
-      pager: .makeBidirectionalCursorQueryPager(
-        client: client,
-        initialQuery: initialQuery,
-        watcherDispatchQueue: watcherDispatchQueue,
-        queryProvider: queryProvider,
-        previousQueryProvider: previousQueryProvider,
-        extractInitialPageInfo: extractInitialPageInfo,
-        extractPaginatedPageInfo: extractPaginatedPageInfo
+        extractPageInfo: pageExtraction(
+          initialTransfom: extractInitialPageInfo,
+          paginatedTransform: extractNextPageInfo
+        ),
+        pageResolver: pageResolver
       ),
       initialTransform: initialTransform,
       pageTransform: pageTransform
     )
   }
 }
-
-// MARK: - Internal helpers
-
-private extension GraphQLQueryPagerCoordinator {
-  static func makeForwardCursorQueryPager(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Forward,
-    nextPageResolver: @escaping (CursorBasedPagination.Forward) -> PaginatedQuery
-  ) -> GraphQLQueryPagerCoordinator {
-    .init(
-      client: client,
-      initialQuery: initialQuery,
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(
-        initialTransfom: extractInitialPageInfo,
-        paginatedTransform: extractNextPageInfo
-      ),
-      pageResolver: { page, direction in
-        guard direction == .next else { return nil }
-        return nextPageResolver(page)
-      }
-    )
-  }
-
-  static func makeReverseCursorQueryPager(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    extractPreviousPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Reverse,
-    previousPageResolver: @escaping (CursorBasedPagination.Reverse) -> PaginatedQuery
-  ) -> GraphQLQueryPagerCoordinator {
-    .init(
-      client: client,
-      initialQuery: initialQuery,
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(
-        initialTransfom: extractInitialPageInfo,
-        paginatedTransform: extractPreviousPageInfo
-      ),
-      pageResolver: { page, direction in
-        guard direction == .previous else { return nil }
-        return previousPageResolver(page)
-      }
-    )
-  }
-
-  static func makeBidirectionalCursorQueryPager(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    extractPaginatedPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Bidirectional
-  ) -> GraphQLQueryPagerCoordinator {
-    .init(
-      client: client,
-      initialQuery: initialQuery,
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(
-        initialTransfom: extractInitialPageInfo,
-        paginatedTransform: extractPaginatedPageInfo
-      ),
-      pageResolver: { page, direction in
-        switch direction {
-        case .next:
-          return queryProvider(page)
-        case .previous:
-          return previousQueryProvider(page)
-        }
-      }
-    )
-  }
-
-  static func makeBidirectionalCursorQueryPager(
-    client: ApolloClientProtocol,
-    start: CursorBasedPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional
-  ) -> GraphQLQueryPagerCoordinator where InitialQuery == PaginatedQuery {
-    .init(
-      client: client,
-      initialQuery: queryProvider(start),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        switch direction {
-        case .next:
-          return queryProvider(page)
-        case .previous:
-          return previousQueryProvider(page)
-        }
-      }
-    )
-  }
-}
-
-private extension AsyncGraphQLQueryPagerCoordinator {
-  static func makeForwardCursorQueryPager(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Forward,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Forward,
-    nextPageResolver: @escaping (CursorBasedPagination.Forward) -> PaginatedQuery
-  ) -> AsyncGraphQLQueryPagerCoordinator {
-    .init(
-      client: client,
-      initialQuery: initialQuery,
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(
-        initialTransfom: extractInitialPageInfo,
-        paginatedTransform: extractNextPageInfo
-      ),
-      pageResolver: { page, direction in
-        guard direction == .next else { return nil }
-        return nextPageResolver(page)
-      }
-    )
-  }
-
-  static func makeReverseCursorQueryPager(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Reverse,
-    extractPreviousPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Reverse,
-    previousPageResolver: @escaping (CursorBasedPagination.Reverse) -> PaginatedQuery
-  ) -> AsyncGraphQLQueryPagerCoordinator {
-    .init(
-      client: client,
-      initialQuery: initialQuery,
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(
-        initialTransfom: extractInitialPageInfo,
-        paginatedTransform: extractPreviousPageInfo
-      ),
-      pageResolver: { page, direction in
-        guard direction == .previous else { return nil }
-        return previousPageResolver(page)
-      }
-    )
-  }
-
-  static func makeBidirectionalCursorQueryPager(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> PaginatedQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional,
-    extractPaginatedPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.Bidirectional
-  ) -> AsyncGraphQLQueryPagerCoordinator {
-    .init(
-      client: client,
-      initialQuery: initialQuery,
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(
-        initialTransfom: extractInitialPageInfo,
-        paginatedTransform: extractPaginatedPageInfo
-      ),
-      pageResolver: { page, direction in
-        switch direction {
-        case .next:
-          return queryProvider(page)
-        case .previous:
-          return previousQueryProvider(page)
-        }
-      }
-    )
-  }
-
-  static func makeBidirectionalCursorQueryPager(
-    client: ApolloClientProtocol,
-    start: CursorBasedPagination.Bidirectional?,
-    watcherDispatchQueue: DispatchQueue = .main,
-    queryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    previousQueryProvider: @escaping (CursorBasedPagination.Bidirectional?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.Bidirectional
-  ) -> AsyncGraphQLQueryPagerCoordinator where InitialQuery == PaginatedQuery {
-    .init(
-      client: client,
-      initialQuery: queryProvider(start),
-      watcherDispatchQueue: watcherDispatchQueue,
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      pageResolver: { page, direction in
-        switch direction {
-        case .next:
-          return queryProvider(page)
-        case .previous:
-          return previousQueryProvider(page)
-        }
-      }
-    )
-  }
-}
-
 private func pageExtraction<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, P: PaginationInfo, T>(
   initialTransfom: @escaping (InitialQuery.Data) -> P,
   paginatedTransform: @escaping (PaginatedQuery.Data) -> P

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
@@ -1476,26 +1476,26 @@ private extension AsyncGraphQLQueryPagerCoordinator {
   }
 }
 
-private func pageExtraction<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, P: PaginationInfo>(
+private func pageExtraction<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, P: PaginationInfo, T>(
   initialTransfom: @escaping (InitialQuery.Data) -> P,
   paginatedTransform: @escaping (PaginatedQuery.Data) -> P
-) -> (PageExtractionData<InitialQuery, PaginatedQuery>) -> P {
+) -> (PageExtractionData<InitialQuery, PaginatedQuery, T>) -> P {
   { extractionData in
     switch extractionData {
-    case .initial(let value):
+    case .initial(let value, _):
       return initialTransfom(value)
-    case .paginated(let value):
+    case .paginated(let value, _):
       return paginatedTransform(value)
     }
   }
 }
 
-private func pageExtraction<InitialQuery: GraphQLQuery, P: PaginationInfo>(
+private func pageExtraction<InitialQuery: GraphQLQuery, P: PaginationInfo, T>(
   transform: @escaping (InitialQuery.Data) -> P
-) -> (PageExtractionData<InitialQuery, InitialQuery>) -> P {
+) -> (PageExtractionData<InitialQuery, InitialQuery, T>) -> P {
   { extractionData in
     switch extractionData {
-    case .initial(let value), .paginated(let value):
+    case .initial(let value, _), .paginated(let value, _):
       return transform(value)
     }
   }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -71,15 +71,27 @@ public class GraphQLQueryPager<Model>: Publisher {
     )
   }
 
-  /// For most use-cases, it's recommended to use the static `make...` functions instead of this initializer.
-  /// - Parameters:
-  ///   - client: The Apollo client
-  ///   - initialQuery: The initial query to be performed.
-  ///   - watcherDispatchQueue: The queue that the internal `GraphQLQueryWatcher`s dispatch their results to. Defaults to `main`.
-  ///   - extractPageInfo: This transforming function extracts a `PaginationInfo` from either `InitialQuery.Data` or `PaginatedQuery.Data`, represented in the form of `PageExtractionData`.
-  ///   - pageResolver: This transforming function initializes a new `PaginatedQuery` given a `PagiantionInfo` and `PaginationDirection`.
-  ///   - initialTransform: Transforms the `InitialQuery.Data` to a `Model` type.
-  ///   - pageTransform: Transforms the `PaginatedQuery.Data` to a `Model` type.
+  public convenience init<
+    P: PaginationInfo,
+    InitialQuery: GraphQLQuery,
+    PaginatedQuery: GraphQLQuery
+  >(
+    client: ApolloClientProtocol,
+    initialQuery: InitialQuery,
+    watcherDispatchQueue: DispatchQueue = .main,
+    extractPageInfo: @escaping (PageExtractionData<InitialQuery, PaginatedQuery, Model?>) -> P,
+    pageResolver: ((P, PaginationDirection) -> PaginatedQuery?)?
+  ) where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
+    let pager = GraphQLQueryPagerCoordinator(
+      client: client,
+      initialQuery: initialQuery,
+      watcherDispatchQueue: watcherDispatchQueue,
+      extractPageInfo: extractPageInfo,
+      pageResolver: pageResolver
+    )
+    self.init(pager: pager)
+  }
+
   public convenience init<
     P: PaginationInfo,
     InitialQuery: GraphQLQuery,

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPagerCoordinator.swift
@@ -43,7 +43,7 @@ class GraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQuery: G
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     watcherDispatchQueue: DispatchQueue = .main,
-    extractPageInfo: @escaping (PageExtractionData<InitialQuery, PaginatedQuery>) -> P,
+    extractPageInfo: @escaping (PageExtractionData<InitialQuery, PaginatedQuery, PaginationOutput<InitialQuery, PaginatedQuery>?>) -> P,
     pageResolver: ((P, PaginationDirection) -> PaginatedQuery?)?
   ) {
     pager = .init(

--- a/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/Bidirectional.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/Bidirectional.swift
@@ -1,0 +1,13 @@
+extension OffsetPagination {
+  public struct Bidirectional: PaginationInfo, Hashable {
+    public let offset: Int
+    public var canLoadNext: Bool
+    public let canLoadPrevious: Bool
+
+    public init(offset: Int, canLoadNext: Bool, canLoadPrevious: Bool) {
+      self.offset = offset
+      self.canLoadNext = canLoadNext
+      self.canLoadPrevious = canLoadPrevious
+    }
+  }
+}

--- a/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/ForwardOffset.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/ForwardOffset.swift
@@ -1,0 +1,13 @@
+extension OffsetPagination {
+  public struct Forward: PaginationInfo, Hashable {
+    public let offset: Int
+    public let canLoadNext: Bool
+    public var canLoadPrevious: Bool { false }
+
+    public init(offset: Int, canLoadNext: Bool) {
+      self.offset = offset
+      self.canLoadNext = canLoadNext
+    }
+  }
+
+}

--- a/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/OffsetPagination.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/OffsetPagination.swift
@@ -1,10 +1,1 @@
-public struct OffsetPagination: PaginationInfo, Hashable {
-  public let offset: Int
-  public let canLoadNext: Bool
-  public var canLoadPrevious: Bool { false }
-
-  public init(offset: Int, canLoadNext: Bool) {
-    self.offset = offset
-    self.canLoadNext = canLoadNext
-  }
-}
+public enum OffsetPagination { }

--- a/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/ReverseOffset.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/ReverseOffset.swift
@@ -1,0 +1,13 @@
+extension OffsetPagination {
+  public struct Reverse: PaginationInfo, Hashable {
+    public let offset: Int
+    public var canLoadNext: Bool { false }
+    public let canLoadPrevious: Bool
+
+    public init(offset: Int, canLoadPrevious: Bool) {
+      self.offset = offset
+      self.canLoadPrevious = canLoadPrevious
+    }
+  }
+
+}

--- a/apollo-ios-pagination/Sources/ApolloPagination/PageExtractionData.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/PageExtractionData.swift
@@ -1,7 +1,7 @@
 import ApolloAPI
 
 /// The result of either the initial query or the paginated query, for the purpose of extracting a `PageInfo` from it.
-public enum PageExtractionData<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery> {
-  case initial(InitialQuery.Data)
-  case paginated(PaginatedQuery.Data)
+public enum PageExtractionData<InitialQuery: GraphQLQuery, PaginatedQuery: GraphQLQuery, T> {
+  case initial(InitialQuery.Data, T)
+  case paginated(PaginatedQuery.Data, T)
 }


### PR DESCRIPTION
Follow-up from https://github.com/apollographql/apollo-ios-dev/pull/267

___

When writing docs in #262, I recognized that support for offset pagination could be better. Specifically:

- We can support more paging types (reverse, bidirectional)
- We can support multi-query paging.

As such, this pull request modifies the OffsetPagination class to be a namespace, just like CursorBasedPagination. We introduce three new structs to facilitate pagination:

- `OffsetPagination.Forward`: Introduced OffsetPagination.Forward structure to represent a forward pagination state. This is identical to the previous contents of OffsetPagination.
- `OffsetPagination.Reverse`: Introduced OffsetPagination.Reverse structure to represent a reverse pagination state.
- `OffsetPagination.Bidirectional`: Introduced OffsetPagination.Bidirectional structure to represent a bidirectional pagination state.

Once introduced, I added tests to use an offset pagination scheme.
The tests made clear that offset-pagination needs the full set of existing data in order to properly determine whether the end of the list had been reached. 

As a result, there were changes to the `PageExtractionData` type to include an additional value. Classes and tests were updated accordingly.

Finally, we generalized and deleted the many convenience functions present – we are working under the assumption that if a user is primarily only using one pagination type, that they can trivially create their own extension.  In order to facilitate the user adding their own extensions, two new initializers were added to both `GraphQLQueryPager` and `AsyncGraphQLQueryPager`.




___

🤖🤖  **Copilot Generated Summary** 🤖🤖

This pull request includes changes to the ApolloPaginationTests in the Apollo iOS SDK. The changes focus on modifying the way the `AsyncGraphQLQueryPager` is created and how it handles pagination, as well as updating the `extractPageInfo` function in multiple test classes. 

Here are the most important changes:

Changes to `AsyncGraphQLQueryPager` creation:

* [`Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift`](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL25-L42): The `AsyncGraphQLQueryPager` is now created with `makeQueryPager` instead of `makeForwardCursorQueryPager`. The `queryProvider` has been replaced with an `initialQuery` and a closure that provides a new query based on the page and direction. This allows for the handling of both next and previous pages. The `extractPageInfo` function has also been updated to handle both initial and paginated data. [[1]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL25-L42) [[2]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL69-L86) [[3]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL119-L142) [[4]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL169-L192)

Changes to `extractPageInfo` function:

* [`Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerCoordinatorTests.swift`](diffhunk://#diff-1c873893b39169b06dfc0bd7bbb4a2f27750aaf60760f5a5260238ac96c20934L175-R175): The `extractPageInfo` function in `AsyncGraphQLQueryPagerCoordinatorTests` has been updated to handle both initial and paginated data. [[1]](diffhunk://#diff-1c873893b39169b06dfc0bd7bbb4a2f27750aaf60760f5a5260238ac96c20934L175-R175) [[2]](diffhunk://#diff-1c873893b39169b06dfc0bd7bbb4a2f27750aaf60760f5a5260238ac96c20934L204-R204)
* [`Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift`](diffhunk://#diff-28d8e35fdde972609288a83c7dbed4ec5071b0ccfdd831a05706ada1d10ad882L43-R43): The `extractPageInfo` function in `GraphQLQueryPagerTests` has been updated to handle both initial and paginated data. [[1]](diffhunk://#diff-28d8e35fdde972609288a83c7dbed4ec5071b0ccfdd831a05706ada1d10ad882L43-R43) [[2]](diffhunk://#diff-28d8e35fdde972609288a83c7dbed4ec5071b0ccfdd831a05706ada1d10ad882L72-R72)
* [`Tests/ApolloPaginationTests/GraphQLQueryPagerTestsCoordinator.swift`](diffhunk://#diff-2b7886129fe81de47b21ef62b0c70cb502e9b78267cc8fa716e27e6d5affbdcbL130-R130): The `extractPageInfo` function in `GraphQLQueryPagerTestsCoordinator` has been updated to handle both initial and paginated data.
* [`Tests/ApolloPaginationTests/ReversePaginationTests.swift`](diffhunk://#diff-c48c1aac75aa0633d238dab1d6c2b05ba346052cfc941aa1ecc50166c53eba43L121-R121): The `extractPageInfo` function in `ReversePaginationTests` has been updated to handle both initial and paginated data.

Addition of new test:

* [`Tests/ApolloPaginationTests/OffsetTests.swift`](diffhunk://#diff-849d1616469c55001c042bc3f8f1c168399a12a377a5522115b5da5bebf6559dR1-R130): A new test file `OffsetTests.swift` was added to test the handling of offset pagination.