### PR TITLE
defer: Adds incremental response cache writes

### DIFF
--- a/Tests/ApolloTests/Interceptors/IncrementalJSONResponseParsingInterceptorTests.swift
+++ b/Tests/ApolloTests/Interceptors/IncrementalJSONResponseParsingInterceptorTests.swift
@@ -1,4 +1,4 @@
-import Apollo
+@testable import Apollo
 import ApolloAPI
 import ApolloInternalTestHelpers
 import XCTest
@@ -22,9 +22,73 @@ class IncrementalJSONResponseParsingInterceptorTests: XCTestCase {
     }
   }
 
+  class AnimalQuery: MockQuery<AnimalQuery.AnAnimal> {
+    class AnAnimal: MockSelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {[
+        .field("animal", Animal.self),
+      ]}
+
+      var animal: Animal { __data["animal"] }
+
+      class Animal: AbstractMockSelectionSet<Animal.Fragments, MockSchemaMetadata> {
+        override class var __selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("species", String.self),
+          .deferred(DeferredGenus.self, label: "deferredGenus"),
+          .deferred(DeferredFriend.self, label: "deferredFriend"),
+        ]}
+
+        var species: String { __data["species"] }
+
+        struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) {
+            __data = _dataDict
+            _deferredGenus = Deferred(_dataDict: _dataDict)
+            _deferredFriend = Deferred(_dataDict: _dataDict)
+          }
+
+          @Deferred var deferredGenus: DeferredGenus?
+          @Deferred var deferredFriend: DeferredFriend?
+        }
+
+        class DeferredGenus: MockTypeCase {
+          override class var __selections: [Selection] {[
+            .field("genus", String.self),
+          ]}
+
+          var genus: String { __data["genus"] }
+        }
+
+        class DeferredFriend: MockTypeCase {
+          override class var __selections: [Selection] {[
+            .field("friend", Friend.self),
+          ]}
+
+          var friend: Friend { __data["friend"] }
+
+          class Friend: MockSelectionSet {
+            override class var __selections: [Selection] {[
+              .field("name", String.self),
+            ]}
+
+            var name: String { __data["name"] }
+          }
+        }
+      }
+    }
+
+    override class var deferredFragments: [DeferredFragmentIdentifier : any SelectionSet.Type]? {[
+      DeferredFragmentIdentifier(label: "deferredGenus", fieldPath: ["animal"]): AnAnimal.Animal.DeferredGenus.self,
+      DeferredFragmentIdentifier(label: "deferredFriend", fieldPath: ["animal"]): AnAnimal.Animal.DeferredFriend.self,
+    ]}
+  }
+
   let defaultTimeout = 0.5
 
