### PR TITLE
docs: Fix non-functional links in migration guide

### DIFF
--- a/docs/source/migrations/1.0.mdx
+++ b/docs/source/migrations/1.0.mdx
@@ -53,10 +53,10 @@ Apollo iOS's code generation engine provides flexible configuration options that
 > To learn about how you can best integrate Apollo iOS to suit your project's needs, see our [Project configuration documentation](../project-configuration/intro).
 
 To migrate to Apollo iOS 1.0, you'll do the following:
-1. [Update your Apollo iOS dependency](#1-update-to-apollo-ios-10)
-2. [Setup code generation](#2-set-up-code-generation)
-3. [Replace the code generation build phase](#3-replace-the-code-generation-build-phase)
-4. [Refactor your code to use new APIs](#4-refactor-your-code)
+1. [Update your Apollo iOS dependency](#step-1-upgrade-to-apollo-ios-10)
+2. [Setup code generation](#step-2-set-up-code-generation)
+3. [Replace the code generation build phase](#step-3-replace-the-code-generation-build-phase)
+4. [Refactor your code to use new APIs](#step-4-refactor-your-code)
 
 Much of this migration process involves the new code generation mechanism.
 


### PR DESCRIPTION
Thanks for great documentation! I fixed links in migration guide that may not function as expected.