### PR TITLE
[ApolloPagination] Add conditional `Equatable` conformance to pagers

### DIFF
--- a/Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift
@@ -324,4 +324,35 @@ final class GraphQLQueryPagerTests: XCTestCase {
     await fulfillment(of: [callbackExpectation, secondPageExpectation], timeout: 1)
   }
 
+  func test_equatable() {
+    let pagerA = GraphQLQueryPager(pager: createPager(), transform: { previous, initial, next in
+      let allPages = previous + [initial] + next
+      return allPages.flatMap { data in
+        data.hero.friendsConnection.friends.map { $0.name }
+      }
+    })
+
+    let pagerB = GraphQLQueryPager(pager: createPager(), transform: { previous, initial, next in
+      let allPages = previous + [initial] + next
+      return allPages.flatMap { data in
+        data.hero.friendsConnection.friends.map { $0.name }
+      }
+    })
+
+    XCTAssertEqual(pagerA, pagerB)
+
+    pagerA._subject.send(.success((["Al-Khwarizmi", "Al-Jaziri", "Charles Babbage", "Ada Lovelace"], .cache)))
+    XCTAssertNotEqual(pagerA, pagerB)
+
+    pagerB._subject.send(.success((["Al-Khwarizmi", "Al-Jaziri", "Charles Babbage", "Ada Lovelace"], .cache)))
+    XCTAssertEqual(pagerA, pagerB)
+
+    pagerA._subject.send(.success((["Al-Khwarizmi", "Al-Jaziri", "Charles Babbage", "Ada Lovelace"], .fetch)))
+    XCTAssertNotEqual(pagerA, pagerB)
+
+    pagerB._subject.send(.success((["Al-Khwarizmi", "Al-Jaziri", "Charles Babbage", "Ada Lovelace"], .fetch)))
+    pagerA.reset()
+    XCTAssertEqual(pagerA, pagerB)
+  }
+
 }

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
@@ -256,6 +256,8 @@ extension AsyncGraphQLQueryPager: Equatable where Model: Equatable {
       return leftValue == rightValue && leftSource == rightSource
     case (.failure(let leftError), .failure(let rightError)):
       return leftError.localizedDescription == rightError.localizedDescription
+    case (.none, .none):
+      return true
     default:
       return false
     }

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
@@ -245,3 +245,19 @@ public class AsyncGraphQLQueryPager<Model>: Publisher {
     publisher.subscribe(subscriber)
   }
 }
+
+extension AsyncGraphQLQueryPager: Equatable where Model: Equatable {
+  public static func == (lhs: AsyncGraphQLQueryPager<Model>, rhs: AsyncGraphQLQueryPager<Model>) -> Bool {
+    let left = lhs._subject.value
+    let right = rhs._subject.value
+
+    switch (left, right) {
+    case (.success((let leftValue, let leftSource)), .success((let rightValue, let rightSource))):
+      return leftValue == rightValue && leftSource == rightSource
+    case (.failure(let leftError), .failure(let rightError)):
+      return leftError.localizedDescription == rightError.localizedDescription
+    default:
+      return false
+    }
+  }
+}

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -260,6 +260,8 @@ extension GraphQLQueryPager: Equatable where Model: Equatable {
       return leftValue == rightValue && leftSource == rightSource
     case (.failure(let leftError), .failure(let rightError)):
       return leftError.localizedDescription == rightError.localizedDescription
+    case (.none, .none):
+      return true
     default:
       return false
     }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -249,3 +249,19 @@ public class GraphQLQueryPager<Model>: Publisher {
     publisher.subscribe(subscriber)
   }
 }
+
+extension GraphQLQueryPager: Equatable where Model: Equatable {
+  public static func == (lhs: GraphQLQueryPager<Model>, rhs: GraphQLQueryPager<Model>) -> Bool {
+    let left = lhs._subject.value
+    let right = rhs._subject.value
+
+    switch (left, right) {
+    case (.success((let leftValue, let leftSource)), .success((let rightValue, let rightSource))):
+      return leftValue == rightValue && leftSource == rightSource
+    case (.failure(let leftError), .failure(let rightError)):
+      return leftError.localizedDescription == rightError.localizedDescription
+    default:
+      return false
+    }
+  }
+}

--- a/apollo-ios-pagination/Sources/ApolloPagination/UpdateSource.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/UpdateSource.swift
@@ -1,3 +1,3 @@
-public enum UpdateSource {
+public enum UpdateSource: Hashable {
   case fetch, cache
 }


### PR DESCRIPTION
A bit of an idea I had to ease usage in SwiftUI.

If an `@Observable` view model owns a pager, we cannot observe value changes (`onChange(...)`) of the whole `viewModel`, as the pager breaks conformance. Whether that's a good pattern or not (I think _probably not?_) is a bit besides the point, as I can see some users doing it anyways. 

There are various values stored on the pager classes – the underlying coordinator, the cancellables, etc – but at its core, the underlying data state is what matters, i.e., the value of `_subject`. 

Note: I don't think I can return `lhs._subject.value == rhs._subject.value` since the value is a `Result<(Model, UpdateSource), Error>`. Even if `Model`, `UpdateSource`, and `Error`, are equatable, the tuple value of `(Model, UpdateSource)` is not equatable – thus failing to translate conditional equatability to the `Result`.

___

🤖 Copilot Generated 🤖 

This pull request includes changes to the Apollo iOS Pagination package to improve the comparability and hashability of certain classes and enums. The most important changes include adding `Equatable` conformance to `AsyncGraphQLQueryPager` and `GraphQLQueryPager` classes, and making the `UpdateSource` enum `Hashable`.

Here are the most significant changes:

* [`apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift`](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1R248-R263): Added `Equatable` protocol conformance to `AsyncGraphQLQueryPager`. This allows for equality comparison between instances of `AsyncGraphQLQueryPager` where `Model` is also `Equatable`. The equality is determined by comparing the values and sources of the subjects of the two `AsyncGraphQLQueryPager` instances, or by comparing the localized descriptions of their errors if they both have errors.

* [`apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift`](diffhunk://#diff-15b3e5571b28a433475df3ef139318cd9aa539ef1302cd4e4600639fbb8d57aaR252-R267): Similarly, the `GraphQLQueryPager` class now conforms to the `Equatable` protocol. The equality comparison is done in the same way as for `AsyncGraphQLQueryPager`.

* [`apollo-ios-pagination/Sources/ApolloPagination/UpdateSource.swift`](diffhunk://#diff-1b96ca532f31d2f77a8a78b720248a4cb0e29f641c22f887b0d3d9756648ed56L1-R1): The `UpdateSource` enum now conforms to the `Hashable` protocol. This allows instances of `UpdateSource` to be used in sets or as dictionary keys.