### PR TITLE
Field Merging[1/x] Configuration Options

### DIFF
--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -54,7 +54,8 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
               "MyInterface": .type(name: "CustomInterface"),
               "MyObject": .type(name: "CustomObject")
             ]
-          ), 
+          ),
+          fieldMerging: .all,
           cocoapodsCompatibleImportStatements: true,
           warningsOnDeprecatedUsage: .exclude,
           conversionStrategies:.init(
@@ -111,6 +112,9 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "inputObjects" : "none"
           },
           "deprecatedEnumCases" : "exclude",
+          "fieldMerging" : [
+            "all"
+          ],
           "markOperationDefinitionsAsFinal" : true,
           "operationDocumentFormat" : [
             "definition"
@@ -783,6 +787,191 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
         from: subject
       )
     ).to(throwError())
+  }
+
+  // MARK: - Field Merging Tests
+
+  func test__encode_fieldMerging__givenAll_shouldReturnAll() throws {
+    // given
+    let subject: ApolloCodegenConfiguration.FieldMerging = .all
+
+    let expected = """
+    [
+      "all"
+    ]
+    """
+
+    // when
+    let actual = try testJSONEncoder.encode(subject).asString
+
+    // then
+    expect(actual).to(equal(expected))
+  }
+
+  func test__decode_fieldMerging__givenAll_shouldReturnAll() throws {
+    // given
+    let subject = """
+    ["all"]
+    """.asData
+
+    // when
+    let decoded = try JSONDecoder().decode(
+      ApolloCodegenConfiguration.FieldMerging.self,
+      from: subject
+    )
+
+    // then
+    expect(decoded).to(equal(.all))
+  }
+
+  func test__encode_fieldMerging__givenAncestorsOnly_shouldReturnAncestors() throws {
+    // given
+    let subject: ApolloCodegenConfiguration.FieldMerging = .ancestors
+
+    let expected = """
+    [
+      "ancestors"
+    ]
+    """
+
+    // when
+    let actual = try testJSONEncoder.encode(subject).asString
+
+    // then
+    expect(actual).to(equal(expected))
+  }
+
+  func test__decode_fieldMerging__givenAncestorsOnly_shouldReturnAncestors() throws {
+    // given
+    let subject = """
+    ["ancestors"]
+    """.asData
+
+    // when
+    let decoded = try JSONDecoder().decode(
+      ApolloCodegenConfiguration.FieldMerging.self,
+      from: subject
+    )
+
+    // then
+    expect(decoded).to(equal(.ancestors))
+  }
+
+  func test__encode_fieldMerging__givenSiblingsOnly_shouldReturnSiblings() throws {
+    // given
+    let subject: ApolloCodegenConfiguration.FieldMerging = .siblings
+
+    let expected = """
+    [
+      "siblings"
+    ]
+    """
+
+    // when
+    let actual = try testJSONEncoder.encode(subject).asString
+
+    // then
+    expect(actual).to(equal(expected))
+  }
+
+  func test__decode_fieldMerging__givenSiblingsOnly_shouldReturnSiblings() throws {
+    // given
+    let subject = """
+    ["siblings"]
+    """.asData
+
+    // when
+    let decoded = try JSONDecoder().decode(
+      ApolloCodegenConfiguration.FieldMerging.self,
+      from: subject
+    )
+
+    // then
+    expect(decoded).to(equal(.siblings))
+  }
+
+  func test__encode_fieldMerging__givenNamedFragmentsOnly_shouldReturnNamedFragments() throws {
+    // given
+    let subject: ApolloCodegenConfiguration.FieldMerging = .namedFragments
+
+    let expected = """
+    [
+      "namedFragments"
+    ]
+    """
+
+    // when
+    let actual = try testJSONEncoder.encode(subject).asString
+
+    // then
+    expect(actual).to(equal(expected))
+  }
+
+  func test__decode_fieldMerging__givenNamedFragmentsOnly_shouldReturnNamedFragments() throws {
+    // given
+    let subject = """
+    ["namedFragments"]
+    """.asData
+
+    // when
+    let decoded = try JSONDecoder().decode(
+      ApolloCodegenConfiguration.FieldMerging.self,
+      from: subject
+    )
+
+    // then
+    expect(decoded).to(equal(.namedFragments))
+  }
+
+  func test__encode_fieldMerging__givenMultipleValues_shouldReturnGivenValues() throws {
+    // given
+    let subject: ApolloCodegenConfiguration.FieldMerging = [.ancestors, .namedFragments]
+
+    let expected = """
+    [
+      "ancestors",
+      "namedFragments"
+    ]
+    """
+
+    // when
+    let actual = try testJSONEncoder.encode(subject).asString
+
+    // then
+    expect(actual).to(equal(expected))
+  }
+
+  func test__decode_fieldMerging__givenMultipleValues_shouldReturnGivenValues() throws {
+    // given
+    let subject = """
+    ["ancestors", "siblings"]
+    """.asData
+
+    // when
+    let decoded = try JSONDecoder().decode(
+      ApolloCodegenConfiguration.FieldMerging.self,
+      from: subject
+    )
+
+    // then
+    expect(decoded).to(equal([.ancestors, .siblings]))
+  }
+
+  func test__decode_fieldMerging__givenUnrecognizedValue_shouldThrowError() throws {
+    // given
+    let subject = """
+    ["invalid"]
+    """.asData
+
+    // when
+    expect(
+      try JSONDecoder().decode(
+      ApolloCodegenConfiguration.FieldMerging.self,
+      from: subject
+      )
+    )
+    // then
+    .to(throwError(errorType: DecodingError.self))
   }
 
   // MARK: - APQConfig Tests

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -878,9 +878,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   /// different instances together to indicate all the types you would like to generate
   /// initializers for.
   public struct SelectionSetInitializers: Codable, Equatable, ExpressibleByArrayLiteral {
-    private var options: SelectionSetInitializers.Options
-    private var definitions: Set<String>
-
     /// Option to generate initializers for all named fragments.
     public static let namedFragments: SelectionSetInitializers = .init(.namedFragments)
 
@@ -906,6 +903,9 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     public static func fragment(named: String) -> SelectionSetInitializers {
       .init(definitionName: named)
     }
+
+    private var options: SelectionSetInitializers.Options
+    private var definitions: Set<String>
 
     /// Initializes a `SelectionSetInitializer` with an array of values.
     public init(arrayLiteral elements: SelectionSetInitializers...) {
@@ -938,29 +938,41 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   ///
   /// By default, all possible fields and named fragment accessors are merged into each selection
   /// set.
-  public struct FieldMerging: OptionSet, Codable, Equatable {
+  public struct FieldMerging: Codable, Equatable, ExpressibleByArrayLiteral {
     /// Merges fields and fragment accessors from the selection set's direct ancestors.
-    public static let ancestors          = FieldMerging(rawValue: 1 << 0)
+    public static let ancestors          = FieldMerging(.ancestors)
 
     /// Merges fields and fragment accessors from sibling inline fragments that match the selection
     /// set's scope.
-    public static let siblings           = FieldMerging(rawValue: 1 << 1)
+    public static let siblings           = FieldMerging(.siblings)
 
     /// Merges fields and fragment accessors from named fragments that have been spread into the
     /// selection set.
-    public static let namedFragments     = FieldMerging(rawValue: 1 << 2)
+    public static let namedFragments     = FieldMerging(.namedFragments)
 
     /// Merges all possible fields and fragment accessors from all sources.
     public static let all: FieldMerging  = [.ancestors, .siblings, .namedFragments]
 
     /// Disables field merging entirely. Aside from removal of redundant selections, the shape of
     /// the generated models will directly mirror the GraphQL definition.
-    public static let none: FieldMerging = FieldMerging(rawValue: 0)
+    public static let none: FieldMerging = []
 
-    public let rawValue: Int
+    private var options: MergedSelections.MergingStrategy
 
-    public init(rawValue: Int) {
-      self.rawValue = rawValue
+    private init(_ options: MergedSelections.MergingStrategy) {
+      self.options = options
+    }
+
+    public init(arrayLiteral elements: FieldMerging...) {
+      self.options = []
+      for element in elements {
+        self.options.insert(element.options)
+      }
+    }
+
+    /// Inserts a `SelectionSetInitializer` into the receiver.
+    public mutating func insert(_ member: FieldMerging) {
+      self.options.insert(member.options)
     }
   }
 
@@ -1275,6 +1287,75 @@ extension ApolloCodegenConfiguration.SelectionSetInitializers {
 
     if !definitions.isEmpty {
       try container.encode(definitions.sorted(), forKey: .definitionsNamed)
+    }
+  }
+}
+
+// MARK: - FieldMerging - Private Implementation
+
+extension ApolloCodegenConfiguration.FieldMerging {
+
+  // MARK: - Codable
+
+  private enum CodableValues: String {
+    case all
+    case ancestors
+    case siblings
+    case namedFragments
+  }
+
+  public init(from decoder: any Decoder) throws {
+    var values = try decoder.unkeyedContainer()
+
+    var options: MergedSelections.MergingStrategy = []
+
+    while !values.isAtEnd {
+      let option = try values.decode(String.self)
+      switch option {
+      case CodableValues.all.rawValue:
+        self.options = [.all]
+        return
+
+      case CodableValues.ancestors.rawValue:
+        options.insert(.ancestors)
+
+      case CodableValues.siblings.rawValue:
+        options.insert(.siblings)
+
+      case CodableValues.namedFragments.rawValue:
+        options.insert(.namedFragments)
+
+      default:
+        throw DecodingError.dataCorrupted(
+          DecodingError.Context(
+            codingPath: values.codingPath,
+            debugDescription: "Unrecognized value: \(option)"
+          )
+        )
+      }
+    }
+
+    self.options = options
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.unkeyedContainer()
+
+    if options == .all {
+      try container.encode(CodableValues.all.rawValue)
+      return
+    }
+
+    if options.contains(.ancestors) {
+      try container.encode(CodableValues.ancestors.rawValue)
+    }
+
+    if options.contains(.siblings) {
+      try container.encode(CodableValues.siblings.rawValue)
+    }
+
+    if options.contains(.namedFragments) {
+      try container.encode(CodableValues.namedFragments.rawValue)
     }
   }
 }

--- a/apollo-ios-codegen/Sources/IR/IR+ComputedSelectionSet.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+ComputedSelectionSet.swift
@@ -169,6 +169,7 @@ extension ComputedSelectionSet {
     fileprivate func finalize() -> ComputedSelectionSet {
       let merged = MergedSelections(
         mergedSources: mergedSources,
+        mergingStrategy: .all,
         fields: fields,
         inlineFragments: inlineFragments,
         namedFragments: namedFragments

--- a/apollo-ios-codegen/Sources/IR/IR+MergedSelections.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+MergedSelections.swift
@@ -1,20 +1,18 @@
 import Foundation
 import OrderedCollections
 
-/// Represents the selections that merged into a selection set from other selection sets.
-/// This includes all selections from other related `SelectionSet`s on the same entity that match
-/// the selection set's type scope.
+/// Represents the selections that are merged into a selection set from other selection sets,
+/// using the given ``MergingStrategy``. See ``MergingStrategy`` for more information on what is
+/// included in the ``MergedSelections`` for a given strategy.
 ///
-/// Combining the `MergedSelections` with the `DirectSelections` for a `SelectionSet` provides all
-/// selections that are available to be accessed by the selection set.
-///
-/// To get the `MergedSelections` for a `SelectionSet` use a `ComputedSelectionSet`.
-///
-/// Selections in the `mergedSelections` are guaranteed to be selected if this `SelectionSet`'s
+/// Selections in the `MergedSelections` are guaranteed to be selected if this `SelectionSet`'s
 /// `selections` are selected. This means they can be merged into the generated object
 /// representing this `SelectionSet` as field accessors.
+///
+/// To get the ``MergedSelections`` for a ``SelectionSet`` use a ``ComputedSelectionSet/Builder``.
 public struct MergedSelections: Equatable {
   public let mergedSources: OrderedSet<MergedSource>
+  public let mergingStrategy: MergingStrategy
   public let fields: OrderedDictionary<String, Field>
   public let inlineFragments: OrderedDictionary<ScopeCondition, InlineFragmentSpread>
   public let namedFragments: OrderedDictionary<String, NamedFragmentSpread>
@@ -25,6 +23,7 @@ public struct MergedSelections: Equatable {
 
   public static func == (lhs: MergedSelections, rhs: MergedSelections) -> Bool {
     lhs.mergedSources == rhs.mergedSources &&
+    lhs.mergingStrategy == rhs.mergingStrategy &&
     lhs.fields == rhs.fields &&
     lhs.inlineFragments == rhs.inlineFragments &&
     lhs.namedFragments == rhs.namedFragments
@@ -42,6 +41,45 @@ extension MergedSelections {
     /// - Note: If `fragment` is present, the `typeInfo` is relative to the fragment,
     /// instead of the operation directly.
     public unowned let fragment: NamedFragment?
+  }
+}
+
+// MARK: - MergingStrategy
+
+extension MergedSelections {
+  /// The ``MergingStrategy`` is used to determine what merged fields and named fragment
+  /// accessors are merged into the ``MergedSelections``.
+  ///
+  /// ``MergedSelections`` can compute which selections from a selection set's parents, sibling
+  /// inline fragments, and named fragment spreads will also be included on the response object,
+  /// given the selection set's ``SelectionSet/TypeInfo``.
+  public struct MergingStrategy: OptionSet, Equatable {
+    /// Merges fields and fragment accessors from the selection set's direct ancestors.
+    public static let ancestors          = MergingStrategy(rawValue: 1 << 0)
+
+    /// Merges fields and fragment accessors from sibling inline fragments that match the selection
+    /// set's scope.
+    public static let siblings           = MergingStrategy(rawValue: 1 << 1)
+
+    /// Merges fields and fragment accessors from named fragments that have been spread into the
+    /// selection set.
+    public static let namedFragments     = MergingStrategy(rawValue: 1 << 2)
+
+    /// Merges all possible fields and fragment accessors from all sources.
+    ///
+    /// This includes all selections from other related `SelectionSet`s on the same entity that match
+    /// the selection set's type scope.
+    ///
+    /// When using this strategy, combining the ``MergedSelections`` with the ``DirectSelections`` 
+    /// for a ``SelectionSet`` provides all selections that are available to be accessed by the
+    /// selection set.
+    public static let all: MergingStrategy  = [.ancestors, .siblings, .namedFragments]
+
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
   }
 }
 


### PR DESCRIPTION
### TL;DR

Update the configuration in ApolloCodegen to allow for selecting specific field merging strategies.

### What changed?

Added the ability to select specific field merging strategies such as ancestors, siblings, and named fragments in the ApolloCodegen configuration.

### How to test?

Unit tests have been added to ensure encoding and decoding of field merging configurations work correctly.

### Why make this change?

This change provides more flexibility in handling merged fields and named fragment accessors in the generated selection set models.

---

