### PR TITLE
Migrate deprecated Nimble types

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGenIR/IRFieldCollectorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRFieldCollectorTests.swift
@@ -558,18 +558,18 @@ class IRFieldCollectorTests: XCTestCase {
   /// MARK: - Custom Matchers
   func equal(
     _ expected: ReferencedFields
-  ) -> Nimble.Predicate<ReferencedFields> {
-    return Predicate.define { actual in
+  ) -> Nimble.Matcher<ReferencedFields> {
+    return Matcher.define { actual in
       let message: ExpectationMessage = .expectedActualValueTo("have fields equal to \(expected)")
 
       guard let actual = try actual.evaluate(),
             expected.count == actual.count else {
-        return PredicateResult(status: .fail, message: message.appended(details: "Fields Did Not Match!"))
+        return MatcherResult(status: .fail, message: message.appended(details: "Fields Did Not Match!"))
       }
 
       for (index, field) in zip(expected, actual).enumerated() {
         guard field.0.0 == field.1.0, field.0.1 == field.1.1 else {
-          return PredicateResult(
+          return MatcherResult(
             status: .fail,
             message: message.appended(
               details: "Expected fields[\(index)] to equal \(field.0), got \(field.1)."
@@ -578,7 +578,7 @@ class IRFieldCollectorTests: XCTestCase {
         }
       }
 
-      return PredicateResult(status: .matches, message: message)
+      return MatcherResult(status: .matches, message: message)
     }
   }
 }

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRNamedFragmentBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRNamedFragmentBuilderTests.swift
@@ -270,29 +270,29 @@ extension IR.Entity.Location.FieldComponent {
 
 fileprivate func match(
   _ expectedValue: [IR.Entity.Location: IR.Entity]
-) -> Nimble.Predicate<[IR.Entity.Location: IR.Entity]> {
-  return Predicate.define { actual in
+) -> Nimble.Matcher<[IR.Entity.Location: IR.Entity]> {
+  return Matcher.define { actual in
     let message: ExpectationMessage = .expectedActualValueTo("equal \(expectedValue)")
     guard var actual = try actual.evaluate(),
           actual.count == expectedValue.count else {
-      return PredicateResult(status: .fail, message: message)
+      return MatcherResult(status: .fail, message: message)
     }
 
     for expected in expectedValue {
       guard let actual = actual.removeValue(forKey: expected.key) else {
-        return PredicateResult(status: .fail, message: message)
+        return MatcherResult(status: .fail, message: message)
       }
 
       if expected.value.rootTypePath != actual.rootTypePath ||
           expected.value.location != actual.location {
-        return PredicateResult(status: .fail, message: message)
+        return MatcherResult(status: .fail, message: message)
       }
     }
 
     guard actual.isEmpty else {
-      return PredicateResult(status: .fail, message: message)
+      return MatcherResult(status: .fail, message: message)
     }
 
-    return PredicateResult(status: .matches, message: message)
+    return MatcherResult(status: .matches, message: message)
   }
 }

--- a/Tests/ApolloCodegenTests/TestHelpers/IRMatchers.swift
+++ b/Tests/ApolloCodegenTests/TestHelpers/IRMatchers.swift
@@ -33,10 +33,10 @@ typealias SelectionMatcherTuple = (fields: [ShallowFieldMatcher],
 
 // MARK - Custom Matchers
 
-func beEmpty<T: SelectionShallowMatchable>() -> Nimble.Predicate<T> {
-    return Predicate.simple("be empty") { actualExpression in
+func beEmpty<T: SelectionShallowMatchable>() -> Nimble.Matcher<T> {
+    return Matcher.simple("be empty") { actualExpression in
       guard let actual = try actualExpression.evaluate() else { return .fail }
-      return PredicateStatus(bool: actual.isEmpty)
+      return MatcherStatus(bool: actual.isEmpty)
     }
 }
 
@@ -45,7 +45,7 @@ func beEmpty<T: SelectionShallowMatchable>() -> Nimble.Predicate<T> {
 /// checking the `MergedSelections` without having to mock out the entire nested selection sets.
 func shallowlyMatch<T: SelectionShallowMatchable>(
   _ expectedValue: SelectionMatcherTuple
-) -> Nimble.Predicate<T> {
+) -> Nimble.Matcher<T> {
   return satisfyAllOf([
     shallowlyMatch(expectedValue.fields).mappingActualTo { $0?.fields.values },
     shallowlyMatch(expectedValue.typeCases).mappingActualTo { $0?.inlineFragments.values.map(\.selectionSet) },
@@ -55,7 +55,7 @@ func shallowlyMatch<T: SelectionShallowMatchable>(
 
 func shallowlyMatch<T: SelectionShallowMatchable>(
   _ expectedValue: [ShallowSelectionMatcher]
-) -> Nimble.Predicate<T> {
+) -> Nimble.Matcher<T> {
   var expectedFields: [ShallowFieldMatcher] = []
   var expectedTypeCases: [ShallowInlineFragmentMatcher] = []
   var expectedFragments: [ShallowFragmentSpreadMatcher] = []
@@ -96,13 +96,13 @@ struct SelectionsMatcher {
 
 func shallowlyMatch(
   _ expectedValue: SelectionsMatcher
-) -> Nimble.Predicate<SelectionSetTestWrapper> {
-  let directPredicate: Nimble.Predicate<IR.DirectSelections.ReadOnly> = expectedValue.direct == nil
+) -> Nimble.Matcher<SelectionSetTestWrapper> {
+  let directMatcher: Nimble.Matcher<IR.DirectSelections.ReadOnly> = expectedValue.direct == nil
   ? beNil()
   : shallowlyMatch(expectedValue.direct!)
 
-  var matchers: [Nimble.Predicate<SelectionSetTestWrapper>] = [
-    directPredicate.mappingActualTo { $0?.computed.direct },
+  var matchers: [Nimble.Matcher<SelectionSetTestWrapper>] = [
+    directMatcher.mappingActualTo { $0?.computed.direct },
   ]
 
   if !expectedValue.ignoreMergedSelections {
@@ -175,18 +175,18 @@ struct SelectionSetMatcher {
 
 func shallowlyMatch(
   _ expectedValue: SelectionSetMatcher
-) -> Nimble.Predicate<SelectionSetTestWrapper> {
+) -> Nimble.Matcher<SelectionSetTestWrapper> {
   let expectedInclusionConditions = IR.InclusionConditions.allOf(
     expectedValue.inclusionConditions ?? []
   ).conditions
 
-  let inclusionPredicate: Nimble.Predicate<IR.InclusionConditions> = expectedInclusionConditions == nil
+  let inclusionMatcher: Nimble.Matcher<IR.InclusionConditions> = expectedInclusionConditions == nil
   ? beNil()
   : equal(expectedInclusionConditions!)
 
   return satisfyAllOf([
     equal(expectedValue.parentType).mappingActualTo { $0?.parentType },
-    inclusionPredicate.mappingActualTo { $0?.inclusionConditions },
+    inclusionMatcher.mappingActualTo { $0?.inclusionConditions },
     shallowlyMatch(expectedValue.selections)
   ])
 }
@@ -318,16 +318,16 @@ public struct ShallowFieldMatcher: Equatable, CustomDebugStringConvertible {
 
 public func shallowlyMatch<T: Collection>(
   _ expectedValue: [ShallowFieldMatcher]
-) -> Nimble.Predicate<T> where T.Element == IR.Field {
-  return Predicate.define { actual in
+) -> Nimble.Matcher<T> where T.Element == IR.Field {
+  return Matcher.define { actual in
     return shallowlyMatch(expected: expectedValue, actual: try actual.evaluate())
   }
 }
 
 public func shallowlyMatch<T: Collection>(
   _ expectedValue: [ShallowSelectionMatcher]
-) -> Nimble.Predicate<T> where T.Element == IR.Field {
-  return Predicate.define { actual in
+) -> Nimble.Matcher<T> where T.Element == IR.Field {
+  return Matcher.define { actual in
     let expectedAsFields: [ShallowFieldMatcher] = try expectedValue.map {
       guard case let .shallowField(field) = $0 else {
         throw TestError("Selection \($0) is not a field!")
@@ -341,17 +341,17 @@ public func shallowlyMatch<T: Collection>(
 public func shallowlyMatch<T: Collection>(
   expected: [ShallowFieldMatcher],
   actual: T?
-) -> PredicateResult where T.Element == IR.Field {
+) -> MatcherResult where T.Element == IR.Field {
   let message: ExpectationMessage = .expectedActualValueTo("have fields equal to \(expected)")
 
   guard let actual = actual,
         expected.count == actual.count else {
-    return PredicateResult(status: .fail, message: message.appended(details: "Fields Did Not Match!"))
+    return MatcherResult(status: .fail, message: message.appended(details: "Fields Did Not Match!"))
   }
 
   for (index, field) in zip(expected, actual).enumerated() {
     guard shallowlyMatch(expected: field.0, actual: field.1) else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: message.appended(
           details: "Expected fields[\(index)] to equal \(field.0), got \(field.1)."
@@ -360,7 +360,7 @@ public func shallowlyMatch<T: Collection>(
     }
   }
 
-  return PredicateResult(status: .matches, message: message)
+  return MatcherResult(status: .matches, message: message)
 }
 
 fileprivate func shallowlyMatch(expected: ShallowFieldMatcher, actual: IR.Field) -> Bool {
@@ -420,8 +420,8 @@ public struct ShallowInlineFragmentMatcher: Equatable, CustomDebugStringConverti
 
 public func shallowlyMatch<T: Collection>(
   _ expectedValue: [ShallowInlineFragmentMatcher]
-) -> Nimble.Predicate<T> where T.Element == IR.SelectionSet {
-  return Predicate.define { actual in
+) -> Nimble.Matcher<T> where T.Element == IR.SelectionSet {
+  return Matcher.define { actual in
     return shallowlyMatch(expected: expectedValue, actual: try actual.evaluate())
   }
 }
@@ -429,16 +429,16 @@ public func shallowlyMatch<T: Collection>(
 fileprivate func shallowlyMatch<T: Collection>(
   expected: [ShallowInlineFragmentMatcher],
   actual: T?
-) -> PredicateResult where T.Element == IR.SelectionSet {
+) -> MatcherResult where T.Element == IR.SelectionSet {
   let message: ExpectationMessage = .expectedActualValueTo("have typeCases equal to \(expected)")
   guard let actual = actual,
         expected.count == actual.count else {
-    return PredicateResult(status: .fail, message: message.appended(details: "Inline Fragments Did Not Match!"))
+    return MatcherResult(status: .fail, message: message.appended(details: "Inline Fragments Did Not Match!"))
   }
 
   for (index, typeCase) in zip(expected, actual).enumerated() {
     guard shallowlyMatch(expected: typeCase.0, actual: typeCase.1) else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: message.appended(
           details: "Expected typeCases[\(index)] to equal \(typeCase.0), got \(typeCase.1)."
@@ -447,7 +447,7 @@ fileprivate func shallowlyMatch<T: Collection>(
     }
   }
 
-  return PredicateResult(status: .matches, message: message)
+  return MatcherResult(status: .matches, message: message)
 }
 
 fileprivate func shallowlyMatch(
@@ -536,16 +536,16 @@ public struct ShallowFragmentSpreadMatcher: Equatable, CustomDebugStringConverti
 
 public func shallowlyMatch<T: Collection>(
   _ expectedValue: [ShallowFragmentSpreadMatcher]
-) -> Nimble.Predicate<T> where T.Element == IR.NamedFragmentSpread {
-  return Predicate.define { actual in
+) -> Nimble.Matcher<T> where T.Element == IR.NamedFragmentSpread {
+  return Matcher.define { actual in
     return shallowlyMatch(expected: expectedValue, actual: try actual.evaluate())
   }
 }
 
 public func shallowlyMatch<T: Collection>(
   _ expectedValue: [CompilationResult.FragmentDefinition]
-) -> Nimble.Predicate<T> where T.Element == IR.NamedFragmentSpread {
-  return Predicate.define { actual in
+) -> Nimble.Matcher<T> where T.Element == IR.NamedFragmentSpread {
+  return Matcher.define { actual in
     return shallowlyMatch(expected: expectedValue.map { .mock($0) }, actual: try actual.evaluate())
   }
 }
@@ -553,16 +553,16 @@ public func shallowlyMatch<T: Collection>(
 fileprivate func shallowlyMatch<T: Collection>(
   expected: [ShallowFragmentSpreadMatcher],
   actual: T?
-) -> PredicateResult where T.Element == IR.NamedFragmentSpread {
+) -> MatcherResult where T.Element == IR.NamedFragmentSpread {
   let message: ExpectationMessage = .expectedActualValueTo("have fragments equal to \(expected)")
   guard let actual = actual,
         expected.count == actual.count else {
-    return PredicateResult(status: .fail, message: message.appended(details: "Fragments Did Not Match!"))
+    return MatcherResult(status: .fail, message: message.appended(details: "Fragments Did Not Match!"))
   }
 
   for (index, fragment) in zip(expected, actual).enumerated() {
     guard shallowlyMatch(expected: fragment.0, actual: fragment.1) else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: message.appended(
           details: "Expected fragments[\(index)] to equal \(fragment.0), got \(fragment.1)."
@@ -571,7 +571,7 @@ fileprivate func shallowlyMatch<T: Collection>(
     }
   }
 
-  return PredicateResult(status: .matches, message: message)
+  return MatcherResult(status: .matches, message: message)
 }
 
 fileprivate func shallowlyMatch(expected: ShallowFragmentSpreadMatcher, actual: IR.NamedFragmentSpread) -> Bool {
@@ -581,13 +581,13 @@ fileprivate func shallowlyMatch(expected: ShallowFragmentSpreadMatcher, actual: 
   && expected.deferCondition == actual.typeInfo.deferCondition
 }
 
-// MARK: - Predicate Mapping
+// MARK: - Matcher Mapping
 
-extension Nimble.Predicate {
+extension Nimble.Matcher {
   func mappingActualTo<U>(
     _ actualMapper: @escaping ((U?) throws -> T?)
-  ) -> Nimble.Predicate<U> {
-    Nimble.Predicate<U>.define { (actual: Expression<U>) in
+  ) -> Nimble.Matcher<U> {
+    Nimble.Matcher<U>.define { (actual: Expression<U>) in
       let newActual = actual.cast(actualMapper)
       return try self.satisfies(newActual)
     }

--- a/Tests/ApolloCodegenTests/TestHelpers/LineByLineComparison.swift
+++ b/Tests/ApolloCodegenTests/TestHelpers/LineByLineComparison.swift
@@ -16,8 +16,8 @@ public func equalLineByLine(
   _ expectedValue: String,
   atLine startLine: Int = 1,
   ignoringExtraLines: Bool = false
-) -> Nimble.Predicate<String> {
-  return Predicate.define() { actual in
+) -> Nimble.Matcher<String> {
+  return Matcher.define() { actual in
     let actualString = try actual.evaluate()
 
     guard let actualLines = actualString?.lines(startingAt: startLine) else {
@@ -35,7 +35,7 @@ public func equalLineByLine(
       let actualLine = actualLines[index]
       guard let expectedLine = expectedLinesBuffer.popLast() else {
         if ignoringExtraLines {
-          return PredicateResult(
+          return MatcherResult(
             status: .matches,
             message: .expectedTo("be equal")
           )
@@ -56,13 +56,13 @@ public func equalLineByLine(
     }
 
     guard expectedLinesBuffer.isEmpty else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: .fail("Expected \(expectedLines.count), actual ended at line \(actualLines.count).")
       )
     }
 
-    return PredicateResult(
+    return MatcherResult(
       status: .matches,
       message: .expectedTo("be equal")
     )
@@ -72,12 +72,12 @@ public func equalLineByLine(
 fileprivate func PrettyPrintedFailureResult(
   actual: String?,
   message: ExpectationMessage
-) -> PredicateResult {
+) -> MatcherResult {
   if let actual = actual {
     print ("Actual Document:")
     print(actual)
   }
-  return PredicateResult(
+  return MatcherResult(
     status: .fail,
     message: message
   )
@@ -102,10 +102,10 @@ extension String {
 public func equalLineByLine(
   toFileAt expectedFileURL: URL,
   trimmingImports trimImports: Bool = false
-) -> Nimble.Predicate<String> {
-  return Predicate.define() { actual in
+) -> Nimble.Matcher<String> {
+  return Matcher.define() { actual in
     guard ApolloFileManager.default.doesFileExist(atPath: expectedFileURL.path) else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: .fail("File not found at \(expectedFileURL)")
       )

--- a/Tests/ApolloTests/JSONValueMatcher.swift
+++ b/Tests/ApolloTests/JSONValueMatcher.swift
@@ -2,16 +2,16 @@ import Nimble
 import Apollo
 import ApolloAPI
 
-public func equalJSONValue(_ expectedValue: JSONEncodable?) -> Predicate<JSONEncodable> {
-  return Predicate { actual in
+public func equalJSONValue(_ expectedValue: JSONEncodable?) -> Matcher<JSONEncodable> {
+  return Matcher { actual in
     let msg = ExpectationMessage.expectedActualValueTo("equal <\(stringify(expectedValue))>")
     if let actualValue = try actual.evaluate(), let expectedValue = expectedValue {
-        return PredicateResult(
+      return MatcherResult(
           bool: actualValue._jsonValue == expectedValue._jsonValue,
           message: msg
         )
     } else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: msg.appendedBeNilHint()
       )

--- a/Tests/ApolloTests/OperationMessageMatchers.swift
+++ b/Tests/ApolloTests/OperationMessageMatchers.swift
@@ -4,10 +4,10 @@ import Apollo
 @testable import ApolloWebSocket
 import ApolloAPI
 
-public func equalMessage(payload: JSONEncodableDictionary? = nil, id: String? = nil, type: OperationMessage.Types) -> Nimble.Predicate<String> {
-  return Nimble.Predicate.define { actualExpression in
+public func equalMessage(payload: JSONEncodableDictionary? = nil, id: String? = nil, type: OperationMessage.Types) -> Nimble.Matcher<String> {
+  return Nimble.Matcher.define { actualExpression in
     guard let actualValue = try actualExpression.evaluate() else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: .fail("Message cannot be nil - type is a required parameter.")
       )
@@ -15,12 +15,12 @@ public func equalMessage(payload: JSONEncodableDictionary? = nil, id: String? = 
 
     let expected = OperationMessage(payload: payload, id: id, type: type)
     guard actualValue == expected.rawMessage! else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: .expectedActualValueTo("equal \(expected)"))
     }
 
-    return PredicateResult(
+    return MatcherResult(
       status: .matches,
       message: .expectedTo("be equal")
     )

--- a/Tests/CodegenCLITests/Matchers/ErrorMatchers.swift
+++ b/Tests/CodegenCLITests/Matchers/ErrorMatchers.swift
@@ -4,8 +4,8 @@ import Nimble
 
 public func throwUserValidationError(
   _ expectedError: ValidationError
-) -> Nimble.Predicate<ParsableCommand> {
-  return Predicate { actualExpression in
+) -> Nimble.Matcher<ParsableCommand> {
+  return Matcher { actualExpression in
     var actualError: Error?
     do {
       _ = try actualExpression.evaluate()
@@ -14,7 +14,7 @@ public func throwUserValidationError(
     }
 
     guard let actualError = actualError else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: .fail("No error was thrown!")
       )
@@ -26,7 +26,7 @@ public func throwUserValidationError(
       let validationError = parserError as? ValidationError,
       validationError.message == expectedError.message
     else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: .expectedTo(
           "equal ValidationError(\"\(expectedError.self)\"), got \(actualError)"
@@ -34,15 +34,15 @@ public func throwUserValidationError(
       )
     }
 
-    return PredicateResult(
+    return MatcherResult(
       status: .matches,
       message: .expectedTo("be equal")
     )
   }
 }
 
-public func throwUnknownOptionError() -> Nimble.Predicate<ParsableCommand> {
-  return Predicate { actualExpression in
+public func throwUnknownOptionError() -> Nimble.Matcher<ParsableCommand> {
+  return Matcher { actualExpression in
     var actualError: Error?
     do {
       _ = try actualExpression.evaluate()
@@ -51,7 +51,7 @@ public func throwUnknownOptionError() -> Nimble.Predicate<ParsableCommand> {
     }
 
     guard let actualError = actualError else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: .fail("No error was thrown!")
       )
@@ -61,13 +61,13 @@ public func throwUnknownOptionError() -> Nimble.Predicate<ParsableCommand> {
       let commandError = actualError as? CommandError,
       case ParserError.unknownOption = commandError.parserError
     else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: .expectedTo("equal UnknownOption(), got \(actualError)")
       )
     }
 
-    return PredicateResult(
+    return MatcherResult(
       status: .matches,
       message: .expectedTo("be equal")
     )
@@ -77,8 +77,8 @@ public func throwUnknownOptionError() -> Nimble.Predicate<ParsableCommand> {
 public func throwError(
   localizedDescription: String,
   ignoringExtraCharacters: Bool = false
-) -> Nimble.Predicate<Any> {
-  return Predicate { actualExpression in
+) -> Nimble.Matcher<Any> {
+  return Matcher { actualExpression in
     var actualError: Error?
     do {
       _ = try actualExpression.evaluate()
@@ -87,7 +87,7 @@ public func throwError(
     }
 
     guard let actualError = actualError else {
-      return PredicateResult(
+      return MatcherResult(
         status: .fail,
         message: .fail("No error was thrown!")
       )
@@ -95,7 +95,7 @@ public func throwError(
 
     if ignoringExtraCharacters {
       if !actualError.localizedDescription.starts(with: localizedDescription) {
-        return PredicateResult(
+        return MatcherResult(
           status: .doesNotMatch,
           message: .expectedTo(
             "start with \"\(localizedDescription)\", got \"\(actualError.localizedDescription)\""
@@ -104,7 +104,7 @@ public func throwError(
       }
     } else {
       if !(actualError.localizedDescription == localizedDescription) {
-        return PredicateResult(
+        return MatcherResult(
           status: .doesNotMatch,
           message: .expectedTo(
             "equal \"\(localizedDescription)\", got \"\(actualError.localizedDescription)\""
@@ -113,7 +113,7 @@ public func throwError(
       }
     }
 
-    return PredicateResult(
+    return MatcherResult(
       status: .matches,
       message: .expectedTo("be equal")
     )


### PR DESCRIPTION
Nimble recently deprecated/renamed `Predicate` to `Matcher`, along with `PredicateResult` to `MatcherResult`. This PR fixes the depreciation warnings by renaming all instances.