### PR TITLE
chore: Update deprecated `--schema-name` property references

### DIFF
--- a/.github/actions/run-cocoapods-integration-tests/action.yml
+++ b/.github/actions/run-cocoapods-integration-tests/action.yml
@@ -12,7 +12,7 @@ runs:
     shell: bash
     working-directory: Tests/CodegenCLITests/pod-install-test/
     run: |
-      ./Pods/Apollo/apollo-ios-cli init --schema-name NewTestSchema --module-type other
+      ./Pods/Apollo/apollo-ios-cli init --schema-namespace NewTestSchema --module-type other
   - name: CocoaPods - CLI Test (generate)
     shell: bash
     working-directory: Tests/CodegenCLITests/pod-install-test/

--- a/docs/shared/setup-codegen/single-panel.mdx
+++ b/docs/shared/setup-codegen/single-panel.mdx
@@ -19,7 +19,7 @@ The Codegen CLI uses a JSON file to configure the code generation engine. You ca
 From your project's root directory, run the following command with your customized values:
 
 <CodeBlock
-  code={props.cliPath + " init --schema-name ${MySchemaName} --module-type ${ModuleType}"}
+  code={props.cliPath + " init --schema-namespace ${MySchemaName} --module-type ${ModuleType}"}
   language="bash"
   showLineNumbers='true'
 />


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-ios/issues/3382.

There isn't much detail in that issue on what the actual problem is so I did an audit on where we might still be using `--schema-name` and found two outdated references; migration guide and CI action. This PR simply updates those to use the newer `--schema-namespace`.