### PR TITLE
fix: Updates Swift `Package.resolved` file version format

### DIFF
--- a/Tests/CodegenCLITests/VersionCheckerTests.swift
+++ b/Tests/CodegenCLITests/VersionCheckerTests.swift
@@ -35,47 +35,78 @@ class VersionCheckerTests: XCTestCase {
     fileManager = nil
   }
 
-  private func version1PackageResolvedFileBody(apolloVersion version: String) -> String {
-    return """
-    {
-      "object": {
-        "pins": [
-          {
-            "package": "Apollo",
-            "repositoryURL": "https://github.com/apollographql/apollo-ios.git",
-            "state": {
-              "branch": null,
-              "revision": "5349afb4e9d098776cc44280258edd5f2ae571ed",
-              "version": "\(version)"
-            }
-          }
-        ]
-      },
-      "version": 1
-    }
-    """
-  }
+  private enum packageResolvedVersion: CaseIterable {
+    case v1
+    case v2
+    case v3
 
-  private func version2PackageResolvedFileBody(apolloVersion version: String) -> String {
-    return """
-    {
-      "pins": [
-        {
-          "identity": "apollo-ios",
-          "kind" : "remoteSourceControl",
-          "location": "https://github.com/apollographql/apollo-ios.git",
-          "state": {
-            "revision": "5349afb4e9d098776cc44280258edd5f2ae571ed",
-            "version": "\(version)"
-          }
-        }
-      ],
-      "version": 2
+    private var int: Int {
+      switch self {
+      case .v1: 1
+      case .v2: 2
+      case .v3: 3
+      }
     }
-    """
+
+    func fileBody(apolloVersion version: String) -> String {
+      switch self {
+      case .v1:
+        return """
+        {
+          "object": {
+            "pins": [
+              {
+                "package": "Apollo",
+                "repositoryURL": "https://github.com/apollographql/apollo-ios.git",
+                "state": {
+                  "branch": null,
+                  "revision": "5349afb4e9d098776cc44280258edd5f2ae571ed",
+                  "version": "\(version)"
+                }
+              }
+            ]
+          },
+          "version": 1
+        }
+        """
+
+      case .v2, .v3:
+        return """
+        {
+          "pins": [
+            {
+              "identity": "apollo-ios",
+              "kind" : "remoteSourceControl",
+              "location": "https://github.com/apollographql/apollo-ios.git",
+              "state": {
+                "revision": "5349afb4e9d098776cc44280258edd5f2ae571ed",
+                "version": "\(version)"
+              }
+            }
+          ],
+          "version": \(self.int)
+        }
+        """
+      }
+    }
   }
 
   // MARK: - Tests
+
+  private func testPackageResolvedFile(
+    packageVersion: packageResolvedVersion,
+    inDirectory directory: String? = nil,
+    apolloVersion: String,
+    _ test: (() throws -> Void)
+  ) rethrows {
+    expect(try self.fileManager.createFile(
+      body: packageVersion.fileBody(apolloVersion: apolloVersion),
+      named: "Package.resolved",
+      inDirectory: directory
+    )).notTo(throwError())
+
+    try test()
+  }
 
   func test__matchCLIVersionToApolloVersion__givenNoPackageResolvedFileInProject_returnsNoApolloVersionFound() throws {
     // when
@@ -87,164 +118,185 @@ class VersionCheckerTests: XCTestCase {
     expect(result).to(equal(.noApolloVersionFound))
   }
 
-  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInProjectRoot_withVersion1FileFormat_hasMatchingVersion_returns_versionMatch() throws {
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInProjectRoot_withKnownResolvedFileFormats_hasMatchingVersion_returns_versionMatch() throws {
     // given
-    try fileManager.createFile(
-      body: version1PackageResolvedFileBody(apolloVersion: Constants.CLIVersion),
-      named: "Package.resolved"
-    )
+    for packageVersion in packageResolvedVersion.allCases {
+      try testPackageResolvedFile(
+        packageVersion: packageVersion,
+        apolloVersion: Constants.CLIVersion
+      ) {
 
-    // when
-    let result = try VersionChecker.matchCLIVersionToApolloVersion(
-      projectRootURL: fileManager.directoryURL
-    )
+        // when
+        let result = try VersionChecker.matchCLIVersionToApolloVersion(
+          projectRootURL: fileManager.directoryURL
+        )
 
-    // then
-    expect(result).to(equal(.versionMatch))
+        // then
+        expect(result).to(equal(.versionMatch))
+      }
+    }
   }
 
-  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInProjectRoot_withVersion1FileFormat_hasNonMatchingVersion_returns_versionMismatch() throws {
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInProjectRoot_withKnownResolvedFileFormats_hasNonMatchingVersion_returns_versionMismatch() throws {
     // given
     let apolloVersion = "1.0.0.test-1"
-    try fileManager.createFile(
-      body: version1PackageResolvedFileBody(apolloVersion: apolloVersion),
-      named: "Package.resolved"
-    )
 
-    // when
-    let result = try VersionChecker.matchCLIVersionToApolloVersion(
-      projectRootURL: fileManager.directoryURL
-    )
+    for packageVersion in packageResolvedVersion.allCases {
+      try testPackageResolvedFile(
+        packageVersion: packageVersion,
+        apolloVersion: apolloVersion
+      ) {
 
-    // then
-    expect(result).to(equal(.versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)))
+        // when
+        let result = try VersionChecker.matchCLIVersionToApolloVersion(
+          projectRootURL: fileManager.directoryURL
+        )
+
+        // then
+        expect(result).to(equal(
+          .versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)
+        ))
+      }
+    }
   }
 
-  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInProjectRoot_withVersion2FileFormat_hasMatchingVersion_returns_versionMatch() throws {
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspace_withKnownResolvedFileFormats_hasMatchingVersion_returns_versionMatch() throws {
     // given
-    try fileManager.createFile(
-      body: version2PackageResolvedFileBody(apolloVersion: Constants.CLIVersion),
-      named: "Package.resolved"
-    )
+    for packageVersion in packageResolvedVersion.allCases {
+      try testPackageResolvedFile(
+        packageVersion: packageVersion,
+        inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm",
+        apolloVersion: Constants.CLIVersion
+      ) {
 
-    // when
-    let result = try VersionChecker.matchCLIVersionToApolloVersion(
-      projectRootURL: fileManager.directoryURL
-    )
+        // when
+        let result = try VersionChecker.matchCLIVersionToApolloVersion(
+          projectRootURL: fileManager.directoryURL
+        )
 
-    // then
-    expect(result).to(equal(.versionMatch))
+        // then
+        expect(result).to(equal(.versionMatch))
+      }
+    }
   }
 
-  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInProjectRoot_withVersion2FileFormat_hasNonMatchingVersion_returns_versionMismatch() throws {
-    // given
-    let apolloVersion = "1.0.0.test-1"
-    try fileManager.createFile(
-      body: version2PackageResolvedFileBody(apolloVersion: apolloVersion),
-      named: "Package.resolved"
-    )
-
-    // when
-    let result = try VersionChecker.matchCLIVersionToApolloVersion(
-      projectRootURL: fileManager.directoryURL
-    )
-
-    // then
-    expect(result).to(equal(.versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)))
-  }
-
-  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspace_withVersion2FileFormat_hasMatchingVersion_returns_versionMatch() throws {
-    // given
-    try fileManager.createFile(
-      body: version2PackageResolvedFileBody(apolloVersion: Constants.CLIVersion),
-      named: "Package.resolved",
-      inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm"
-    )
-
-    // when
-    let result = try VersionChecker.matchCLIVersionToApolloVersion(
-      projectRootURL: fileManager.directoryURL
-    )
-
-    // then
-    expect(result).to(equal(.versionMatch))
-  }
-
-  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspace_withVersion2FileFormat_hasNonMatchingVersion_returns_versionMismatch() throws {
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspace_withKnownResolvedFileFormats_hasNonMatchingVersion_returns_versionMismatch() throws {
     // given
     let apolloVersion = "1.0.0.test-1"
-    try fileManager.createFile(
-      body: version2PackageResolvedFileBody(apolloVersion: apolloVersion),
-      named: "Package.resolved",
-      inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm"
-    )
 
-    // when
-    let result = try VersionChecker.matchCLIVersionToApolloVersion(
-      projectRootURL: fileManager.directoryURL
-    )
+    for packageVersion in packageResolvedVersion.allCases {
+      try testPackageResolvedFile(
+        packageVersion: packageVersion,
+        inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm",
+        apolloVersion: apolloVersion
+      ) {
 
-    // then
-    expect(result).to(equal(.versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)))
+        // when
+        let result = try VersionChecker.matchCLIVersionToApolloVersion(
+          projectRootURL: fileManager.directoryURL
+        )
+
+        // then
+        expect(result).to(equal(
+          .versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)
+        ))
+      }
+    }
   }
 
-  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeProject_withVersion2FileFormat_hasMatchingVersion_returns_versionMatch() throws {
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeProject_withKnownResolvedFileFormats_hasMatchingVersion_returns_versionMatch() throws {
     // given
-    try fileManager.createFile(
-      body: version2PackageResolvedFileBody(apolloVersion: Constants.CLIVersion),
-      named: "Package.resolved",
-      inDirectory: "MyProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
-    )
+    for packageVersion in packageResolvedVersion.allCases {
+      try testPackageResolvedFile(
+        packageVersion: packageVersion,
+        inDirectory: "MyProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm",
+        apolloVersion: Constants.CLIVersion
+      ) {
 
-    // when
-    let result = try VersionChecker.matchCLIVersionToApolloVersion(
-      projectRootURL: fileManager.directoryURL
-    )
+        // when
+        let result = try VersionChecker.matchCLIVersionToApolloVersion(
+          projectRootURL: fileManager.directoryURL
+        )
 
-    // then
-    expect(result).to(equal(.versionMatch))
+        // then
+        expect(result).to(equal(.versionMatch))
+      }
+    }
   }
 
-  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeProject_withVersion2FileFormat_hasNonMatchingVersion_returns_versionMismatch() throws {
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeProject_withKnownResolvedFileFormats_hasNonMatchingVersion_returns_versionMismatch() throws {
     // given
     let apolloVersion = "1.0.0.test-1"
-    try fileManager.createFile(
-      body: version2PackageResolvedFileBody(apolloVersion: apolloVersion),
-      named: "Package.resolved",
-      inDirectory: "MyProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
-    )
 
-    // when
-    let result = try VersionChecker.matchCLIVersionToApolloVersion(
-      projectRootURL: fileManager.directoryURL
-    )
+    for packageVersion in packageResolvedVersion.allCases {
+      try testPackageResolvedFile(
+        packageVersion: packageVersion,
+        inDirectory: "MyProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm",
+        apolloVersion: apolloVersion
+      ) {
 
-    // then
-    expect(result).to(equal(.versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)))
+        // when
+        let result = try VersionChecker.matchCLIVersionToApolloVersion(
+          projectRootURL: fileManager.directoryURL
+        )
+
+        // then
+        expect(result).to(equal(
+          .versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)
+        ))
+      }
+    }
   }
   
-  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspaceAndProject_withVersion2FileFormat_hasMatchingVersion_returns_versionMatch_fromWorkspace() throws {
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspaceAndProject_withKnownResolvedFileFormats_hasMatchingVersion_returns_versionMatch_fromWorkspace() throws {
     // given
-    try fileManager.createFile(
-      body: version2PackageResolvedFileBody(apolloVersion: Constants.CLIVersion),
-      named: "Package.resolved",
-      inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm"
-    )
-    
-    let apolloProjectVersion = "1.0.0.test-1"
-    try fileManager.createFile(
-      body: version2PackageResolvedFileBody(apolloVersion: apolloProjectVersion),
-      named: "Package.resolved",
-      inDirectory: "MyProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
-    )
+    for packageVersion in packageResolvedVersion.allCases {
+      try fileManager.createFile(
+        body: packageVersion.fileBody(apolloVersion: Constants.CLIVersion),
+        named: "Package.resolved",
+        inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm"
+      )
 
-    // when
-    let result = try VersionChecker.matchCLIVersionToApolloVersion(
-      projectRootURL: fileManager.directoryURL
-    )
+      try fileManager.createFile(
+        body: packageVersion.fileBody(apolloVersion: Constants.CLIVersion),
+        named: "Package.resolved",
+        inDirectory: "MyProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
+      )
 
-    // then
-    expect(result).to(equal(.versionMatch))
+      // when
+      let result = try VersionChecker.matchCLIVersionToApolloVersion(
+        projectRootURL: fileManager.directoryURL
+      )
+
+      // then
+      expect(result).to(equal(.versionMatch))
+    }
+  }
+
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspaceAndProject_withKnownResolvedFileFormats_hasNonMatchingVersion_returns_versionMatch_fromWorkspace() throws {
+    // given
+    for packageVersion in packageResolvedVersion.allCases {
+      try fileManager.createFile(
+        body: packageVersion.fileBody(apolloVersion: Constants.CLIVersion),
+        named: "Package.resolved",
+        inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm"
+      )
+
+      let apolloProjectVersion = "1.0.0.test-1"
+      try fileManager.createFile(
+        body: packageVersion.fileBody(apolloVersion: apolloProjectVersion),
+        named: "Package.resolved",
+        inDirectory: "MyProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
+      )
+
+      // when
+      let result = try VersionChecker.matchCLIVersionToApolloVersion(
+        projectRootURL: fileManager.directoryURL
+      )
+
+      // then
+      expect(result).to(equal(.versionMatch))
+    }
   }
 
 }

--- a/apollo-ios-codegen/Sources/CodegenCLI/Extensions/VersionChecker.swift
+++ b/apollo-ios-codegen/Sources/CodegenCLI/Extensions/VersionChecker.swift
@@ -158,13 +158,14 @@ struct PackageResolvedModel {
   enum FileFormatVersion: Int {
     case v1 = 1
     case v2 = 2
+    case v3 = 3
 
     func getPackageList(fromPackageResolvedJSON json: [String: Any]) -> ObjectList? {
       switch self {
       case .v1:
         return (json["object"] as? Object)?["pins"] as? ObjectList
 
-      case .v2:
+      case .v2, .v3:
         return json["pins"] as? ObjectList
       }
     }
@@ -174,7 +175,7 @@ struct PackageResolvedModel {
       case .v1:
         return package["package"] as? String
 
-      case .v2:
+      case .v2, .v3:
         return package["identity"] as? String
       }
     }


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3355.

This is the fix to accept version `3` as a valid format for the version checker.