### PR TITLE
[ApolloPagination] Remove `async` requirement from `AsyncGraphQLQueryPager` initializers

### DIFF
--- a/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
@@ -28,7 +28,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       "first": 2,
       "after": GraphQLNullable<String>.null
     ]
-    let pager = await AsyncGraphQLQueryPager(
+    let pager = AsyncGraphQLQueryPager(
       client: client,
       initialQuery: initialQuery,
       extractPageInfo: { data in
@@ -84,7 +84,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       "first": 2,
       "after": GraphQLNullable<String>.null
     ]
-    let pager = await AsyncGraphQLQueryPager(
+    let pager = AsyncGraphQLQueryPager(
       client: client,
       initialQuery: initialQuery,
       extractPageInfo: { data in
@@ -146,7 +146,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       "first": 2,
       "after": GraphQLNullable<String>.null
     ]
-    let pager = await AsyncGraphQLQueryPager(
+    let pager = AsyncGraphQLQueryPager(
       client: client,
       initialQuery: initialQuery,
       extractPageInfo: { data in
@@ -208,7 +208,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       "first": 2,
       "after": GraphQLNullable<String>.null
     ]
-    let pager = await AsyncGraphQLQueryPager(
+    let pager = AsyncGraphQLQueryPager(
       client: client,
       initialQuery: initialQuery,
       extractPageInfo: { data in
@@ -273,7 +273,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       let name: String
     }
 
-    let anyPager = await createPager().eraseToAnyPager { data in
+    let anyPager = createPager().eraseToAnyPager { data in
       data.hero.friendsConnection.friends.map {
         ViewModel(name: $0.name)
       }
@@ -306,7 +306,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
   }
 
   func test_passesBackSeparateData() async throws {
-    let anyPager = await createPager().eraseToAnyPager { _, initial, next in
+    let anyPager = createPager().eraseToAnyPager { _, initial, next in
       if let latestPage = next.last {
         return latestPage.hero.friendsConnection.friends.last?.name
       }

--- a/Tests/ApolloPaginationTests/OffsetTests.swift
+++ b/Tests/ApolloPaginationTests/OffsetTests.swift
@@ -58,7 +58,7 @@ final class OffsetTests: XCTestCase {
         return nextQuery
       }
     )
-    return await AsyncGraphQLQueryPager(pager: pager)
+    return AsyncGraphQLQueryPager(pager: pager)
   }
 
   // This is due to a timing issue in unit tests only wherein we deinit immediately after waiting for expectations

--- a/Tests/ApolloPaginationTests/PagerCoordinator+Erase.swift
+++ b/Tests/ApolloPaginationTests/PagerCoordinator+Erase.swift
@@ -32,8 +32,8 @@ extension GraphQLQueryPagerCoordinator {
 extension AsyncGraphQLQueryPagerCoordinator {
   nonisolated func eraseToAnyPager<T>(
     transform: @escaping ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> T
-  ) async -> AsyncGraphQLQueryPager<T> {
-    await AsyncGraphQLQueryPager(
+  ) -> AsyncGraphQLQueryPager<T> {
+    AsyncGraphQLQueryPager(
       pager: self,
       transform: transform
     )
@@ -42,8 +42,8 @@ extension AsyncGraphQLQueryPagerCoordinator {
   nonisolated func eraseToAnyPager<T, S: RangeReplaceableCollection>(
     initialTransform: @escaping (InitialQuery.Data) throws -> S,
     pageTransform: @escaping (PaginatedQuery.Data) throws -> S
-  ) async -> AsyncGraphQLQueryPager<S> where T == S.Element {
-    await AsyncGraphQLQueryPager(
+  ) -> AsyncGraphQLQueryPager<S> where T == S.Element {
+    AsyncGraphQLQueryPager(
       pager: self,
       initialTransform: initialTransform,
       pageTransform: pageTransform
@@ -52,8 +52,8 @@ extension AsyncGraphQLQueryPagerCoordinator {
 
   nonisolated func eraseToAnyPager<T, S: RangeReplaceableCollection>(
     transform: @escaping (InitialQuery.Data) throws -> S
-  ) async -> AsyncGraphQLQueryPager<S> where InitialQuery == PaginatedQuery, T == S.Element {
-    await AsyncGraphQLQueryPager(
+  ) -> AsyncGraphQLQueryPager<S> where InitialQuery == PaginatedQuery, T == S.Element {
+    AsyncGraphQLQueryPager(
       pager: self,
       initialTransform: transform,
       pageTransform: transform

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
@@ -159,8 +159,8 @@ public extension AsyncGraphQLQueryPager {
     initialQuery: InitialQuery,
     extractPageInfo: @escaping (InitialQuery.Data) -> P,
     pageResolver: @escaping (P, PaginationDirection) -> InitialQuery?
-  ) async where Model == PaginationOutput<InitialQuery, InitialQuery> {
-    await self.init(
+  ) where Model == PaginationOutput<InitialQuery, InitialQuery> {
+    self.init(
       pager: AsyncGraphQLQueryPagerCoordinator(
         client: client,
         initialQuery: initialQuery,
@@ -179,8 +179,8 @@ public extension AsyncGraphQLQueryPager {
     extractPageInfo: @escaping (InitialQuery.Data) -> P,
     pageResolver: @escaping (P, PaginationDirection) -> InitialQuery?,
     transform: @escaping ([InitialQuery.Data], InitialQuery.Data, [InitialQuery.Data]) throws -> Model
-  ) async {
-    await self.init(
+  ) {
+    self.init(
       pager: AsyncGraphQLQueryPagerCoordinator(
         client: client,
         initialQuery: initialQuery,
@@ -201,8 +201,8 @@ public extension AsyncGraphQLQueryPager {
     extractPageInfo: @escaping (InitialQuery.Data) -> P,
     pageResolver: @escaping (P, PaginationDirection) -> InitialQuery?,
     transform: @escaping (InitialQuery.Data) throws -> Model
-  ) async where Model: RangeReplaceableCollection, T == Model.Element {
-    await self.init(
+  ) where Model: RangeReplaceableCollection, T == Model.Element {
+    self.init(
       pager: AsyncGraphQLQueryPagerCoordinator(
         client: client,
         initialQuery: initialQuery,
@@ -224,8 +224,8 @@ public extension AsyncGraphQLQueryPager {
     extractInitialPageInfo: @escaping (InitialQuery.Data) -> P,
     extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
     pageResolver: @escaping (P, PaginationDirection) -> PaginatedQuery?
-  ) async where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
-    await self.init(
+  ) where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
+    self.init(
       pager: .init(
         client: client,
         initialQuery: initialQuery,
@@ -249,8 +249,8 @@ public extension AsyncGraphQLQueryPager {
     extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
     pageResolver: @escaping (P, PaginationDirection) -> PaginatedQuery?,
     transform: @escaping ([PaginatedQuery.Data], InitialQuery.Data, [PaginatedQuery.Data]) throws -> Model
-  ) async where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
-    await self.init(
+  ) where Model == PaginationOutput<InitialQuery, PaginatedQuery> {
+    self.init(
       pager: .init(
         client: client,
         initialQuery: initialQuery,
@@ -276,8 +276,8 @@ public extension AsyncGraphQLQueryPager {
     pageResolver: @escaping (P, PaginationDirection) -> PaginatedQuery?,
     initialTransform: @escaping (InitialQuery.Data) throws -> Model,
     pageTransform: @escaping (PaginatedQuery.Data) throws -> Model
-  ) async where Model: RangeReplaceableCollection, T == Model.Element {
-    await self.init(
+  ) where Model: RangeReplaceableCollection, T == Model.Element {
+    self.init(
       pager: .init(
         client: client,
         initialQuery: initialQuery,


### PR DESCRIPTION
**This is a breaking change, and would require a 0.2.0 release**. 

In order to make instantiation of the `AsyncGraphQLQueryPager` easier, we can remove the `async` requirement of the initializer _if_ we also ensure that accesses to `cancellables` becomes atomic. This pull request primarily focuses on the removal of asynchronous initializers and the introduction of `Task` in the `AsyncGraphQLQueryPager` class and its related test classes. The most significant changes include the removal of `await` from `AsyncGraphQLQueryPager` initializers, the introduction of `Task` for subscribing to pager results, and the use of `@Atomic` for thread-safe mutation of `cancellables`.

___

#### Why?

Honestly, it just feels better to instantiate it this way: it opens up the reality of instantiating the object in a `SwiftUI` view model, and then using it in an asynchronous context via `.task` modifiers in the view as the `async` entry-point. We could technically do that by declaring a new `Task` to instantiate the pager in, but then we are relegated to an optional-only pager. 

The effective change to SwiftUI view models is something like this:

Before:

```swift
@Observable final class MyViewModel {
  var pager: AsyncGraphQLQueryPager<[MyCustomModel]>?

  init() {
    Task {
      pager = await AsyncGraphQLQueryPager(...)
    }
  }
}
```

After:

```swift
@Observable final class MyViewModel {
  var pager: AsyncGraphQLQueryPager<[MyCustomModel]>

  init() {
    pager = AsyncGraphQLQueryPager(...)
  }
}
```

___

I ran the `AsyncGraphQLQueryPagerTests` suite 100 times with the address sanitizer:
 ✅  `Executed 700 tests, with 0 failures (0 unexpected) in 74.311 (74.597) seconds` 

100 times with the thread sanitizer:
✅  `Executed 700 tests, with 0 failures (0 unexpected) in 79.664 (79.981) seconds`

___

Changes to `AsyncGraphQLQueryPager`:

* [`apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift`](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L12-R12): Removed `async` from the initialization of `AsyncGraphQLQueryPager` and its related methods. The `cancellables` property has been made atomic to ensure thread safety. Subscription to the pager's results has been modified to store the cancellable internally. [[1]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L12-R12) [[2]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L21-R24) [[3]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L40-R51) [[4]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L59-R65) [[5]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L71-R78) [[6]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L96-R102) [[7]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L111-R117) [[8]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L140-R154) [[9]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L164-R170) [[10]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L179-R185) [[11]](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L194-R203)

Changes to `AsyncGraphQLQueryPagerTests`:

* [`Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift`](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL31-R31): Adjusted the tests to reflect the removal of `async` from the initialization of `AsyncGraphQLQueryPager`. [[1]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL31-R31) [[2]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL87-R87) [[3]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL149-R149) [[4]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL211-R211) [[5]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL276-R276) [[6]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL309-R309) [[7]](diffhunk://#diff-849d1616469c55001c042bc3f8f1c168399a12a377a5522115b5da5bebf6559dL61-R61)

Changes to `PagerCoordinator+Erase`:

* [`Tests/ApolloPaginationTests/PagerCoordinator+Erase.swift`](diffhunk://#diff-74ba0cde07e55b1bddc4aa253b14f6f0a0ca4a662e33083f77bad0befa5ea905L35-R36): Adjusted the tests to reflect the removal of `async` from the initialization of `AsyncGraphQLQueryPager`. [[1]](diffhunk://#diff-74ba0cde07e55b1bddc4aa253b14f6f0a0ca4a662e33083f77bad0befa5ea905L35-R36) [[2]](diffhunk://#diff-74ba0cde07e55b1bddc4aa253b14f6f0a0ca4a662e33083f77bad0befa5ea905L45-R46) [[3]](diffhunk://#diff-74ba0cde07e55b1bddc4aa253b14f6f0a0ca4a662e33083f77bad0befa5ea905L55-R56)

Changes to `GraphQLQueryPager+Convenience`:

* [`apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift`](diffhunk://#diff-1ab0c1f28ec542beeb66edd5a206a3857033e09c4102a474bc306b9c3b48ab43L162-R163): Adjusted the convenience methods to reflect the removal of `async` from the initialization of `AsyncGraphQLQueryPager`. [[1]](diffhunk://#diff-1ab0c1f28ec542beeb66edd5a206a3857033e09c4102a474bc306b9c3b48ab43L162-R163) [[2]](diffhunk://#diff-1ab0c1f28ec542beeb66edd5a206a3857033e09c4102a474bc306b9c3b48ab43L182-R183) [[3]](diffhunk://#diff-1ab0c1f28ec542beeb66edd5a206a3857033e09c4102a474bc306b9c3b48ab43L204-R205) [[4]](diffhunk://#diff-1ab0c1f28ec542beeb66edd5a206a3857033e09c4102a474bc306b9c3b48ab43L227-R228) [[5]](diffhunk://#diff-1ab0c1f28ec542beeb66edd5a206a3857033e09c4102a474bc306b9c3b48ab43L252-R253) [[6]](diffhunk://#diff-1ab0c1f28ec542beeb66edd5a206a3857033e09c4102a474bc306b9c3b48ab43L279-R280)