### PR TITLE
Replace ApolloStoreSubscriber didChangeKeys with ApolloStore.Activity…

### DIFF
--- a/Tests/ApolloTests/Cache/StoreSubscriptionTests.swift
+++ b/Tests/ApolloTests/Cache/StoreSubscriptionTests.swift
@@ -2,20 +2,53 @@ import Nimble
 import XCTest
 @testable import Apollo
 
-class StoreSubscriptionTests: XCTestCase {
+open class StoreSubscriptionTests: XCTestCase {
   static let defaultWaitTimeout: TimeInterval = 1
 
   var store: ApolloStore!
 
-  override func setUpWithError() throws {
+  open override func setUpWithError() throws {
     try super.setUpWithError()
     store = ApolloStore()
   }
 
-  override func tearDownWithError() throws {
+  open override func tearDownWithError() throws {
     store = nil
     try super.tearDownWithError()
   }
+
+  // MARK: - Tests
+
+  func testUnsubscribeRemovesSubscriberFromApolloStore() throws {
+    let subscriber = NoopSubscriber()
+
+    store.subscribe(subscriber)
+
+    store.unsubscribe(subscriber)
+
+    expect(self.store.subscribers).toEventually(beEmpty())
+  }
+
+  /// Fufills the provided expectation when all expected keys have been observed.
+  internal class NoopSubscriber: ApolloStoreSubscriber {
+
+    init() {}
+
+    func store(_ store: ApolloStore,
+               didChangeKeys changedKeys: Set<CacheKey>,
+               contextIdentifier: UUID?) {
+      // not implemented, deprecated
+    }
+
+    func store(_ store: Apollo.ApolloStore,
+               activity: Apollo.ApolloStore.Activity,
+               contextIdentifier: UUID?) throws {
+      // not implemented
+    }
+  }
+}
+
+final class StoreSubscriptionSimpleTests: StoreSubscriptionTests {
 
   // MARK: - Tests
 
@@ -39,16 +72,6 @@ class StoreSubscriptionTests: XCTestCase {
     wait(for: [cacheKeyChangeExpectation], timeout: Self.defaultWaitTimeout)
   }
 
-  func testUnsubscribeRemovesSubscriberFromApolloStore() throws {
-    let subscriber = SimpleSubscriber(XCTestExpectation(), [])
-
-    store.subscribe(subscriber)
-
-    store.unsubscribe(subscriber)
-
-    expect(self.store.subscribers).toEventually(beEmpty())
-  }
-
   /// Fufills the provided expectation when all expected keys have been observed.
   internal class SimpleSubscriber: ApolloStoreSubscriber {
     private let expectation: XCTestExpectation
@@ -62,8 +85,71 @@ class StoreSubscriptionTests: XCTestCase {
     func store(_ store: ApolloStore,
                didChangeKeys changedKeys: Set<CacheKey>,
                contextIdentifier: UUID?) {
+      // not implemented, deprecated
+    }
+
+    func store(_ store: Apollo.ApolloStore,
+               activity: Apollo.ApolloStore.Activity,
+               contextIdentifier: UUID?) throws {
+      // To match the old didChangeKeys ApolloStoreSubscriber behavior, only operation on the "did merge" action.
+      guard case .did(perform: .merge, outcome: .changedKeys(let changedKeys)) = activity else {
+        return
+      }
       changeSet.subtract(changedKeys)
       if (changeSet.isEmpty) {
+        expectation.fulfill()
+      }
+    }
+  }
+}
+
+final class StoreSubscriptionAdvancedTests: StoreSubscriptionTests {
+
+  // MARK: - Tests
+
+  func testSubscriberIsNotifiedOfStoreUpdate() throws {
+    let records: RecordSet = [
+      "QUERY_ROOT": [
+        "__typename": "Hero",
+        "name": "Han Solo"
+      ]
+    ]
+    let cacheSubscriberExpectation = XCTestExpectation(description: "Subscriber is notified of all expected activities")
+    let expectedActivitiesSet: Set<ApolloStore.Activity> = [
+        .will(perform: .merge(records: records)),
+        .did(perform: .merge(records: records), outcome: .changedKeys(["QUERY_ROOT.__typename", "QUERY_ROOT.name"]))
+    ]
+    let subscriber = AdvancedSubscriber(cacheSubscriberExpectation, expectedActivitiesSet)
+
+    store.subscribe(subscriber)
+    addTeardownBlock { self.store.unsubscribe(subscriber) }
+
+    store.publish(records: records)
+
+    wait(for: [cacheSubscriberExpectation], timeout: Self.defaultWaitTimeout)
+  }
+
+  /// Fufills the provided expectation when all expected keys have been observed.
+  internal class AdvancedSubscriber: ApolloStoreSubscriber {
+    private let expectation: XCTestExpectation
+    private var activities: Set<ApolloStore.Activity>
+
+    init(_ expectation: XCTestExpectation, _ activities: Set<ApolloStore.Activity>) {
+      self.expectation = expectation
+      self.activities = activities
+    }
+
+    func store(_ store: ApolloStore,
+               didChangeKeys changedKeys: Set<CacheKey>,
+               contextIdentifier: UUID?) {
+      // not implemented, deprecated
+    }
+
+    func store(_ store: Apollo.ApolloStore,
+               activity: Apollo.ApolloStore.Activity,
+               contextIdentifier: UUID?) throws {
+      activities.remove(activity)
+      if (activities.isEmpty) {
         expectation.fulfill()
       }
     }

--- a/apollo-ios/Sources/Apollo/DataLoader.swift
+++ b/apollo-ios/Sources/Apollo/DataLoader.swift
@@ -1,5 +1,5 @@
 final class DataLoader<Key: Hashable, Value> {
-  public typealias BatchLoad = (Set<Key>) throws -> [Key: Value]
+  public typealias BatchLoad = (Set<Key>) throws -> [Key: Value]?
   private var batchLoad: BatchLoad
 
   private var cache: [Key: Result<Value?, Error>] = [:]
@@ -29,12 +29,12 @@ final class DataLoader<Key: Hashable, Value> {
     let values = try batchLoad(pendingLoads)
     
     for key in pendingLoads {
-      cache[key] = .success(values[key])
+      cache[key] = .success(values?[key])
     }
     
     pendingLoads.removeAll()
         
-    return values[key]
+    return values?[key]
   }
   
   func removeAll() {

--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -99,6 +99,17 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   public func store(_ store: ApolloStore,
                     didChangeKeys changedKeys: Set<CacheKey>,
                     contextIdentifier: UUID?) {
+    // not implemented, deprecated
+  }
+
+  public func store(_ store: Apollo.ApolloStore,
+             activity: Apollo.ApolloStore.Activity,
+             contextIdentifier: UUID?) throws {
+    // To match the old didChangeKeys ApolloStoreSubscriber behavior, only operation on the "did merge" action.
+    guard case .did(perform: .merge, outcome: .changedKeys(let changedKeys)) = activity else {
+      return
+    }
+
     if
       let incomingIdentifier = contextIdentifier,
       incomingIdentifier == self.contextIdentifier {


### PR DESCRIPTION
The following changes are to support the need to hook up data residing in separate stores into the life-cycle of the data in ApolloStore. This PR represents 1 of 2 ways I considered accomplishing this.
1. Implement `NormalizeCache` by wrapping another implementation of `NormalizedCache` and forwarding calls to it.
2. A more robust `ApolloStoreSubsciber`, i.e. this PR

I decided that I was submitting 2 as a PR because I believe the interface is an improvement to what is currently in main (the didChangeKeys subscriber method). The didChangeKeys call follows a call to `cache.merge(records:)`, which is covered in this PR's implementation as the following:
```swift
  public func store(_ store: Apollo.ApolloStore,
             activity: Apollo.ApolloStore.Activity,
             contextIdentifier: UUID?) throws {
    if case .did(perform: .merge, outcome: .changedKeys(let changedKeys)) = activity {
      self.store(store, didChangeKeys: changedKeys, contextIdentifier: contextIdentifier)
    }
  }
```

Example:
```swift
final class MyOtherStoreApolloStoreSubscriber {

    private class UnsubscribeRef {
        private let _unsubscribe: () -> Void
        public init(unsubscribe: @escaping () -> Void) {
            _unsubscribe = unsubscribe
        }
        deinit {
            _unsubscribe()
        }
    }
    private lazy var unsubscribeRefs = [String: UnsubscribeRef]()

    private func shouldSubscribeToMyOtherStore(for record: Apollo.Record) -> Bool {
        /* boolean to determine whether or not you should subscribe to my other store for the provided record */
        return unsubscribeRefs[record.key] == nil 
    }

    private func subscribeToMyOtherStore(_ otherStoreListener: () -> Void) -> () -> Void {
        /* stuff to subscribe to my other store in here */
        return { /* stuff to unsubscribe from my other store in here, weak self please! */ }
    }

    private func syncMyOtherStoreWith(store: ApolloStore, records: [Apollo.CacheKey: Apollo.Record]) throws {
        for (key, record) in records {
            if shouldSubscribeToMyOtherStore(for: record) {
                unsubscribeRefs[key] = UnsubscribeRef(unsubscribe: subscribeToMyOtherStore({
                    /* stuff to handle my other store changes in here */
                }))
            }
        }
    }
}

extension MyOtherStoreApolloStoreSubscriber: ApolloStoreSubscriber {

    public func store(_ store: Apollo.ApolloStore, didChangeKeys changedKeys: Set<Apollo.CacheKey>, contextIdentifier: UUID?) {
        /* not implemented, this is now deprecated */
    }

    public func store(_ store: Apollo.ApolloStore, activity: Apollo.ApolloStore.Activity, contextIdentifier: UUID?) throws {
        switch activity {
        case .will(perform: .merge(records: let records)):
            try syncMyOtherStoreWith(store: store, records: records.storage)
        case .did(perform: .loadRecords, outcome: .records(let records)):
            try syncMyOtherStoreWith(store: store, records: records)
        case .did(perform: .removeRecord(for: let key), outcome: .success):
            unsubscribeRefs.removeValue(forKey: key)
        case .did(perform: .removeRecords(matching: let pattern), outcome: .success):
            for key in unsubscribeRefs.keys {
                if key.range(of: pattern, options: .caseInsensitive) != nil {
                    unsubscribeRefs.removeValue(forKey: key)
                }
            }
        case .did(perform: .clear, outcome: .success):
            unsubscribeRefs.removeAll()
        default:
            return
        }
    }
}
```