### PR TITLE
feature: Enable visionOS Support

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "e78ae0220e17525a15ac68c697a155eb7a672a8e",
-        "version" : "0.15.0"
+        "revision" : "f0af5e0a2b6917ae38e3019e3456fd0fa9365864",
+        "version" : "0.15.1"
       }
     },
     {

--- a/.package.resolved
+++ b/.package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "efe11bbca024b57115260709b5c05e01131470d0",
-        "version" : "13.2.1"
+        "revision" : "1c49fc1243018f81a7ea99cb5e0985b00096e9f4",
+        "version" : "13.3.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
-        "version" : "1.3.0"
+        "revision" : "46989693916f56d1186bd59ac15124caef896560",
+        "version" : "1.3.1"
       }
     },
     {

--- a/Project.swift
+++ b/Project.swift
@@ -8,7 +8,7 @@ let project = Project(
     organizationName: "apollographql",
     packages: [
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.2.0"),
-        .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.13.1"),
+        .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.1"),
         .package(path: "apollo-ios"),
         .package(path: "apollo-ios-codegen"),
         .package(path: "apollo-ios-pagination"),

--- a/apollo-ios-codegen/Package.swift
+++ b/apollo-ios-codegen/Package.swift
@@ -19,10 +19,10 @@ let package = Package(
       .upToNextMajor(from: "1.0.0")),
     .package(
       url: "https://github.com/apple/swift-collections",
-      .upToNextMajor(from: "1.0.6")),
+      .upToNextMajor(from: "1.1.0")),
     .package(
       url: "https://github.com/apple/swift-argument-parser.git", 
-      .upToNextMajor(from: "1.2.0")),
+      .upToNextMajor(from: "1.3.0")),
   ],
   targets: [
     .target(

--- a/apollo-ios/Apollo.podspec
+++ b/apollo-ios/Apollo.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.subspec 'SQLite' do |ss|
     ss.source_files = 'Sources/ApolloSQLite/*.swift'
     ss.dependency 'Apollo/Core'
-    ss.dependency 'SQLite.swift', '~>0.13.1'
+    ss.dependency 'SQLite.swift', '~>0.15.1'
     ss.resource_bundles = {
       'ApolloSQLite' => ['Sources/ApolloSQLite/Resources/PrivacyInfo.xcprivacy']
     }

--- a/apollo-ios/Apollo.podspec
+++ b/apollo-ios/Apollo.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.14'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '5.0'
+  s.visionos.deployment_target = '1.0'
 
   cli_binary_name = 'apollo-ios-cli'
   s.preserve_paths = [cli_binary_name]

--- a/apollo-ios/Package.swift
+++ b/apollo-ios/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/stephencelis/SQLite.swift.git",
-      .upToNextMajor(from: "0.13.1")),
+      .upToNextMajor(from: "0.15.1")),
   ],
   targets: [
     .target(

--- a/apollo-ios/Package.swift
+++ b/apollo-ios/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
     .iOS(.v12),
     .macOS(.v10_14),
     .tvOS(.v12),
-    .watchOS(.v5)
+    .watchOS(.v5),
+    .visionOS(.v1),
   ],
   products: [
     .library(name: "Apollo", targets: ["Apollo"]),


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-ios/issues/3320.

With [SQLite.swift being updated to support visionOS](https://github.com/stephencelis/SQLite.swift/releases/tag/0.15.1) this:
* Updates our SQLite.swift dependency version
* Adds `visionOS` platform declarations
* Updates other dependency versions