### PR TITLE
Provide a direct means to observe changes in ApolloStore

### DIFF
--- a/Tests/ApolloTests/Cache/StoreSubscriptionTests.swift
+++ b/Tests/ApolloTests/Cache/StoreSubscriptionTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Apollo
+
+class StoreSubscriptionTests: XCTestCase {
+  static let defaultWaitTimeout: TimeInterval = 1
+
+  var store: ApolloStore!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    store = ApolloStore()
+  }
+
+  override func tearDownWithError() throws {
+    store = nil
+    try super.tearDownWithError()
+  }
+
+  // MARK: - Tests
+
+  func testSubscriberIsNotifiedOfStoreUpdate() throws {
+    let cacheKeyChangeExpectation = XCTestExpectation(description: "Subscriber is notified of cache key change")
+    let expectedChangeKeySet: Set<String> = ["QUERY_ROOT.__typename", "QUERY_ROOT.name"]
+    let subscriber = SimpleSubscriber(cacheKeyChangeExpectation, expectedChangeKeySet)
+
+    store.subscribe(subscriber)
+    addTeardownBlock { self.store.unsubscribe(subscriber) }
+
+    store.publish(
+      records: [
+        "QUERY_ROOT": [
+          "__typename": "Hero",
+          "name": "Han Solo"
+        ]
+      ]
+    )
+
+    wait(for: [cacheKeyChangeExpectation], timeout: Self.defaultWaitTimeout)
+  }
+
+  func testUnsubscribedSubscriberDoesNotReceiveStoreUpdate() throws {
+    let cacheKeyChangeExpectation = XCTestExpectation(description: "Subscriber is notified of cache key change")
+    cacheKeyChangeExpectation.isInverted = true
+
+    let expectedChangeKeySet: Set<String> = ["QUERY_ROOT.__typename", "QUERY_ROOT.name"]
+    let subscriber = SimpleSubscriber(cacheKeyChangeExpectation, expectedChangeKeySet)
+
+    store.subscribe(subscriber)
+
+    store.unsubscribe(subscriber)
+
+    store.publish(
+      records: [
+        "QUERY_ROOT": [
+          "__typename": "Hero",
+          "name": "Han Solo"
+        ]
+      ]
+    )
+
+    wait(for: [cacheKeyChangeExpectation], timeout: Self.defaultWaitTimeout)
+  }
+
+  /// Fufills the provided expectation when all expected keys have been observed.
+  internal class SimpleSubscriber: ApolloStoreSubscriber {
+    private let expectation: XCTestExpectation
+    private var changeSet: Set<String>
+
+    init(_ expectation: XCTestExpectation, _ changeSet: Set<String>) {
+      self.expectation = expectation
+      self.changeSet = changeSet
+    }
+
+    func store(_ store: ApolloStore,
+               didChangeKeys changedKeys: Set<CacheKey>,
+               contextIdentifier: UUID?) {
+      changeSet.subtract(changedKeys)
+      if (changeSet.isEmpty) {
+        expectation.fulfill()
+      }
+    }
+  }
+}

--- a/Tests/ApolloTests/Cache/StoreSubscriptionTests.swift
+++ b/Tests/ApolloTests/Cache/StoreSubscriptionTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 import XCTest
 @testable import Apollo
 
@@ -38,27 +39,14 @@ class StoreSubscriptionTests: XCTestCase {
     wait(for: [cacheKeyChangeExpectation], timeout: Self.defaultWaitTimeout)
   }
 
