### PR TITLE
Add refetchOnFailedUpdates to query watcher

### DIFF
--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -826,7 +826,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
   }
 
-  func testWatchedQuery_givenRefetchOnFailedUpdates_false_doesNotrefetchFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
+  func testWatchedQuery_givenRefetchOnFailedUpdates_false_doesNotRefetchFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
     class HeroAndFriendsIDsSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[
         .field("hero", Hero?.self)

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -826,6 +826,146 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
   }
 
+  func testWatchedQuery_givenRefetchOnFailedUpdates_false_doesNotrefetchFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
+    class HeroAndFriendsIDsSelectionSet: MockSelectionSet {
+      override class var __selections: [Selection] {[
+        .field("hero", Hero?.self)
+      ]}
+
+      var hero: Hero? { __data["hero"] }
+
+      class Hero: MockSelectionSet {
+        override class var __selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("friends", [Friend]?.self),
+        ]}
+
+        var friends: [Friend]? { __data["friends"] }
+
+        class Friend: MockSelectionSet {
+          override class var __selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("id", String.self),
+          ]}
+        }
+      }
+    }
+
+    class HeroAndFriendsNameWithIDsSelectionSet: MockSelectionSet {
+      override class var __selections: [Selection] {[
+        .field("hero", Hero?.self)
+      ]}
+
+      var hero: Hero? { __data["hero"] }
+
+      class Hero: MockSelectionSet {
+        override class var __selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend]?.self),
+        ]}
+
+        var friends: [Friend]? { __data["friends"] }
+
+        class Friend: MockSelectionSet {
+          override class var __selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .field("name", String.self),
+          ]}
+
+          var name: String { __data["name"] }
+        }
+      }
+    }
+
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+
+    let watchedQuery = MockQuery<HeroAndFriendsNameWithIDsSelectionSet>()
+
+    let resultObserver = makeResultObserver(for: watchedQuery)
+
+    let watcher = GraphQLQueryWatcher(client: client,
+                                      query: watchedQuery,
+                                      refetchOnFailedUpdates: false,
+                                      resultHandler: resultObserver.handler)
+
+    addTeardownBlock { watcher.cancel() }
+
+    runActivity("Initial fetch from server") { _ in
+      let serverRequestExpectation =
+        server.expect(MockQuery<HeroAndFriendsNameWithIDsSelectionSet>.self) { request in
+        [
+          "data": [
+            "hero": [
+              "id": "2001",
+              "name": "R2-D2",
+              "__typename": "Droid",
+              "friends": [
+                ["__typename": "Human", "id": "1000", "name": "Luke Skywalker"],
+                ["__typename": "Human", "id": "1002", "name": "Han Solo"],
+                ["__typename": "Human", "id": "1003", "name": "Leia Organa"],
+              ]
+            ]
+          ]
+        ]
+      }
+
+      let initialWatcherResultExpectation = resultObserver.expectation(description: "Watcher received initial result from server") { result in
+        try XCTAssertSuccessResult(result) { graphQLResult in
+          XCTAssertEqual(graphQLResult.source, .server)
+          XCTAssertNil(graphQLResult.errors)
+
+          let data = try XCTUnwrap(graphQLResult.data)
+          XCTAssertEqual(data.hero?.name, "R2-D2")
+          let friendsNames = data.hero?.friends?.compactMap { $0.name }
+          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
+        }
+      }
+
+      watcher.fetch(cachePolicy: .fetchIgnoringCacheData)
+
+      wait(for: [serverRequestExpectation, initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    runActivity("Fetch other query with list of updated keys from server") { _ in
+      let serverRequestExpectation =
+        server.expect(MockQuery<HeroAndFriendsIDsSelectionSet>.self) { request in
+        [
+          "data": [
+            "hero": [
+              "id": "2001",
+              "name": "Artoo",
+              "__typename": "Droid",
+              "friends": [
+                ["__typename": "Human", "id": "1003"],
+                ["__typename": "Human", "id": "1004"],
+                ["__typename": "Human", "id": "1000"],
+              ]
+            ]
+          ]
+        ]
+      }
+
+      let updatedWatcherResultExpectation = resultObserver.expectation(
+        description: "Watcher received updated result from cache"
+      ) { _ in }
+      updatedWatcherResultExpectation.isInverted = true
+
+      let otherFetchCompletedExpectation = expectation(description: "Other fetch completed")
+
+      client.fetch(query: MockQuery<HeroAndFriendsIDsSelectionSet>(),
+                   cachePolicy: .fetchIgnoringCacheData) { result in
+        defer { otherFetchCompletedExpectation.fulfill() }
+        XCTAssertSuccessResult(result)
+      }
+
+      wait(for: [serverRequestExpectation, otherFetchCompletedExpectation, updatedWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
+    }
+  }
+
   func testWatchedQueryGetsUpdatedWhenObjectIsChangedByDirectStoreUpdate() throws {
     struct HeroAndFriendsNamesSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()

--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -77,12 +77,14 @@ extension ApolloClient: ApolloClientProtocol {
     self.store.clearCache(callbackQueue: callbackQueue, completion: completion)
   }
   
-  @discardableResult public func fetch<Query: GraphQLQuery>(query: Query,
-                                                            cachePolicy: CachePolicy = .default,
-                                                            contextIdentifier: UUID? = nil,
-                                                            context: RequestContext? = nil,
-                                                            queue: DispatchQueue = .main,
-                                                            resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable {
+  @discardableResult public func fetch<Query: GraphQLQuery>(
+    query: Query,
+    cachePolicy: CachePolicy = .default,
+    contextIdentifier: UUID? = nil,
+    context: RequestContext? = nil,
+    queue: DispatchQueue = .main,
+    resultHandler: GraphQLResultHandler<Query.Data>? = nil
+  ) -> Cancellable {
     return self.networkTransport.send(operation: query,
                                       cachePolicy: cachePolicy,
                                       contextIdentifier: contextIdentifier,
@@ -92,13 +94,17 @@ extension ApolloClient: ApolloClientProtocol {
     }
   }
 
-  public func watch<Query: GraphQLQuery>(query: Query,
-                                         cachePolicy: CachePolicy = .default,
-                                         context: RequestContext? = nil,
-                                         callbackQueue: DispatchQueue = .main,
-                                         resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query> {
+  public func watch<Query: GraphQLQuery>(
+    query: Query,
+    cachePolicy: CachePolicy = .default,
+    refetchOnFailedUpdates: Bool = true,
+    context: RequestContext? = nil,
+    callbackQueue: DispatchQueue = .main,
+    resultHandler: @escaping GraphQLResultHandler<Query.Data>
+  ) -> GraphQLQueryWatcher<Query> {
     let watcher = GraphQLQueryWatcher(client: self,
                                       query: query,
+                                      refetchOnFailedUpdates: refetchOnFailedUpdates,
                                       context: context,
                                       callbackQueue: callbackQueue,
                                       resultHandler: resultHandler)
@@ -107,12 +113,14 @@ extension ApolloClient: ApolloClientProtocol {
   }
 
   @discardableResult
-  public func perform<Mutation: GraphQLMutation>(mutation: Mutation,
-                                                 publishResultToStore: Bool = true,
-                                                 contextIdentifier: UUID? = nil,
-                                                 context: RequestContext? = nil,
-                                                 queue: DispatchQueue = .main,
-                                                 resultHandler: GraphQLResultHandler<Mutation.Data>? = nil) -> Cancellable {
+  public func perform<Mutation: GraphQLMutation>(
+    mutation: Mutation,
+    publishResultToStore: Bool = true,
+    contextIdentifier: UUID? = nil,
+    context: RequestContext? = nil,
+    queue: DispatchQueue = .main,
+    resultHandler: GraphQLResultHandler<Mutation.Data>? = nil
+  ) -> Cancellable {
     return self.networkTransport.send(
       operation: mutation,
       cachePolicy: publishResultToStore ? .default : .fetchIgnoringCacheCompletely,
@@ -126,11 +134,13 @@ extension ApolloClient: ApolloClientProtocol {
   }
 
   @discardableResult
-  public func upload<Operation: GraphQLOperation>(operation: Operation,
-                                                  files: [GraphQLFile],
-                                                  context: RequestContext? = nil,
-                                                  queue: DispatchQueue = .main,
-                                                  resultHandler: GraphQLResultHandler<Operation.Data>? = nil) -> Cancellable {
+  public func upload<Operation: GraphQLOperation>(
+    operation: Operation,
+    files: [GraphQLFile],
+    context: RequestContext? = nil,
+    queue: DispatchQueue = .main,
+    resultHandler: GraphQLResultHandler<Operation.Data>? = nil
+  ) -> Cancellable {
     guard let uploadingTransport = self.networkTransport as? UploadingNetworkTransport else {
       assertionFailure("Trying to upload without an uploading transport. Please make sure your network transport conforms to `UploadingNetworkTransport`.")
       queue.async {
@@ -146,11 +156,13 @@ extension ApolloClient: ApolloClientProtocol {
       resultHandler?(result)
     }
   }
-  
-  public func subscribe<Subscription: GraphQLSubscription>(subscription: Subscription,
-                                                           context: RequestContext? = nil,
-                                                           queue: DispatchQueue = .main,
-                                                           resultHandler: @escaping GraphQLResultHandler<Subscription.Data>) -> Cancellable {
+
+  public func subscribe<Subscription: GraphQLSubscription>(
+    subscription: Subscription,
+    context: RequestContext? = nil,
+    queue: DispatchQueue = .main,
+    resultHandler: @escaping GraphQLResultHandler<Subscription.Data>
+  ) -> Cancellable {
     return self.networkTransport.send(operation: subscription,
                                       cachePolicy: .default,
                                       contextIdentifier: nil,

--- a/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
@@ -39,15 +39,12 @@ public protocol ApolloClientProtocol: AnyObject {
   /// - Parameters:
   ///   - query: The query to fetch.
   ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
-  ///   - refetchOnFailedUpdates: Should the watcher perform a network fetch when it's watched
-  ///     objects have changed, but reloading them from the cache fails. Should default to `true`.
   ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
   ///   - callbackQueue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
   /// - Returns: A query watcher object that can be used to control the watching behavior.
   func watch<Query: GraphQLQuery>(query: Query,
                                   cachePolicy: CachePolicy,
-                                  refetchOnFailedUpdates: Bool,
                                   context: RequestContext?,
                                   callbackQueue: DispatchQueue,
                                   resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query>
@@ -125,32 +122,6 @@ public extension ApolloClientProtocol {
       contextIdentifier: nil,
       context: context,
       queue: queue,
-      resultHandler: resultHandler
-    )
-  }
-
-  /// Watches a query by first fetching an initial result from the server or from the local cache, depending on the current contents of the cache and the specified cache policy. After the initial fetch, the returned query watcher object will get notified whenever any of the data the query result depends on changes in the local cache, and calls the result handler again with the new result.
-  ///
-  /// - Parameters:
-  ///   - query: The query to fetch.
-  ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
-  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
-  ///   - callbackQueue: A dispatch queue on which the result handler will be called. Should default to the main queue.
-  ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
-  /// - Returns: A query watcher object that can be used to control the watching behavior.
-  func watch<Query: GraphQLQuery>(
-    query: Query,
-    cachePolicy: CachePolicy,
-    context: RequestContext?,
-    callbackQueue: DispatchQueue,
-    resultHandler: @escaping GraphQLResultHandler<Query.Data>
-  ) -> GraphQLQueryWatcher<Query> {
-    self.watch(
-      query: query,
-      cachePolicy: cachePolicy,
-      refetchOnFailedUpdates: true,
-      context: context,
-      callbackQueue: callbackQueue,
       resultHandler: resultHandler
     )
   }


### PR DESCRIPTION
This PR adds a `refetchOnFailedUpdates` to `GraphQLQueryWatcher`. When this is set to `false`, network fetches will no longer occur if the cache load for updates to a watched object fails. This features was added at the request of @jimisaacs.