### PR TITLE
fix (defer): deferred fragment condition evaluation

### DIFF
--- a/apollo-ios/Sources/Apollo/FieldSelectionCollector.swift
+++ b/apollo-ios/Sources/Apollo/FieldSelectionCollector.swift
@@ -101,10 +101,12 @@ struct DefaultFieldSelectionCollector: FieldSelectionCollector {
         //
         // The deferred fragment identifiers still need to be collected becuase that is how the
         // user determines the state of the deferred fragment via the @Deferred property wrapper.
-        var collectDeferredFragment: Bool = true
-        if let condition {
-          collectDeferredFragment = condition.evaluate(with: info.variables)
-        }
+        let isDeferred: Bool = {
+          if let condition, !condition.evaluate(with: info.variables) {
+            return false
+          }
+          return true
+        }()
 
         if collectDeferredFragment {
           groupedFields.addDeferredFragment(typeCase)

--- a/apollo-ios/Sources/Apollo/FieldSelectionCollector.swift
+++ b/apollo-ios/Sources/Apollo/FieldSelectionCollector.swift
@@ -108,6 +108,10 @@ struct DefaultFieldSelectionCollector: FieldSelectionCollector {
 
         if collectDeferredFragment {
           groupedFields.addDeferredFragment(typeCase)
+        } else {
+
+          groupedFields.addFulfilledFragment(typeCase)
+          try collectFields(from: typeCase.__selections, into: &groupedFields, for: object, info: info)
         }
 
       case let .fragment(fragment):

--- a/apollo-ios/Sources/Apollo/FieldSelectionCollector.swift
+++ b/apollo-ios/Sources/Apollo/FieldSelectionCollector.swift
@@ -93,7 +93,7 @@ struct DefaultFieldSelectionCollector: FieldSelectionCollector {
                             info: info)
         }
 
-      case let .deferred(_, typeCase, _):
+      case let .deferred(condition, typeCase, _):
         // In Apollo's implementation (Router + Server) of deferSpec=20220824 ALL defer directives
         // will be honoured and sent as separate incremental responses. This means deferred
         // selection fields never need to be collected because they are parsed with the incremental
@@ -101,7 +101,14 @@ struct DefaultFieldSelectionCollector: FieldSelectionCollector {
         //
         // The deferred fragment identifiers still need to be collected becuase that is how the
         // user determines the state of the deferred fragment via the @Deferred property wrapper.
-        groupedFields.addDeferredFragment(typeCase)
+        var collectDeferredFragment: Bool = true
+        if let condition {
+          collectDeferredFragment = condition.evaluate(with: info.variables)
+        }
+
+        if collectDeferredFragment {
+          groupedFields.addDeferredFragment(typeCase)
+        }
 
       case let .fragment(fragment):
         groupedFields.addFulfilledFragment(fragment)

--- a/apollo-ios/Sources/ApolloAPI/Selection+Conditions.swift
+++ b/apollo-ios/Sources/ApolloAPI/Selection+Conditions.swift
@@ -114,7 +114,7 @@ fileprivate extension Array where Element == Selection.Condition {
 }
 
 // MARK: Conditions - Individual
-fileprivate extension Selection.Condition {
+public extension Selection.Condition {
   func evaluate(with variables: GraphQLOperation.Variables?) -> Bool {
     switch self {
     case let .value(value):


### PR DESCRIPTION
Conditions on a deferred fragment were not correctly being evaluated during field collection. This meant that deferred fragments would always be collected into `_deferredFragments` regardless of any condition. It's now fixed and deferred fragments are not collected if the condition would evaluate to false meaning the deferred fragment should never be expected to be received.