### PR TITLE
docs: In-memory cache note

### DIFF
--- a/docs/source/caching/cache-setup.mdx
+++ b/docs/source/caching/cache-setup.mdx
@@ -27,6 +27,12 @@ A few examples of this are:
 
 For data that is short-lived, the simplicity of having a clear cache at the beginning of each application run, combined with the improved performance, may make an `InMemoryNormalizedCache` a good choice.
 
+<Note>
+
+`InMemoryNormalizedCache` **does not** implement any auto-eviction policies. This means your application is responsible for reacting to any low memory notifications and taking action to either clear the cache or remove select records. 
+
+</Note>
+
 ### Setup
 
 To use an `InMemoryNormalizedCache`, no additional work is necessary!

--- a/docs/source/caching/cache-setup.mdx
+++ b/docs/source/caching/cache-setup.mdx
@@ -62,9 +62,11 @@ A few examples of this are:
 
 For data that you want to persist between application runs, the `SQLiteNormalizedCache` may fit your needs.
 
-> **Note: Caching Sensitive Data**
->
-> When persisting cache data to disk, be sure to consider if any sensitive data is being written to the cache. Cache data is stored in plain-text and can be retrieved from the device. You may need to sanitize your cache data or encrypt the cache file.
+<Note>
+
+When persisting cache data to disk, be sure to consider if any sensitive data is being written to the cache. Cache data is stored in plain-text and can be retrieved from the device. You may need to sanitize your cache data or encrypt the cache file.
+
+</Note>
 
 ### Setup
 


### PR DESCRIPTION
Related to https://github.com/apollographql/apollo-ios/issues/3365.

* Adds a note to the [`InMemoryNormalizedCache ` cache documentation](https://www.apollographql.com/docs/ios/caching/cache-setup#inmemorynormalizedcache) re. auto-eviction policies
* Updates another note in the same page to use the new `<note>` tag