### PR TITLE
Watcher refetch policy

### DIFF
--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -94,11 +94,13 @@ extension ApolloClient: ApolloClientProtocol {
 
   public func watch<Query: GraphQLQuery>(query: Query,
                                          cachePolicy: CachePolicy = .default,
+                                         refetchCachePolicy: CachePolicy? = nil,
                                          context: RequestContext? = nil,
                                          callbackQueue: DispatchQueue = .main,
                                          resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query> {
     let watcher = GraphQLQueryWatcher(client: self,
                                       query: query,
+                                      refetchCachePolicy: refetchCachePolicy,
                                       context: context,
                                       callbackQueue: callbackQueue,
                                       resultHandler: resultHandler)

--- a/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
@@ -39,12 +39,14 @@ public protocol ApolloClientProtocol: AnyObject {
   /// - Parameters:
   ///   - query: The query to fetch.
   ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
+  ///   - refetchCachePolicy: If provided (not `nil`), this value is used when deciding how to repsond to watched store changes.
   ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   ///   - callbackQueue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
   /// - Returns: A query watcher object that can be used to control the watching behavior.
   func watch<Query: GraphQLQuery>(query: Query,
                                   cachePolicy: CachePolicy,
+                                  refetchCachePolicy: CachePolicy?,
                                   context: RequestContext?,
                                   callbackQueue: DispatchQueue,
                                   resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query>


### PR DESCRIPTION
Sorry, I don't have much of a description here. I've just been having some difficulty rationalizing the Apollo-iOS watcher with Apollo-Kotlin's. I am aware that Apollo-Kotlin has a concept of both a fetchPolicy and a refetchPolicy, and the watcher of Apollo-Kotlin defaults to cache-only for refetch. This is what we want on iOS. We want to be able to invoke client.watch(), while providing both an initial fetch cache policy, and the refetch policy for how to determine what to do when the keys change. Basically allow the network on initial fetch, but never hit the network when handling a change.
I was looking through the Apollo-iOS code to see if this could be a non-breaking contribution, but I am realizing the difficulty of that and am about to write my own watcher to handle our needs. Any thoughts or suggestions would be appreciated.

My current implementation only tries to allow wrapping implementations to inject a refetchPolicy but not have any sort of default value so that `nil` means that it just uses current behavior. However what would actually make sense to lean into the same defaults as Apollo-Kotlin, i.e. cache-only for a watcher refetch.