### PR TITLE
ci: Do not install xcbeautify

### DIFF
--- a/.github/actions/build-and-run-unit-tests/action.yml
+++ b/.github/actions/build-and-run-unit-tests/action.yml
@@ -13,11 +13,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-  # Look into caching the xcbeautify installation to instead of installing for each test
-  - name: Install XCBeautify
-    shell: bash
-    run: |
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify
   - name: Build and Test
     shell: bash
     run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -199,10 +199,6 @@ jobs:
         xcode-version: ${{ env.XCODE_VERSION }}
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Install XCBeautify
-      shell: bash
-      run: |
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify
     - name: Test Codegen Configurations
       shell: bash
       run: |

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -227,10 +227,6 @@ jobs:
         xcode-version: ${{ env.XCODE_VERSION }}
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Install XCBeautify
-      shell: bash
-      run: |
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify
     - name: Test Codegen Configurations
       shell: bash
       run: |


### PR DESCRIPTION
I noticed [this warning](https://github.com/apollographql/apollo-ios-dev/actions/runs/8602142168/job/23571075344?pr=329#step:5:18) earlier in a CI log.
> `>` Run HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify
> Warning: xcbeautify 2.0.1 is already installed and up-to-date.
> To reinstall 2.0.1, run:
>   brew reinstall xcbeautify

Seems like we do not need to install `xcbeautify` on CI because it's already included in [the `macos-13` image](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md).