### PR TITLE
Fix GraphQLOperationVariableValue conformance

### DIFF
--- a/apollo-ios/Sources/ApolloAPI/SchemaTypes/InputObject.swift
+++ b/apollo-ios/Sources/ApolloAPI/SchemaTypes/InputObject.swift
@@ -7,8 +7,8 @@ public protocol InputObject: GraphQLOperationVariableValue, JSONEncodable, Hasha
 }
 
 extension InputObject {
-  public var _jsonValue: JSONValue { jsonEncodableValue?._jsonValue }
-  public var jsonEncodableValue: (any JSONEncodable)? { __data._jsonEncodableValue }
+  public var _jsonValue: JSONValue { _jsonEncodableValue?._jsonValue }
+  public var _jsonEncodableValue: (any JSONEncodable)? { __data._jsonEncodableValue }
 
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.__data == rhs.__data


### PR DESCRIPTION
- [GraphQLOperationVariableValue](https://github.com/apollographql/apollo-ios-dev/blob/550bf291989d0b52cbf5992b7a8b341f77f5a123/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift#L114-L116) protocol defined with property `_jsonEncodableValue` (containing underscore)
- [InputObject](https://github.com/apollographql/apollo-ios-dev/blob/550bf291989d0b52cbf5992b7a8b341f77f5a123/apollo-ios/Sources/ApolloAPI/SchemaTypes/InputObject.swift#L5-L11) conformance to `GraphQLOperationVariableValue` with `jsonEncodableValue` (not containing underscore)
- This PR adds the underscore to fix the protocol conformance