### PR TITLE
Deprecate localCacheMutation selectionSetInitializer option

### DIFF
--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -116,9 +116,6 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "inputObjects" : "none"
           },
           "deprecatedEnumCases" : "exclude",
-          "fieldMerging" : [
-            "all"
-          ],
           "markOperationDefinitionsAsFinal" : true,
           "operationDocumentFormat" : [
             "definition"

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -137,7 +137,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           },
           "schemaDocumentation" : "exclude",
           "selectionSetInitializers" : {
-            "localCacheMutations" : true
+
           },
           "warningsOnDeprecatedUsage" : "exclude"
         },
@@ -513,66 +513,12 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     expect(decoded).to(equal([]))
   }
 
-  func test__encode_selectionSetInitializers__givenLocalCacheMutations_shouldReturnObjectString() throws {
-    // given
-    let subject: ApolloCodegenConfiguration.SelectionSetInitializers = [.localCacheMutations]
-
-    let expected = """
-    {
-      "localCacheMutations" : true
-    }
-    """
-
-    // when
-    let actual = try testJSONEncoder.encode(subject).asString
-
-    // then
-    expect(actual).to(equal(expected))
-  }
-
-  func test__decode_selectionSetInitializers__givenLocalCacheMutations_shouldReturnOptions() throws {
-    // given
-    let subject = """
-    {
-      "localCacheMutations": true
-    }
-    """.asData
-
-    // when
-    let decoded = try JSONDecoder().decode(
-      ApolloCodegenConfiguration.SelectionSetInitializers.self,
-      from: subject
-    )
-
-    // then
-    expect(decoded).to(equal(.localCacheMutations))
-  }
-
-  func test__decode_selectionSetInitializers__givenLocalCacheMutations_false_shouldReturnEmptyOptions() throws {
-    // given
-    let subject = """
-    {
-      "localCacheMutations": false
-    }
-    """.asData
-
-    // when
-    let decoded = try JSONDecoder().decode(
-      ApolloCodegenConfiguration.SelectionSetInitializers.self,
-      from: subject
-    )
-
-    // then
-    expect(decoded).to(equal([]))
-  }
-
   func test__encode_selectionSetInitializers__givenAll_shouldReturnObjectString() throws {
     // given
     let subject: ApolloCodegenConfiguration.SelectionSetInitializers = .all
 
     let expected = """
     {
-      "localCacheMutations" : true,
       "namedFragments" : true,
       "operations" : true
     }
@@ -590,8 +536,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     let subject = """
     {
       "operations" : true,
-      "namedFragments" : true,
-      "localCacheMutations" : true
+      "namedFragments" : true
     }
     """.asData
 

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -116,6 +116,9 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "inputObjects" : "none"
           },
           "deprecatedEnumCases" : "exclude",
+          "fieldMerging" : [
+            "all"
+          ],
           "markOperationDefinitionsAsFinal" : true,
           "operationDocumentFormat" : [
             "definition"

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -2427,12 +2427,11 @@ class ApolloCodegenTests: XCTestCase {
       [.siblings, .namedFragments]
     ]
     let initializerOptions: [ApolloCodegenConfiguration.SelectionSetInitializers] = [
-      .all,
-      .localCacheMutations,
+      .all,      
       .operations,
       .namedFragments,
       .fragment(named: "TestFragment"),
-      [.operations, .localCacheMutations]
+      [.operations, .namedFragments]
     ]
 
     for fieldMergingOption in fieldMergingOptions {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -574,7 +574,7 @@ class FragmentTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine("}", atLine: 16, ignoringExtraLines: true))
   }
 
-  func test__render_givenNamedFragments_asLocalCacheMutation_configIncludeLocalCacheMutations_rendersInitializer() async throws {
+  func test__render_givenNamedFragments_asLocalCacheMutation_rendersInitializer() async throws {
     // given
     schemaSDL = """
       type Query {
@@ -612,7 +612,7 @@ class FragmentTemplateTests: XCTestCase {
     // when
     try await buildSubjectAndFragment(
       config: .mock(options: .init(
-        selectionSetInitializers: [.localCacheMutations]
+        selectionSetInitializers: []
       )))
 
     let actual = renderSubject()

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
@@ -670,7 +670,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
 
   // MARK: Initializer Rendering Config - Tests
 
-  func test__render_givenLocalCacheMutation_configIncludesLocalCacheMutations_rendersInitializer() async throws {
+  func test__render_givenLocalCacheMutation_rendersInitializer() async throws {
     // given
     schemaSDL = """
     type Query {
@@ -700,7 +700,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
     config = ApolloCodegenConfiguration.mock(
       schemaNamespace: "TestSchema",
       options: .init(
-        selectionSetInitializers: [.localCacheMutations]
+        selectionSetInitializers: []
       )
     )
 
@@ -711,86 +711,6 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
-  }
-
-  func test__render_givenLocalCacheMutation_configIncludesSpecificLocalCacheMutations_rendersInitializer() async throws {
-    // given
-    schemaSDL = """
-    type Query {
-      allAnimals: [Animal!]
-    }
-
-    type Animal {
-      species: String!
-    }
-    """
-
-    document = """
-    query TestOperation @apollo_client_ios_localCacheMutation {
-      allAnimals {
-        species
-      }
-    }
-    """
-
-    let expected =
-    """
-        }
-
-        init(
-    """
-
-    config = ApolloCodegenConfiguration.mock(
-      schemaNamespace: "TestSchema",
-      options: .init(
-        selectionSetInitializers: [.operation(named: "TestOperation")]
-      )
-    )
-
-    // when
-    try await buildSubjectAndOperation()
-
-    let actual = renderSubject()
-
-    // then
-    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
-  }
-
-  func test__render_givenLocalCacheMutation_configDoesNotIncludesLocalCacheMutations_doesNotRenderInitializer() async throws
-  {
-    // given
-    schemaSDL = """
-    type Query {
-      allAnimals: [Animal!]
-    }
-
-    type Animal {
-      species: String!
-    }
-    """
-
-    document = """
-    query TestOperation @apollo_client_ios_localCacheMutation {
-      allAnimals {
-        species
-      }
-    }
-    """
-
-    config = ApolloCodegenConfiguration.mock(
-      schemaNamespace: "TestSchema",
-      options: .init(
-        selectionSetInitializers: [.namedFragments]
-      )
-    )
-
-    // when
-    try await buildSubjectAndOperation()
-
-    let actual = renderSubject()
-
-    // then
-    expect(actual).to(equalLineByLine("    /// AllAnimal", atLine: 20, ignoringExtraLines: true))
   }
 
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -466,8 +466,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     public let schemaDocumentation: Composition
     /// Which generated selection sets should include generated initializers.
     public let selectionSetInitializers: SelectionSetInitializers
-    /// Which merged fields and named fragment accessors are generated. Defaults to `.all`.
-    public let fieldMerging: FieldMerging
     /// How to generate the operation documents for your generated operations.
     public let operationDocumentFormat: OperationDocumentFormat
     /// Customization options to be applie to the schema during code generation.
@@ -517,7 +515,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       public static let deprecatedEnumCases: Composition = .include
       public static let schemaDocumentation: Composition = .include
       public static let selectionSetInitializers: SelectionSetInitializers = [.localCacheMutations]
-      public static let fieldMerging: FieldMerging = [.all]
       public static let operationDocumentFormat: OperationDocumentFormat = .definition
       public static let schemaCustomization: SchemaCustomization = .init()
       public static let cocoapodsCompatibleImportStatements: Bool = false
@@ -536,7 +533,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///   - schemaDocumentation: Whether schema documentation is added to the generated files.
     ///   - selectionSetInitializers: Which generated selection sets should include
     ///     generated initializers.
-    ///   - fieldMerging: Which merged fields and named fragment accessors are generated.
     ///   - operationDocumentFormat: How to generate the operation documents for your generated operations.
     ///   - cocoapodsCompatibleImportStatements: Generate import statements that are compatible with
     ///     including `Apollo` via Cocoapods.
@@ -552,7 +548,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       deprecatedEnumCases: Composition = Default.deprecatedEnumCases,
       schemaDocumentation: Composition = Default.schemaDocumentation,
       selectionSetInitializers: SelectionSetInitializers = Default.selectionSetInitializers,
-      fieldMerging: FieldMerging = Default.fieldMerging,
       operationDocumentFormat: OperationDocumentFormat = Default.operationDocumentFormat,
       schemaCustomization: SchemaCustomization = Default.schemaCustomization,
       cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
@@ -565,7 +560,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       self.deprecatedEnumCases = deprecatedEnumCases
       self.schemaDocumentation = schemaDocumentation
       self.selectionSetInitializers = selectionSetInitializers
-      self.fieldMerging = fieldMerging
       self.operationDocumentFormat = operationDocumentFormat
       self.schemaCustomization = schemaCustomization
       self.cocoapodsCompatibleImportStatements = cocoapodsCompatibleImportStatements
@@ -583,7 +577,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       case deprecatedEnumCases
       case schemaDocumentation
       case selectionSetInitializers
-      case fieldMerging
       case apqs
       case operationDocumentFormat
       case schemaCustomization
@@ -617,11 +610,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
         SelectionSetInitializers.self,
         forKey: .selectionSetInitializers
       ) ?? Default.selectionSetInitializers
-
-      fieldMerging = try values.decodeIfPresent(
-        FieldMerging.self,
-        forKey: .fieldMerging
-      ) ?? Default.fieldMerging
 
       operationDocumentFormat = try values.decodeIfPresent(
         OperationDocumentFormat.self,
@@ -671,7 +659,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       try container.encode(self.deprecatedEnumCases, forKey: .deprecatedEnumCases)
       try container.encode(self.schemaDocumentation, forKey: .schemaDocumentation)
       try container.encode(self.selectionSetInitializers, forKey: .selectionSetInitializers)
-      try container.encode(self.fieldMerging, forKey: .fieldMerging)
       try container.encode(self.operationDocumentFormat, forKey: .operationDocumentFormat)
       try container.encode(self.schemaCustomization, forKey: .schemaCustomization)
       try container.encode(self.cocoapodsCompatibleImportStatements, forKey: .cocoapodsCompatibleImportStatements)
@@ -1507,8 +1494,7 @@ extension ApolloCodegenConfiguration.OutputOptions {
   ///   - deprecatedEnumCases: How deprecated enum cases from the schema should be handled.
   ///   - schemaDocumentation: Whether schema documentation is added to the generated files.
   ///   - selectionSetInitializers: Which generated selection sets should include
-  ///     generated initializers.
-  ///   - fieldMerging: Which merged fields and named fragment accessors are generated.
+  ///     generated initializers.  
   ///   - apqs: Whether the generated operations should use Automatic Persisted Queries.
   ///   - cocoapodsCompatibleImportStatements: Generate import statements that are compatible with
   ///     including `Apollo` via Cocoapods.
@@ -1528,7 +1514,6 @@ extension ApolloCodegenConfiguration.OutputOptions {
     deprecatedEnumCases: ApolloCodegenConfiguration.Composition = Default.deprecatedEnumCases,
     schemaDocumentation: ApolloCodegenConfiguration.Composition = Default.schemaDocumentation,
     selectionSetInitializers: ApolloCodegenConfiguration.SelectionSetInitializers = Default.selectionSetInitializers,
-    fieldMerging: ApolloCodegenConfiguration.FieldMerging = Default.fieldMerging,
     apqs: ApolloCodegenConfiguration.APQConfig,
     cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = Default.warningsOnDeprecatedUsage,
@@ -1540,7 +1525,6 @@ extension ApolloCodegenConfiguration.OutputOptions {
     self.deprecatedEnumCases = deprecatedEnumCases
     self.schemaDocumentation = schemaDocumentation
     self.selectionSetInitializers = selectionSetInitializers
-    self.fieldMerging = fieldMerging
     self.operationDocumentFormat = apqs.operationDocumentFormat
     self.cocoapodsCompatibleImportStatements = cocoapodsCompatibleImportStatements
     self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
@@ -1561,7 +1545,6 @@ extension ApolloCodegenConfiguration.OutputOptions {
   ///   - schemaDocumentation: Whether schema documentation is added to the generated files.
   ///   - selectionSetInitializers: Which generated selection sets should include
   ///     generated initializers.
-  ///   - fieldMerging: Which merged fields and named fragment accessors are generated.
   ///   - operationDocumentFormat: How to generate the operation documents for your generated operations.
   ///   - cocoapodsCompatibleImportStatements: Generate import statements that are compatible with
   ///     including `Apollo` via Cocoapods.
@@ -1581,7 +1564,6 @@ extension ApolloCodegenConfiguration.OutputOptions {
     deprecatedEnumCases: ApolloCodegenConfiguration.Composition = Default.deprecatedEnumCases,
     schemaDocumentation: ApolloCodegenConfiguration.Composition = Default.schemaDocumentation,
     selectionSetInitializers: ApolloCodegenConfiguration.SelectionSetInitializers = Default.selectionSetInitializers,
-    fieldMerging: ApolloCodegenConfiguration.FieldMerging = Default.fieldMerging,
     operationDocumentFormat: ApolloCodegenConfiguration.OperationDocumentFormat = Default.operationDocumentFormat,
     cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = Default.warningsOnDeprecatedUsage,
@@ -1593,7 +1575,6 @@ extension ApolloCodegenConfiguration.OutputOptions {
     self.deprecatedEnumCases = deprecatedEnumCases
     self.schemaDocumentation = schemaDocumentation
     self.selectionSetInitializers = selectionSetInitializers
-    self.fieldMerging = fieldMerging
     self.operationDocumentFormat = operationDocumentFormat
     self.cocoapodsCompatibleImportStatements = cocoapodsCompatibleImportStatements
     self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -466,6 +466,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     public let schemaDocumentation: Composition
     /// Which generated selection sets should include generated initializers.
     public let selectionSetInitializers: SelectionSetInitializers
+    /// Which merged fields and named fragment accessors are generated. Defaults to `.all`.
+    public let fieldMerging: FieldMerging
     /// How to generate the operation documents for your generated operations.
     public let operationDocumentFormat: OperationDocumentFormat
     /// Customization options to be applie to the schema during code generation.
@@ -515,6 +517,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       public static let deprecatedEnumCases: Composition = .include
       public static let schemaDocumentation: Composition = .include
       public static let selectionSetInitializers: SelectionSetInitializers = [.localCacheMutations]
+      public static let fieldMerging: FieldMerging = [.all]
       public static let operationDocumentFormat: OperationDocumentFormat = .definition
       public static let schemaCustomization: SchemaCustomization = .init()
       public static let cocoapodsCompatibleImportStatements: Bool = false
@@ -533,6 +536,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///   - schemaDocumentation: Whether schema documentation is added to the generated files.
     ///   - selectionSetInitializers: Which generated selection sets should include
     ///     generated initializers.
+    ///   - fieldMerging: Which merged fields and named fragment accessors are generated.
     ///   - operationDocumentFormat: How to generate the operation documents for your generated operations.
     ///   - cocoapodsCompatibleImportStatements: Generate import statements that are compatible with
     ///     including `Apollo` via Cocoapods.
@@ -548,6 +552,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       deprecatedEnumCases: Composition = Default.deprecatedEnumCases,
       schemaDocumentation: Composition = Default.schemaDocumentation,
       selectionSetInitializers: SelectionSetInitializers = Default.selectionSetInitializers,
+      fieldMerging: FieldMerging = Default.fieldMerging,
       operationDocumentFormat: OperationDocumentFormat = Default.operationDocumentFormat,
       schemaCustomization: SchemaCustomization = Default.schemaCustomization,
       cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
@@ -560,6 +565,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       self.deprecatedEnumCases = deprecatedEnumCases
       self.schemaDocumentation = schemaDocumentation
       self.selectionSetInitializers = selectionSetInitializers
+      self.fieldMerging = fieldMerging
       self.operationDocumentFormat = operationDocumentFormat
       self.schemaCustomization = schemaCustomization
       self.cocoapodsCompatibleImportStatements = cocoapodsCompatibleImportStatements
@@ -577,6 +583,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       case deprecatedEnumCases
       case schemaDocumentation
       case selectionSetInitializers
+      case fieldMerging
       case apqs
       case operationDocumentFormat
       case schemaCustomization
@@ -610,6 +617,11 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
         SelectionSetInitializers.self,
         forKey: .selectionSetInitializers
       ) ?? Default.selectionSetInitializers
+
+      fieldMerging = try values.decodeIfPresent(
+        FieldMerging.self,
+        forKey: .fieldMerging
+      ) ?? Default.fieldMerging
 
       operationDocumentFormat = try values.decodeIfPresent(
         OperationDocumentFormat.self,
@@ -659,6 +671,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       try container.encode(self.deprecatedEnumCases, forKey: .deprecatedEnumCases)
       try container.encode(self.schemaDocumentation, forKey: .schemaDocumentation)
       try container.encode(self.selectionSetInitializers, forKey: .selectionSetInitializers)
+      try container.encode(self.fieldMerging, forKey: .fieldMerging)
       try container.encode(self.operationDocumentFormat, forKey: .operationDocumentFormat)
       try container.encode(self.schemaCustomization, forKey: .schemaCustomization)
       try container.encode(self.cocoapodsCompatibleImportStatements, forKey: .cocoapodsCompatibleImportStatements)
@@ -1494,7 +1507,8 @@ extension ApolloCodegenConfiguration.OutputOptions {
   ///   - deprecatedEnumCases: How deprecated enum cases from the schema should be handled.
   ///   - schemaDocumentation: Whether schema documentation is added to the generated files.
   ///   - selectionSetInitializers: Which generated selection sets should include
-  ///     generated initializers.  
+  ///     generated initializers.
+  ///   - fieldMerging: Which merged fields and named fragment accessors are generated.
   ///   - apqs: Whether the generated operations should use Automatic Persisted Queries.
   ///   - cocoapodsCompatibleImportStatements: Generate import statements that are compatible with
   ///     including `Apollo` via Cocoapods.
@@ -1514,6 +1528,7 @@ extension ApolloCodegenConfiguration.OutputOptions {
     deprecatedEnumCases: ApolloCodegenConfiguration.Composition = Default.deprecatedEnumCases,
     schemaDocumentation: ApolloCodegenConfiguration.Composition = Default.schemaDocumentation,
     selectionSetInitializers: ApolloCodegenConfiguration.SelectionSetInitializers = Default.selectionSetInitializers,
+    fieldMerging: ApolloCodegenConfiguration.FieldMerging = Default.fieldMerging,
     apqs: ApolloCodegenConfiguration.APQConfig,
     cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = Default.warningsOnDeprecatedUsage,
@@ -1525,6 +1540,7 @@ extension ApolloCodegenConfiguration.OutputOptions {
     self.deprecatedEnumCases = deprecatedEnumCases
     self.schemaDocumentation = schemaDocumentation
     self.selectionSetInitializers = selectionSetInitializers
+    self.fieldMerging = fieldMerging
     self.operationDocumentFormat = apqs.operationDocumentFormat
     self.cocoapodsCompatibleImportStatements = cocoapodsCompatibleImportStatements
     self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
@@ -1545,6 +1561,7 @@ extension ApolloCodegenConfiguration.OutputOptions {
   ///   - schemaDocumentation: Whether schema documentation is added to the generated files.
   ///   - selectionSetInitializers: Which generated selection sets should include
   ///     generated initializers.
+  ///   - fieldMerging: Which merged fields and named fragment accessors are generated.
   ///   - operationDocumentFormat: How to generate the operation documents for your generated operations.
   ///   - cocoapodsCompatibleImportStatements: Generate import statements that are compatible with
   ///     including `Apollo` via Cocoapods.
@@ -1564,6 +1581,7 @@ extension ApolloCodegenConfiguration.OutputOptions {
     deprecatedEnumCases: ApolloCodegenConfiguration.Composition = Default.deprecatedEnumCases,
     schemaDocumentation: ApolloCodegenConfiguration.Composition = Default.schemaDocumentation,
     selectionSetInitializers: ApolloCodegenConfiguration.SelectionSetInitializers = Default.selectionSetInitializers,
+    fieldMerging: ApolloCodegenConfiguration.FieldMerging = Default.fieldMerging,
     operationDocumentFormat: ApolloCodegenConfiguration.OperationDocumentFormat = Default.operationDocumentFormat,
     cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = Default.warningsOnDeprecatedUsage,
@@ -1575,6 +1593,7 @@ extension ApolloCodegenConfiguration.OutputOptions {
     self.deprecatedEnumCases = deprecatedEnumCases
     self.schemaDocumentation = schemaDocumentation
     self.selectionSetInitializers = selectionSetInitializers
+    self.fieldMerging = fieldMerging
     self.operationDocumentFormat = operationDocumentFormat
     self.cocoapodsCompatibleImportStatements = cocoapodsCompatibleImportStatements
     self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage


### PR DESCRIPTION
### TL;DR
Updated the selection set initializers configuration to always generate initializers for local cache mutations

### What changed?
- Removed the explicit configuration for local cache mutations in the `ApolloCodegenConfiguration` struct.
- Modified the `SelectionSetInitializers` enum to always generate initializers for local cache mutations
- Deprecated the `localCacheMutations` option in `SelectionSetInitializers`.

### How to test?
No specific test instructions provided.

### Why make this change?
The change was made to streamline the configuration process and ensure consistent generation of initializers for local cache mutations.

---

