### PR TITLE
docs: Minor addition to clarify option

### DIFF
--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -484,7 +484,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     public let warningsOnDeprecatedUsage: Composition
     /// Rules for how to convert the names of values from the schema in generated code.
     public let conversionStrategies: ConversionStrategies
-    /// Whether unused generated files will be automatically deleted.
+    /// Whether unused previously generated files will be automatically deleted.
     ///
     /// This will automatically delete any previously generated files that no longer
     /// would be generated.


### PR DESCRIPTION
This change is a minor one to clarify which files will be deleted in the single line that most people read.

Read as a whole it's unambiguous which files will be deleted by this option but I think it's easy for readers to gloss over the expanded "This includes" section that goes into detail about when a file will be no longer generated and therefore deleted.