### PR TITLE
Remove redundant iteration in EntitySelectionTree merging algorithm

### DIFF
--- a/apollo-ios-codegen/Sources/IR/IR+EntitySelectionTree.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+EntitySelectionTree.swift
@@ -224,23 +224,6 @@ class EntitySelectionTree {
           targetSelections.mergeIn(scopeSelections, from: source)
         }
 
-        if let conditionalScopes = scopeConditions {
-          for (condition, node) in conditionalScopes {
-            guard !node.scope.isDeferred else { continue }
-
-            if scopePathNode.value.matches(condition) {
-              node.mergeSelections(
-                matchingScopePath: scopePathNode,
-                into: targetSelections,
-                transformingSelections: transformingSelections
-              )
-
-            } else {
-              targetSelections.addMergedInlineFragment(with: condition)
-            }
-          }
-        }
-
       case .none: break
       }
 
@@ -254,6 +237,8 @@ class EntitySelectionTree {
               into: targetSelections,
               transformingSelections: transformingSelections
             )
+          } else if case .selections = child {
+            targetSelections.addMergedInlineFragment(with: condition)
           }
         }
       }


### PR DESCRIPTION
### TL;DR

This PR refactors the `EntitySelectionTree` in `apollo-ios-codegen`.

### What changed?

The conditions for merging selections were revisited. The use of `scopeConditions` was removed from the part of the code where the node's scope is checked if it is deferred. Instead, the condition to add merged inline fragments was moved under the child case, specifically when the child case is selections.

### How to test?

Unit tests pass

### Why make this change?

This is a significant performance improvement as it removes an entire additional iteration through all the conditional scopes in the tree.

---

