### PR TITLE
Add Sendable conformance to some basic SchemaTypes

### DIFF
--- a/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
@@ -16,7 +16,7 @@ public enum GraphQLOperationType: Hashable {
 /// ``GraphQLOperation``. You can configure the the code generation engine to include the
 /// ``OperationDefinition``, ``operationIdentifier``, or both using the `OperationDocumentFormat`
 /// options in your `ApolloCodegenConfiguration`.
-public struct OperationDocument {
+public struct OperationDocument: Sendable {
   public let operationIdentifier: String?
   public let definition: OperationDefinition?
 
@@ -35,7 +35,7 @@ public struct OperationDocument {
 /// This data represents the `Definition` for a `Document` as defined in the GraphQL Spec.
 /// In the case of the Apollo client, the definition will always be an `ExecutableDefinition`.
 /// - See: [GraphQLSpec - Document](https://spec.graphql.org/draft/#Document)
-public struct OperationDefinition {
+public struct OperationDefinition: Sendable {
   let operationDefinition: String
   let fragments: [any Fragment.Type]?
 

--- a/apollo-ios/Sources/ApolloAPI/SchemaTypes/Interface.swift
+++ b/apollo-ios/Sources/ApolloAPI/SchemaTypes/Interface.swift
@@ -4,7 +4,7 @@
 ///
 /// # See Also
 /// [GraphQLSpec - Interfaces](https://spec.graphql.org/draft/#sec-Interfaces)
-public struct Interface: Hashable {
+public struct Interface: Hashable, Sendable {
   /// The name of the ``Interface`` in the GraphQL schema.
   public let name: String
 

--- a/apollo-ios/Sources/ApolloAPI/SchemaTypes/Object.swift
+++ b/apollo-ios/Sources/ApolloAPI/SchemaTypes/Object.swift
@@ -3,7 +3,7 @@
 /// Each `type` defined in the GraphQL schema will have an instance of ``Object`` generated.
 /// # See Also
 /// [GraphQLSpec - Objects](https://spec.graphql.org/draft/#sec-Objects)
-public struct Object: Hashable {
+public struct Object: Hashable, Sendable {
 
   /// Designated Initializer
   ///

--- a/apollo-ios/Sources/ApolloAPI/SchemaTypes/Object.swift
+++ b/apollo-ios/Sources/ApolloAPI/SchemaTypes/Object.swift
@@ -34,14 +34,4 @@ public struct Object: Hashable, Sendable {
   public func implements(_ interface: Interface) -> Bool {
     implementedInterfaces.contains(where: { $0 == interface })
   }
-
-  public static func == (lhs: Object, rhs: Object) -> Bool {
-    return lhs.typename == rhs.typename &&
-    lhs.implementedInterfaces == rhs.implementedInterfaces
-  }
-
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(typename)
-    hasher.combine(implementedInterfaces)
-  }
 }

--- a/apollo-ios/Sources/ApolloAPI/SchemaTypes/Union.swift
+++ b/apollo-ios/Sources/ApolloAPI/SchemaTypes/Union.swift
@@ -4,7 +4,7 @@
 ///
 /// # See Also
 /// [GraphQLSpec - Unions](https://spec.graphql.org/draft/#sec-Unions)
-public struct Union: Hashable {
+public struct Union: Hashable, Sendable {
   /// The name of the ``Union`` in the GraphQL schema.
   public let name: String
 


### PR DESCRIPTION
Changes in Swift 5.10 and Xcode 15.3 improved the complete concurrency checking functionality in preparation for Swift 6.0. When using Apollo in a project with complete concurrency checking enabled, many warnings are surfaced for some of the generated schema types such as `Interface`, `Object`, and `Union`. These types are simple `struct`s with no mutability semantics, so they can adopt `Sendable` without any further changes or concerns. The same goes for `OperationDefinition` and `OperationDocument` types used in generated queries, mutations, and fragments.