-  // MARK: Errors
+  // MARK: - Errors
 
   func test__errors__givenNoResponse_shouldThrow() {
     // given
@@ -152,62 +216,6 @@ class IncrementalJSONResponseParsingInterceptorTests: XCTestCase {
 
   // MARK: Parsing tests
 
-  class AnimalQuery: MockQuery<AnimalQuery.AnAnimal> {
-    class AnAnimal: MockSelectionSet {
-      typealias Schema = MockSchemaMetadata
-
-      override class var __selections: [Selection] {[
-        .field("animal", Animal.self),
-      ]}
-
-      var animal: Animal { __data["animal"] }
-
-      class Animal: AbstractMockSelectionSet<Animal.Fragments, MockSchemaMetadata> {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("species", String.self),
-          .deferred(DeferredGenus.self, label: "deferredGenus"),
-          .deferred(DeferredFriend.self, label: "deferredFriend"),
-        ]}
-
-        var species: String { __data["species"] }
-
-        struct Fragments: FragmentContainer {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) {
-            __data = _dataDict
-            _deferredGenus = Deferred(_dataDict: _dataDict)
-            _deferredFriend = Deferred(_dataDict: _dataDict)
-          }
-
-          @Deferred var deferredGenus: DeferredGenus?
-          @Deferred var deferredFriend: DeferredFriend?
-        }
-
-        class DeferredGenus: MockTypeCase {
-          override class var __selections: [Selection] {[
-            .field("genus", String.self),
-          ]}
-
-          var genus: String { __data["genus"] }
-        }
-
-        class DeferredFriend: MockTypeCase {
-          override class var __selections: [Selection] {[
-            .field("friend", String.self),
-          ]}
-
-          var friend: String { __data["friend"] }
-        }
-      }
-    }
-
-    override class var deferredFragments: [DeferredFragmentIdentifier : any SelectionSet.Type]? {[
-      DeferredFragmentIdentifier(label: "deferredGenus", fieldPath: ["animal"]): AnAnimal.Animal.DeferredGenus.self,
-      DeferredFragmentIdentifier(label: "deferredFriend", fieldPath: ["animal"]): AnAnimal.Animal.DeferredFriend.self,
-    ]}
-  }
-
   func test__parsing__givenSingleIncrementalResult_shouldMergeResult() throws {
     // given
     let subject = InterceptorTester(interceptor: IncrementalJSONResponseParsingInterceptor())
@@ -329,7 +337,9 @@ class IncrementalJSONResponseParsingInterceptorTests: XCTestCase {
             {
               "label": "deferredFriend",
               "data": {
-                "friend": "Buster"
+                "friend": {
+                  "name": "Buster"
+                }
               },
               "path": [
                 "animal"
@@ -349,7 +359,137 @@ class IncrementalJSONResponseParsingInterceptorTests: XCTestCase {
       let graphQLResult = try? result.get()?.parsedResponse
       expect(graphQLResult?.data?.animal.species).to(equal("Canis Familiaris"))
       expect(graphQLResult?.data?.animal.fragments.deferredGenus?.genus).to(equal("Canis"))
-      expect(graphQLResult?.data?.animal.fragments.deferredFriend?.friend).to(equal("Buster"))
+      expect(graphQLResult?.data?.animal.fragments.deferredFriend?.friend.name).to(equal("Buster"))
+    }
+
+    wait(for: [incrementalExpectation], timeout: defaultTimeout)
+  }
+
+  // MARK: Cache Records Tests
+
+  func test__cacheRecords__givenMultipleIncrementalResults_shouldComputeCacheRecordsMatchingResults() throws {
+    // given
+    let subject = InterceptorTester(interceptor: IncrementalJSONResponseParsingInterceptor())
+
+    let partialExpectation = expectation(description: "Received partial response callback")
+    let incrementalExpectation = expectation(description: "Received incremental response callback")
+    incrementalExpectation.expectedFulfillmentCount = 2
+
+    // when
+    subject.intercept(
+      request: .mock(operation: AnimalQuery()),
+      response: .mock(data: """
+        {
+          "data": {
+            "animal": {
+              "__typename": "Animal",
+              "species": "Canis Familiaris"
+            }
+          }
+        }
+        """.data(using: .utf8)!)
+    ) { result in
+      defer {
+        partialExpectation.fulfill()
+      }
+
+      // then
+      expect(result).to(beSuccess())
+
+      let cacheRecords = try? result.get()?.cacheRecords
+      expect(cacheRecords).to(equal(RecordSet(records: [
+        Record(key: "QUERY_ROOT", [
+          "animal": CacheReference("QUERY_ROOT.animal")
+        ]),
+        Record(key: "QUERY_ROOT.animal", [
+          "__typename": "Animal",
+          "species": "Canis Familiaris"
+        ])
+      ])))
+    }
+
+    wait(for: [partialExpectation], timeout: defaultTimeout)
+
+    subject.intercept(
+      request: .mock(operation: AnimalQuery()),
+      response: .mock(data: """
+        {
+          "incremental": [
+            {
+              "label": "deferredGenus",
+              "data": {
+                "genus": "Canis"
+              },
+              "path": [
+                "animal"
+              ]
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+      )
+    ) { result in
+      defer {
+        incrementalExpectation.fulfill()
+      }
+
+      expect(result).to(beSuccess())
+
+      let cacheRecords = try? result.get()?.cacheRecords
+      expect(cacheRecords).to(equal(RecordSet(records: [
+        Record(key: "QUERY_ROOT", [
+          "animal": CacheReference("QUERY_ROOT.animal")
+        ]),
+        Record(key: "QUERY_ROOT.animal", [
+          "__typename": "Animal",
+          "genus": "Canis",
+          "species": "Canis Familiaris"
+        ])
+      ])))
+    }
+
+    subject.intercept(
+      request: .mock(operation: AnimalQuery()),
+      response: .mock(data: """
+        {
+          "incremental": [
+            {
+              "label": "deferredFriend",
+              "data": {
+                "friend": {
+                  "name": "Buster"
+                }
+              },
+              "path": [
+                "animal"
+              ]
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+      )
+    ) { result in
+      defer {
+        incrementalExpectation.fulfill()
+      }
+
+      expect(result).to(beSuccess())
+
+      let cacheRecords = try? result.get()?.cacheRecords
+      expect(cacheRecords).to(equal(RecordSet(records: [
+        Record(key: "QUERY_ROOT", [
+          "animal": CacheReference("QUERY_ROOT.animal")
+        ]),
+        Record(key: "QUERY_ROOT.animal", [
+          "__typename": "Animal",
+          "genus": "Canis",
+          "species": "Canis Familiaris",
+          "friend": CacheReference("QUERY_ROOT.animal.friend")
+        ]),
+        Record(key: "QUERY_ROOT.animal.friend", [
+          "name": "Buster"
+        ])
+      ])))
     }
 
     wait(for: [incrementalExpectation], timeout: defaultTimeout)

--- a/apollo-ios/Sources/Apollo/CacheWriteInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/CacheWriteInterceptor.swift
@@ -49,16 +49,6 @@ public struct CacheWriteInterceptor: ApolloInterceptor {
       return
     }
 
-    guard !Operation.hasDeferredFragments else {
-      chain.proceedAsync(
-        request: request,
-        response: response,
-        interceptor: self,
-        completion: completion
-      )
-      return
-    }
-
     guard
       let createdResponse = response,
       let cacheRecords = createdResponse.cacheRecords


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-ios/issues/3362.

With only minor changes we've got cache writing successfully working for the partial and incremental responses of operations using `@defer`.
* Adds storage for cache records to `IncrementalJSONResponseParsingInterceptor` so they can be merged when multiple incremental results are received in the same response.
* Removes the early-exit in `CacheWriteInterceptor` to disable cache writes for operations using `@defer`.
* Adds tests for incremental cache writes.