### PR TITLE
[ApolloPagination] Add completion callbacks to fetch and refetch in GraphQLQueryPager for API Consistency

### DIFF
--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -228,7 +228,10 @@ public class GraphQLQueryPager<Model>: Publisher {
   }
 
   /// Discards pagination state and fetches the first page from scratch.
-  /// - Parameter cachePolicy: The apollo cache policy to trigger the first fetch with. Defaults to `fetchIgnoringCacheData`.
+  /// - Parameters:
+  ///   - cachePolicy: The apollo cache policy to trigger the first fetch with. Defaults to `fetchIgnoringCacheData`.
+  ///   - callbackQueue: The `DispatchQueue` that the `completion` fires on. Defaults to `main`.
+  ///   - completion: A completion block that will always trigger after the execution of this  operation.
   public func refetch(
     cachePolicy: CachePolicy = .fetchIgnoringCacheData,
     callbackQueue: DispatchQueue = .main,
@@ -238,6 +241,9 @@ public class GraphQLQueryPager<Model>: Publisher {
   }
 
   /// Fetches the first page.
+  /// - Parameters:
+  ///   - callbackQueue: The `DispatchQueue` that the `completion` fires on. Defaults to `main`.
+  ///   - completion: A completion block that will always trigger after the execution of this  operation.
   public func fetch(
     callbackQueue: DispatchQueue = .main,
     completion: (() -> Void)? = nil

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -229,13 +229,20 @@ public class GraphQLQueryPager<Model>: Publisher {
 
   /// Discards pagination state and fetches the first page from scratch.
   /// - Parameter cachePolicy: The apollo cache policy to trigger the first fetch with. Defaults to `fetchIgnoringCacheData`.
-  public func refetch(cachePolicy: CachePolicy = .fetchIgnoringCacheData) {
-    pager.refetch(cachePolicy: cachePolicy)
+  public func refetch(
+    cachePolicy: CachePolicy = .fetchIgnoringCacheData,
+    callbackQueue: DispatchQueue = .main,
+    completion: (() -> Void)? = nil
+  ) {
+    pager.refetch(cachePolicy: cachePolicy, callbackQueue: callbackQueue, completion: completion)
   }
 
   /// Fetches the first page.
-  public func fetch() {
-    pager.fetch()
+  public func fetch(
+    callbackQueue: DispatchQueue = .main,
+    completion: (() -> Void)? = nil
+  ) {
+    pager.fetch(callbackQueue: callbackQueue, completion: completion)
   }
 
   /// Resets pagination state and cancels in-flight updates from the pager.


### PR DESCRIPTION
For API consistency, it makes sense that both `fetch` and `refetch` have completion blocks to indicate when their operations are completed. If we think about the way that the `Async` variant works, we always have a "completion" signal in the form of the `await` – whereas we don't for `fetch` and `refetch` in the `GraphQLQueryPager`. 


____

Related: https://github.com/apollographql/apollo-ios/issues/3349

___

Changes in `GraphQLQueryPager.swift`:

* [`public class GraphQLQueryPager<Model>: Publisher {`](diffhunk://#diff-15b3e5571b28a433475df3ef139318cd9aa539ef1302cd4e4600639fbb8d57aaL232-R245): The `refetch` and `fetch` methods have been updated to include two new parameters: `callbackQueue` and `completion`. This allows users to specify a dispatch queue on which the completion callback should be fired and a completion block that triggers after the operation execution.

Changes in `GraphQLQueryPagerCoordinator.swift`:

* [`public protocol PagerType {`](diffhunk://#diff-55a381cd001c8f61f1ea8b3de40ecb0cfd97d4fadf68641fa77317dcb0ca8d2cL28-R36): The `refetch` and `fetch` methods in the `PagerType` protocol have been updated to include the `callbackQueue` and `completion` parameters, aligning with the changes made in the `GraphQLQueryPager` class.
* `class GraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQuery: G`: The `refetch` and `fetch` methods have been updated to include the `callbackQueue` and `completion` parameters. This allows users to specify a dispatch queue on which the completion callback should be fired and a completion block that triggers after the operation execution. [[1]](diffhunk://#diff-55a381cd001c8f61f1ea8b3de40ecb0cfd97d4fadf68641fa77317dcb0ca8d2cL154-R171) [[2]](diffhunk://#diff-55a381cd001c8f61f1ea8b3de40ecb0cfd97d4fadf68641fa77317dcb0ca8d2cL165-R188)