-  func testUnsubscribedSubscriberDoesNotReceiveStoreUpdate() throws {
-    let cacheKeyChangeExpectation = XCTestExpectation(description: "Subscriber is notified of cache key change")
-    cacheKeyChangeExpectation.isInverted = true
-
-    let expectedChangeKeySet: Set<String> = ["QUERY_ROOT.__typename", "QUERY_ROOT.name"]
-    let subscriber = SimpleSubscriber(cacheKeyChangeExpectation, expectedChangeKeySet)
+  func testUnsubscribeRemovesSubscriberFromApolloStore() throws {
+    let subscriber = SimpleSubscriber(XCTestExpectation(), [])
 
     store.subscribe(subscriber)
 
     store.unsubscribe(subscriber)
 
-    store.publish(
-      records: [
-        "QUERY_ROOT": [
-          "__typename": "Hero",
-          "name": "Han Solo"
-        ]
-      ]
-    )
-
-    wait(for: [cacheKeyChangeExpectation], timeout: Self.defaultWaitTimeout)
+    expect(self.store.subscribers).toEventually(beEmpty())
   }
 
   /// Fufills the provided expectation when all expected keys have been observed.

--- a/apollo-ios/Sources/Apollo/ApolloStore.swift
+++ b/apollo-ios/Sources/Apollo/ApolloStore.swift
@@ -5,7 +5,9 @@ import ApolloAPI
 
 public typealias DidChangeKeysFunc = (Set<CacheKey>, UUID?) -> Void
 
-protocol ApolloStoreSubscriber: AnyObject {
+/// The `ApolloStoreSubscriber` provides a means to observe changes to items in the ApolloStore.
+/// This protocol is available for advanced use cases only. Most users will prefer using `ApolloClient.watch(query:)`.
+public protocol ApolloStoreSubscriber: AnyObject {
   
   /// A callback that can be received by subscribers when keys are changed within the database
   ///
@@ -83,13 +85,23 @@ public class ApolloStore {
     }
   }
 
-  func subscribe(_ subscriber: ApolloStoreSubscriber) {
+  /// Subscribes to notifications of ApolloStore content changes
+  ///
+  /// - Parameters:
+  ///    - subscriber: A subscriber to receive content change notificatons. To avoid a retain cycle,
+  ///                  ensure you call `unsubscribe` on this subcriber before it goes out of scope.
+  public func subscribe(_ subscriber: ApolloStoreSubscriber) {
     queue.async(flags: .barrier) {
       self.subscribers.append(subscriber)
     }
   }
 
-  func unsubscribe(_ subscriber: ApolloStoreSubscriber) {
+  /// Unsubscribes from notifications of ApolloStore content changes
+  ///
+  /// - Parameters:
+  ///    - subscriber: A subscribe that has previously been added via `subscribe`. To avoid retain cycles,
+  ///                  call `unsubscribe` on all active subscribers before they go out of scope.
+  public func unsubscribe(_ subscriber: ApolloStoreSubscriber) {
     queue.async(flags: .barrier) {
       self.subscribers = self.subscribers.filter({ $0 !== subscriber })
     }

--- a/apollo-ios/Sources/Apollo/ApolloStore.swift
+++ b/apollo-ios/Sources/Apollo/ApolloStore.swift
@@ -25,7 +25,7 @@ public class ApolloStore {
   private let cache: NormalizedCache
   private let queue: DispatchQueue
 
-  private var subscribers: [ApolloStoreSubscriber] = []
+  internal var subscribers: [ApolloStoreSubscriber] = []
 
   /// Designated initializer
   /// - Parameters:
@@ -89,7 +89,7 @@ public class ApolloStore {
   ///
   /// - Parameters:
   ///    - subscriber: A subscriber to receive content change notificatons. To avoid a retain cycle,
-  ///                  ensure you call `unsubscribe` on this subcriber before it goes out of scope.
+  ///                  ensure you call `unsubscribe` on this subscriber before it goes out of scope.
   public func subscribe(_ subscriber: ApolloStoreSubscriber) {
     queue.async(flags: .barrier) {
       self.subscribers.append(subscriber)

--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -85,9 +85,9 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
     client?.store.unsubscribe(self)
   }
 
-  func store(_ store: ApolloStore,
-             didChangeKeys changedKeys: Set<CacheKey>,
-             contextIdentifier: UUID?) {
+  public func store(_ store: ApolloStore,
+                    didChangeKeys changedKeys: Set<CacheKey>,
+                    contextIdentifier: UUID?) {
     if
       let incomingIdentifier = contextIdentifier,
       incomingIdentifier == self.contextIdentifier {


### PR DESCRIPTION
(Full context in https://github.com/apollographql/apollo-ios/issues/3350.)

Apollo Kotlin currently provides a public [`changedKeys`](https://github.com/apollographql/apollo-kotlin/blob/v4.0.0-beta.5/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt#L27-L30) property to get notified when objects in the ApolloStore change. Internally, iOS has had a similar facility, too -- but it hasn't been `public` until now.