### PR TITLE
GraphQLQueryWatcher: `publisher` property

### DIFF
--- a/apollo-ios/Package.swift
+++ b/apollo-ios/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
   name: "Apollo",
   platforms: [
     .iOS(.v12),
-    .macOS(.v10_14),
+    .macOS(.v10_15),
     .tvOS(.v12),
     .watchOS(.v5),
     .visionOS(.v1),


### PR DESCRIPTION
### What are you trying to accomplish?

I noticed that in situations where we have a large number of local cache updates and network cache updates, that we end up refreshing the UI far too often. By being able to treat the results of cache updates as a `Publisher`, we can place `throttle` or `debounce` functionality into the watcher's update stream. 

### What approach did you choose and why?

This PR introduces the following changes:
* [`apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift`](diffhunk://#diff-642389f551252b1671c22b4d281628bd3472fe810c25974f01a72257b781ad4dR178-R218): The `GraphQLQueryWatcher` class was extended to include a `CachePublisher` struct and a `WatcherSubscription` class, enabling the watcher to publish cache updates to subscribers. A `publisher()` method was also added to allow access to the `CachePublisher`.
  - This was chosen as an alternative to making the `GraphQLQueryWatcher` a `Publisher` itself, as it is an observer of the underlying cache. 
* [`apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift`](diffhunk://#diff-642389f551252b1671c22b4d281628bd3472fe810c25974f01a72257b781ad4dR33-R97): The `GraphQLQueryWatcher` class was refactored to include convenience initializers and a private initializer. The `resultHandler` was updated to trigger subscriptions when a result is received.
  - The original initializer was effectively left unchanged, meaning that there is no breaking change to existing consumers. 
  - A new initializer was added that does not take a result handler. This initializer expects users to then utilize the `publisher` property. 
* [`apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift`](diffhunk://#diff-642389f551252b1671c22b4d281628bd3472fe810c25974f01a72257b781ad4dL12-R13): The `resultHandler` property in the `GraphQLQueryWatcher` class was changed from a constant to an optional variable.
* [`apollo-ios/Package.swift`](diffhunk://#diff-3a2cd2d70a6f8cf86d3d3783c8f4d3c6ab2b29e3fc6524f9c9ca12dd513b6603L10-R10): **The minimum macOS version for the Apollo package was updated from 10.14 to 10.15**. This is because `Combine` is unsupported on 10.14. **This constitutes a breaking change for macOS 10.14 deployments**. 

### Anything you want to highlight for special attention from reviewers?

Employing this on the `GraphQLQueryWatcher` feels like the correct choice, as opposed to doing it in a [roundabout manner](https://github.com/joel-perry/ApolloCombine/tree/master?tab=readme-ov-file#usage) on the `ApolloClient`, but would require a version minimum increase to macOS 10_15. 

**NOTE**: I didn't tackle any macOS 10.15 deprecations. 


### Alternatives Considered:

- As per the OSS `ApolloCombine` project: an extension on `ApolloClient`. I chose to avoid this route because: it wouldn't integrate well with `ApolloPagination`, it would be wasteful if you want multiple subscribers on the same watcher.
- Pulling the behavior of `GraphQLQueryWatcher` into a protocol / creating a subclass of `GraphQLQueryWatcher` that has this behavior. I chose not to do this since it seems less discoverable, and perhaps a bit arbitrary. It has the advantage of not needing a version bump. 