### PR TITLE
[ApolloPagination] Declare canLoadPrevious and canLoadNext @Atomic

### DIFF
--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPagerCoordinator.swift
@@ -64,8 +64,8 @@ class GraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQuery: G
         Task { [weak self] in
           guard let self else { return }
           let (canLoadNext, canLoadPrevious) = await self.pager.canLoadPages
-          self.canLoadNext = canLoadNext
-          self.canLoadPrevious = canLoadPrevious
+          self.$canLoadNext.mutate { $0 = canLoadNext }
+          self.$canLoadPrevious.mutate { $0 = canLoadPrevious }
         }
       }
       await subscriptions.store(subscription: publishSubscriber)
@@ -89,9 +89,9 @@ class GraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQuery: G
   }
 
   /// Whether or not we can load the next page. Initializes with a `false` value that is updated after the initial fetch.
-  var canLoadNext: Bool = false
+  @Atomic var canLoadNext: Bool = false
   /// Whether or not we can load the previous page. Initializes with a `false` value that is updated after the initial fetch.
-  var canLoadPrevious: Bool = false
+  @Atomic var canLoadPrevious: Bool = false
 
   /// Reset all pagination state and cancel all in-flight operations.
   func reset() {


### PR DESCRIPTION
This pull request adds the `@Atomic` property wrapper to the `canLoadNext` and `canLoadPrevious` values. 

I noticed these two were popping up in the address sanitizer as a possible data race. I don't believe there was one – but this should at least quiet those warnings. 

___

🤖 Copilot Generated 🤖 

This pull request primarily focuses on improving the thread-safety of the `GraphQLQueryPagerCoordinator` class in the `apollo-ios-pagination` package. The changes involve converting the `canLoadNext` and `canLoadPrevious` properties to atomic properties and updating the way they are mutated.

Here are the most important changes:

Thread-safety improvements:

* [`apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPagerCoordinator.swift`](diffhunk://#diff-55a381cd001c8f61f1ea8b3de40ecb0cfd97d4fadf68641fa77317dcb0ca8d2cL92-R94): The `canLoadNext` and `canLoadPrevious` variables have been modified to use the `@Atomic` property wrapper, ensuring that changes to these variables are thread-safe.
* [`apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPagerCoordinator.swift`](diffhunk://#diff-55a381cd001c8f61f1ea8b3de40ecb0cfd97d4fadf68641fa77317dcb0ca8d2cL67-R68): The assignment of values to `canLoadNext` and `canLoadPrevious` has been changed to use the `mutate` method provided by the `@Atomic` property wrapper. This ensures that the assignment operation is atomic, further improving thread-safety.