### PR TITLE
fix: Remove empty arrays from privacy manifests

### DIFF
--- a/apollo-ios/Sources/Apollo/Resources/PrivacyInfo.xcprivacy
+++ b/apollo-ios/Sources/Apollo/Resources/PrivacyInfo.xcprivacy
@@ -3,24 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyTracking</key>

--- a/apollo-ios/Sources/ApolloAPI/Resources/PrivacyInfo.xcprivacy
+++ b/apollo-ios/Sources/ApolloAPI/Resources/PrivacyInfo.xcprivacy
@@ -3,24 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyTracking</key>

--- a/apollo-ios/Sources/ApolloSQLite/Resources/PrivacyInfo.xcprivacy
+++ b/apollo-ios/Sources/ApolloSQLite/Resources/PrivacyInfo.xcprivacy
@@ -3,24 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyTracking</key>

--- a/apollo-ios/Sources/ApolloWebSocket/Resources/PrivacyInfo.xcprivacy
+++ b/apollo-ios/Sources/ApolloWebSocket/Resources/PrivacyInfo.xcprivacy
@@ -3,24 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3359.

I re-read [Apple's privacy manifest files documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) and it looked like we were declaring arrays but not completing them correctly. This appears to be what made the manifests appear invalid. This change is simply to remove those arrays, leaving the parent keys empty.