### PR TITLE
[ApolloPagination] Support queued operations

### DIFF
--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
@@ -306,7 +306,7 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
 
   private func executeQueuedOperations() async throws {
     guard !queuedOperations.isEmpty else { return }
-    var copy = queuedOperations
+    let copy = queuedOperations
     queuedOperations.removeAll()
     for queuedOperation in copy {
       switch queuedOperation {

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
@@ -212,6 +212,7 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
     previousPageVarMap = [:]
     nextPageVarMap = [:]
     initialPageResult = nil
+    queuedOperations.removeAll()
 
     // Ensure any active networking operations are halted.
     taskGroup?.cancelAll()

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
@@ -233,7 +233,6 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
   // MARK: - Private
 
   private func fetch(cachePolicy: CachePolicy = .returnCacheDataAndFetch) async {
-    queuedOperations.removeAll()
     await execute { [weak self] publisher in
       guard let self else { return }
       if await self.firstPageWatcher == nil {
@@ -251,6 +250,7 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
       }
       await self.firstPageWatcher?.refetch(cachePolicy: cachePolicy)
     }
+    try? await executeQueuedOperations()
   }
 
   private func paginationFetch(


### PR DESCRIPTION
This is an experimental change which aims to add support for queued operations.
I'm testing this branch in a sample application [here](https://github.com/Iron-Ham/PaginationSample-SwiftUI/pull/1).

This change attempts to address the need for secondary triggers in SwiftUI projects, relevant to my comment here: https://github.com/apollographql/apollo-ios-dev/pull/317#issuecomment-2018604543

For more information, read the README of my [sample](https://github.com/Iron-Ham/PaginationSample-SwiftUI) under the `Secondary Triggers` known issue. 

This pull request adds support for queued operations. Each queued operation is setup such that only one queued operation per set of current data can be executed. If, for example, I call `loadNext` rapidly three times while nothing is actively loading, the first call will trigger a pagination load, as before. The second call will queue to be executed after the completion of the first call, but will throw a `loadInProgress` error (as before). The third call will behave as it did before: by only throwing the error. Once the first call is complete, the second pagination fetch will execute. 

I am using the current data state to disambiguate these fetches. That does mean that 3 calls to loadNext and 3 calls to loadPrevious will queue both a loadPrevious and a loadNext. 

___

🤖 Copilot Generated 🤖 

This pull request primarily focuses on improving the functionality of the `AsyncGraphQLQueryPagerCoordinator` in the `apollo-ios-pagination` package. The changes include the introduction of an `Operation` enum and a `queuedOperations` property to handle and queue operations, and modifications to the `loadNext`, `loadPrevious`, and `reset` methods to execute these queued operations. Additionally, the `paginationFetch` method has been updated to handle pagination errors and queue operations accordingly.

Here are the most important changes:

* [`apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift`](diffhunk://#diff-734cf04edf27d84c994976e044fdb587c2f0e1dda821705b55a6162a36c97937R21-R25): An `Operation` enum has been introduced within the `AsyncGraphQLQueryPagerCoordinator` actor that includes two cases: `loadNext` and `loadPrevious`. Each case can hold a `CachePolicy` and a `PaginatedQuery`.

* [`apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift`](diffhunk://#diff-734cf04edf27d84c994976e044fdb587c2f0e1dda821705b55a6162a36c97937R72-R73): A new property `queuedOperations` of type `OrderedSet<Operation>` has been added to store the operations to be executed.

* [`apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift`](diffhunk://#diff-734cf04edf27d84c994976e044fdb587c2f0e1dda821705b55a6162a36c97937R164): The `loadPrevious` and `loadNext` methods now include a call to `executeQueuedOperations` after the `paginationFetch` call. This ensures that any queued operations are executed after a page load operation. [[1]](diffhunk://#diff-734cf04edf27d84c994976e044fdb587c2f0e1dda821705b55a6162a36c97937R164) [[2]](diffhunk://#diff-734cf04edf27d84c994976e044fdb587c2f0e1dda821705b55a6162a36c97937R176)

* [`apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift`](diffhunk://#diff-734cf04edf27d84c994976e044fdb587c2f0e1dda821705b55a6162a36c97937R215): The `reset` method now clears all queued operations.

* [`apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift`](diffhunk://#diff-734cf04edf27d84c994976e044fdb587c2f0e1dda821705b55a6162a36c97937R254-R292): The `paginationFetch` method has been updated to queue operations in case of a `loadInProgress` or `missingInitialPage` error. A new private method `_paginationFetch` has been introduced to handle the actual fetch operation.

* [`apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift`](diffhunk://#diff-734cf04edf27d84c994976e044fdb587c2f0e1dda821705b55a6162a36c97937R327-R340): A new method `executeQueuedOperations` has been introduced to execute all operations in the queue sequentially and then clear the queue.