### PR TITLE
Support ID scalar as a custom scalar

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -7,7 +7,7 @@ public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"query AllAnimalsQuery { allAnimals { __typename height { __typename feet inches } ...HeightInMeters ...WarmBloodedDetails species skinCovering ... on Pet { ...PetDetails ...WarmBloodedDetails ... on Animal { height { __typename relativeSize centimeters } } } ... on Cat { isJellicle } ... on ClassroomPet { ... on Bird { wingspan } } ... on Dog { favoriteToy birthdate } predators { __typename species ... on WarmBlooded { predators { __typename species } ...WarmBloodedDetails laysEggs } } } }"#,
+      #"query AllAnimalsQuery { allAnimals { __typename id height { __typename feet inches } ...HeightInMeters ...WarmBloodedDetails species skinCovering ... on Pet { ...PetDetails ...WarmBloodedDetails ... on Animal { height { __typename relativeSize centimeters } } } ... on Cat { isJellicle } ... on ClassroomPet { ... on Bird { wingspan } } ... on Dog { favoriteToy birthdate } predators { __typename species ... on WarmBlooded { predators { __typename species } ...WarmBloodedDetails laysEggs } } } }"#,
       fragments: [HeightInMeters.self, PetDetails.self, WarmBloodedDetails.self]
     ))
 
@@ -48,6 +48,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
+        .field("id", AnimalKingdomAPI.ID.self),
         .field("height", Height.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<AnimalKingdomAPI.SkinCovering>?.self),
@@ -60,6 +61,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         .fragment(HeightInMeters.self),
       ] }
 
+      public var id: AnimalKingdomAPI.ID { __data["id"] }
       public var height: Height { __data["height"] }
       public var species: String { __data["species"] }
       public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
@@ -80,6 +82,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
       public init(
         __typename: String,
+        id: AnimalKingdomAPI.ID,
         height: Height,
         species: String,
         skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
@@ -88,6 +91,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         self.init(_dataDict: DataDict(
           data: [
             "__typename": __typename,
+            "id": id,
             "height": height._fieldData,
             "species": species,
             "skinCovering": skinCovering,
@@ -273,6 +277,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           .fragment(WarmBloodedDetails.self),
         ] }
 
+        public var id: AnimalKingdomAPI.ID { __data["id"] }
         public var height: Height { __data["height"] }
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
@@ -289,6 +294,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public init(
           __typename: String,
+          id: AnimalKingdomAPI.ID,
           height: Height,
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
@@ -298,6 +304,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           self.init(_dataDict: DataDict(
             data: [
               "__typename": __typename,
+              "id": id,
               "height": height._fieldData,
               "species": species,
               "skinCovering": skinCovering,
@@ -364,6 +371,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         ] }
 
         public var height: Height { __data["height"] }
+        public var id: AnimalKingdomAPI.ID { __data["id"] }
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
@@ -384,6 +392,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(
           __typename: String,
           height: Height,
+          id: AnimalKingdomAPI.ID,
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           predators: [Predator],
@@ -395,6 +404,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             data: [
               "__typename": __typename,
               "height": height._fieldData,
+              "id": id,
               "species": species,
               "skinCovering": skinCovering,
               "predators": predators._fieldData,
@@ -470,6 +480,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             .fragment(WarmBloodedDetails.self),
           ] }
 
+          public var id: AnimalKingdomAPI.ID { __data["id"] }
           public var height: Height { __data["height"] }
           public var species: String { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
@@ -490,6 +501,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
           public init(
             __typename: String,
+            id: AnimalKingdomAPI.ID,
             height: Height,
             species: String,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
@@ -502,6 +514,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             self.init(_dataDict: DataDict(
               data: [
                 "__typename": __typename,
+                "id": id,
                 "height": height._fieldData,
                 "species": species,
                 "skinCovering": skinCovering,
@@ -581,6 +594,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         ] }
 
         public var isJellicle: Bool { __data["isJellicle"] }
+        public var id: AnimalKingdomAPI.ID { __data["id"] }
         public var height: Height { __data["height"] }
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
@@ -601,6 +615,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public init(
           isJellicle: Bool,
+          id: AnimalKingdomAPI.ID,
           height: Height,
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
@@ -614,6 +629,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             data: [
               "__typename": AnimalKingdomAPI.Objects.Cat.typename,
               "isJellicle": isJellicle,
+              "id": id,
               "height": height._fieldData,
               "species": species,
               "skinCovering": skinCovering,
@@ -693,6 +709,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           .inlineFragment(AsBird.self),
         ] }
 
+        public var id: AnimalKingdomAPI.ID { __data["id"] }
         public var height: Height { __data["height"] }
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
@@ -709,6 +726,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public init(
           __typename: String,
+          id: AnimalKingdomAPI.ID,
           height: Height,
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
@@ -717,6 +735,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           self.init(_dataDict: DataDict(
             data: [
               "__typename": __typename,
+              "id": id,
               "height": height._fieldData,
               "species": species,
               "skinCovering": skinCovering,
@@ -778,6 +797,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           ] }
 
           public var wingspan: Double { __data["wingspan"] }
+          public var id: AnimalKingdomAPI.ID { __data["id"] }
           public var height: Height { __data["height"] }
           public var species: String { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
@@ -798,6 +818,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
           public init(
             wingspan: Double,
+            id: AnimalKingdomAPI.ID,
             height: Height,
             species: String,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
@@ -811,6 +832,7 @@ public class AllAnimalsQuery: GraphQLQuery {
               data: [
                 "__typename": AnimalKingdomAPI.Objects.Bird.typename,
                 "wingspan": wingspan,
+                "id": id,
                 "height": height._fieldData,
                 "species": species,
                 "skinCovering": skinCovering,
@@ -895,6 +917,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public var favoriteToy: String { __data["favoriteToy"] }
         public var birthdate: AnimalKingdomAPI.CustomDate? { __data["birthdate"] }
+        public var id: AnimalKingdomAPI.ID { __data["id"] }
         public var height: Height { __data["height"] }
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
@@ -915,6 +938,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(
           favoriteToy: String,
           birthdate: AnimalKingdomAPI.CustomDate? = nil,
+          id: AnimalKingdomAPI.ID,
           height: Height,
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
@@ -928,6 +952,7 @@ public class AllAnimalsQuery: GraphQLQuery {
               "__typename": AnimalKingdomAPI.Objects.Dog.typename,
               "favoriteToy": favoriteToy,
               "birthdate": birthdate,
+              "id": id,
               "height": height._fieldData,
               "species": species,
               "skinCovering": skinCovering,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/CustomScalars/ID.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/CustomScalars/ID.swift
@@ -1,0 +1,11 @@
+// @generated
+// This file was automatically generated and can be edited to
+// implement advanced custom scalar functionality.
+//
+// Any changes to this file will not be overwritten by future
+// code generation execution.
+
+import ApolloAPI
+
+/// The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+public typealias ID = String

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/InputObjects/PetAdoptionInput.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/InputObjects/PetAdoptionInput.graphql.swift
@@ -15,7 +15,7 @@ public struct PetAdoptionInput: InputObject {
     petID: ID,
     humanName: GraphQLNullable<String> = nil,
     favoriteToy: String,
-    isSpayedOrNeutered: Bool?,
+    isSpayedOrNeutered: Bool? = nil,
     measurements: GraphQLNullable<MeasurementsInput> = nil
   ) {
     __data = InputDict([

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Interfaces/Animal.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Interfaces/Animal.graphql.swift
@@ -4,5 +4,5 @@
 import ApolloAPI
 
 public extension Interfaces {
-  static let Animal = Interface(name: "Animal")
+  static let Animal = ApolloAPI.Interface(name: "Animal")
 }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Interfaces/HousePet.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Interfaces/HousePet.graphql.swift
@@ -4,5 +4,5 @@
 import ApolloAPI
 
 public extension Interfaces {
-  static let HousePet = Interface(name: "HousePet")
+  static let HousePet = ApolloAPI.Interface(name: "HousePet")
 }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Interfaces/Pet.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Interfaces/Pet.graphql.swift
@@ -4,5 +4,5 @@
 import ApolloAPI
 
 public extension Interfaces {
-  static let Pet = Interface(name: "Pet")
+  static let Pet = ApolloAPI.Interface(name: "Pet")
 }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Interfaces/WarmBlooded.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/Interfaces/WarmBlooded.graphql.swift
@@ -4,5 +4,5 @@
 import ApolloAPI
 
 public extension Interfaces {
-  static let WarmBlooded = Interface(name: "WarmBlooded")
+  static let WarmBlooded = ApolloAPI.Interface(name: "WarmBlooded")
 }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -3,8 +3,6 @@
 
 import ApolloAPI
 
-public typealias ID = String
-
 public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
 where Schema == AnimalKingdomAPI.SchemaMetadata {}
 

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/AllAnimalsQuery.graphql
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/AllAnimalsQuery.graphql
@@ -1,6 +1,7 @@
 query AllAnimalsQuery {
   allAnimals {
     __typename
+    id
     height {
       feet
       inches

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/CustomScalars/ID.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/CustomScalars/ID.swift
@@ -1,0 +1,11 @@
+// @generated
+// This file was automatically generated and can be edited to
+// implement advanced custom scalar functionality.
+//
+// Any changes to this file will not be overwritten by future
+// code generation execution.
+
+import ApolloAPI
+
+/// The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+public typealias ID = String

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Actor.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Actor.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents an object which can take actions on GitHub. Typically a User or Bot.
-  static let Actor = Interface(name: "Actor")
+  static let Actor = ApolloAPI.Interface(name: "Actor")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Assignable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Assignable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// An object that can have users assigned to it.
-  static let Assignable = Interface(name: "Assignable")
+  static let Assignable = ApolloAPI.Interface(name: "Assignable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/AuditEntry.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/AuditEntry.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// An entry in the audit log.
-  static let AuditEntry = Interface(name: "AuditEntry")
+  static let AuditEntry = ApolloAPI.Interface(name: "AuditEntry")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Closable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Closable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// An object that can be closed
-  static let Closable = Interface(name: "Closable")
+  static let Closable = ApolloAPI.Interface(name: "Closable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Comment.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Comment.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents a comment.
-  static let Comment = Interface(name: "Comment")
+  static let Comment = ApolloAPI.Interface(name: "Comment")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Deletable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Deletable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Entities that can be deleted.
-  static let Deletable = Interface(name: "Deletable")
+  static let Deletable = ApolloAPI.Interface(name: "Deletable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/EnterpriseAuditEntryData.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/EnterpriseAuditEntryData.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Metadata for an audit entry containing enterprise account information.
-  static let EnterpriseAuditEntryData = Interface(name: "EnterpriseAuditEntryData")
+  static let EnterpriseAuditEntryData = ApolloAPI.Interface(name: "EnterpriseAuditEntryData")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/GitObject.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/GitObject.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents a Git object.
-  static let GitObject = Interface(name: "GitObject")
+  static let GitObject = ApolloAPI.Interface(name: "GitObject")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Labelable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Labelable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// An object that can have labels assigned to it.
-  static let Labelable = Interface(name: "Labelable")
+  static let Labelable = ApolloAPI.Interface(name: "Labelable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Lockable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Lockable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// An object that can be locked.
-  static let Lockable = Interface(name: "Lockable")
+  static let Lockable = ApolloAPI.Interface(name: "Lockable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/MemberStatusable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/MemberStatusable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Entities that have members who can set status messages.
-  static let MemberStatusable = Interface(name: "MemberStatusable")
+  static let MemberStatusable = ApolloAPI.Interface(name: "MemberStatusable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Minimizable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Minimizable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Entities that can be minimized.
-  static let Minimizable = Interface(name: "Minimizable")
+  static let Minimizable = ApolloAPI.Interface(name: "Minimizable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Node.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Node.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// An object with an ID.
-  static let Node = Interface(name: "Node")
+  static let Node = ApolloAPI.Interface(name: "Node")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/OauthApplicationAuditEntryData.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/OauthApplicationAuditEntryData.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Metadata for an audit entry with action oauth_application.*
-  static let OauthApplicationAuditEntryData = Interface(name: "OauthApplicationAuditEntryData")
+  static let OauthApplicationAuditEntryData = ApolloAPI.Interface(name: "OauthApplicationAuditEntryData")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/OrganizationAuditEntryData.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/OrganizationAuditEntryData.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Metadata for an audit entry with action org.*
-  static let OrganizationAuditEntryData = Interface(name: "OrganizationAuditEntryData")
+  static let OrganizationAuditEntryData = ApolloAPI.Interface(name: "OrganizationAuditEntryData")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/PackageOwner.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/PackageOwner.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents an owner of a package.
-  static let PackageOwner = Interface(name: "PackageOwner")
+  static let PackageOwner = ApolloAPI.Interface(name: "PackageOwner")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/ProfileOwner.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/ProfileOwner.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents any entity on GitHub that has a profile page.
-  static let ProfileOwner = Interface(name: "ProfileOwner")
+  static let ProfileOwner = ApolloAPI.Interface(name: "ProfileOwner")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/ProjectOwner.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/ProjectOwner.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents an owner of a Project.
-  static let ProjectOwner = Interface(name: "ProjectOwner")
+  static let ProjectOwner = ApolloAPI.Interface(name: "ProjectOwner")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Reactable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Reactable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents a subject that can be reacted on.
-  static let Reactable = Interface(name: "Reactable")
+  static let Reactable = ApolloAPI.Interface(name: "Reactable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/RepositoryAuditEntryData.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/RepositoryAuditEntryData.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Metadata for an audit entry with action repo.*
-  static let RepositoryAuditEntryData = Interface(name: "RepositoryAuditEntryData")
+  static let RepositoryAuditEntryData = ApolloAPI.Interface(name: "RepositoryAuditEntryData")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/RepositoryInfo.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/RepositoryInfo.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// A subset of repository info.
-  static let RepositoryInfo = Interface(name: "RepositoryInfo")
+  static let RepositoryInfo = ApolloAPI.Interface(name: "RepositoryInfo")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/RepositoryNode.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/RepositoryNode.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents a object that belongs to a repository.
-  static let RepositoryNode = Interface(name: "RepositoryNode")
+  static let RepositoryNode = ApolloAPI.Interface(name: "RepositoryNode")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/RepositoryOwner.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/RepositoryOwner.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents an owner of a Repository.
-  static let RepositoryOwner = Interface(name: "RepositoryOwner")
+  static let RepositoryOwner = ApolloAPI.Interface(name: "RepositoryOwner")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Sponsorable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Sponsorable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Entities that can be sponsored through GitHub Sponsors
-  static let Sponsorable = Interface(name: "Sponsorable")
+  static let Sponsorable = ApolloAPI.Interface(name: "Sponsorable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Starrable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Starrable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Things that can be starred.
-  static let Starrable = Interface(name: "Starrable")
+  static let Starrable = ApolloAPI.Interface(name: "Starrable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Subscribable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Subscribable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Entities that can be subscribed to for web and email notifications.
-  static let Subscribable = Interface(name: "Subscribable")
+  static let Subscribable = ApolloAPI.Interface(name: "Subscribable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/TeamAuditEntryData.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/TeamAuditEntryData.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Metadata for an audit entry with action team.*
-  static let TeamAuditEntryData = Interface(name: "TeamAuditEntryData")
+  static let TeamAuditEntryData = ApolloAPI.Interface(name: "TeamAuditEntryData")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/TopicAuditEntryData.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/TopicAuditEntryData.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Metadata for an audit entry with a topic.
-  static let TopicAuditEntryData = Interface(name: "TopicAuditEntryData")
+  static let TopicAuditEntryData = ApolloAPI.Interface(name: "TopicAuditEntryData")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/UniformResourceLocatable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/UniformResourceLocatable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Represents a type that can be retrieved by a URL.
-  static let UniformResourceLocatable = Interface(name: "UniformResourceLocatable")
+  static let UniformResourceLocatable = ApolloAPI.Interface(name: "UniformResourceLocatable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Updatable.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/Updatable.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Entities that can be updated.
-  static let Updatable = Interface(name: "Updatable")
+  static let Updatable = ApolloAPI.Interface(name: "Updatable")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/UpdatableComment.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/Interfaces/UpdatableComment.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// Comments that can be updated.
-  static let UpdatableComment = Interface(name: "UpdatableComment")
+  static let UpdatableComment = ApolloAPI.Interface(name: "UpdatableComment")
 }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -3,8 +3,6 @@
 
 import ApolloAPI
 
-public typealias ID = String
-
 public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
 where Schema == GitHubAPI.SchemaMetadata {}
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/CustomScalars/ID.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/CustomScalars/ID.swift
@@ -1,0 +1,11 @@
+// @generated
+// This file was automatically generated and can be edited to
+// implement advanced custom scalar functionality.
+//
+// Any changes to this file will not be overwritten by future
+// code generation execution.
+
+import ApolloAPI
+
+/// The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+public typealias ID = String

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Interfaces/Character.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/Interfaces/Character.graphql.swift
@@ -5,5 +5,5 @@ import ApolloAPI
 
 public extension Interfaces {
   /// A character from the Star Wars universe
-  static let Character = Interface(name: "Character")
+  static let Character = ApolloAPI.Interface(name: "Character")
 }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -3,8 +3,6 @@
 
 import ApolloAPI
 
-public typealias ID = String
-
 public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
 where Schema == StarWarsAPI.SchemaMetadata {}
 

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -3,8 +3,6 @@
 
 import ApolloAPI
 
-public typealias ID = String
-
 public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
 where Schema == SubscriptionAPI.SchemaMetadata {}
 

--- a/Sources/UploadAPI/UploadAPI/Sources/Schema/CustomScalars/ID.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Schema/CustomScalars/ID.swift
@@ -1,0 +1,11 @@
+// @generated
+// This file was automatically generated and can be edited to
+// implement advanced custom scalar functionality.
+//
+// Any changes to this file will not be overwritten by future
+// code generation execution.
+
+import ApolloAPI
+
+/// The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+public typealias ID = String

--- a/Sources/UploadAPI/UploadAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -3,8 +3,6 @@
 
 import ApolloAPI
 
-public typealias ID = String
-
 public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
 where Schema == UploadAPI.SchemaMetadata {}
 

--- a/Tests/ApolloCodegenTests/AnimalKingdomAPI/AnimalKingdomIRCreationTests.swift
+++ b/Tests/ApolloCodegenTests/AnimalKingdomAPI/AnimalKingdomIRCreationTests.swift
@@ -135,6 +135,8 @@ final class AnimalKingdomIRCreationTests: XCTestCase {
 
     expected = (
       fields: [
+        .mock("id",
+              type: .nonNull(.scalar(GraphQLScalarType.mock(name: "ID")))),
         .mock("height",
               type: .nonNull(.entity(GraphQLObjectType.mock("Height")))),
         .mock("species",
@@ -369,6 +371,8 @@ final class AnimalKingdomIRCreationTests: XCTestCase {
 
     expected = (
       fields: [
+        .mock("id",
+              type: .nonNull(.scalar(GraphQLScalarType.mock(name: "ID")))),
         .mock("height",
               type: .nonNull(.entity(GraphQLObjectType.mock("Height")))),
         .mock("species",
@@ -478,6 +482,8 @@ final class AnimalKingdomIRCreationTests: XCTestCase {
 
     expected = (
       fields: [
+        .mock("id",
+              type: .nonNull(.scalar(GraphQLScalarType.mock(name: "ID")))),
         .mock("species",
               type: .nonNull(.scalar(GraphQLScalarType.string()))),
         .mock("skinCovering",
@@ -596,6 +602,8 @@ final class AnimalKingdomIRCreationTests: XCTestCase {
 
     expected = (
       fields: [
+        .mock("id",
+              type: .nonNull(.scalar(GraphQLScalarType.mock(name: "ID")))),
         .mock("height",
               type: .nonNull(.entity(GraphQLObjectType.mock("Height")))),
         .mock("species",
@@ -712,6 +720,8 @@ final class AnimalKingdomIRCreationTests: XCTestCase {
 
     expected = (
       fields: [
+        .mock("id",
+              type: .nonNull(.scalar(GraphQLScalarType.mock(name: "ID")))),
         .mock("height",
               type: .nonNull(.entity(GraphQLObjectType.mock("Height")))),
         .mock("species",
@@ -828,6 +838,8 @@ final class AnimalKingdomIRCreationTests: XCTestCase {
 
     expected = (
       fields: [
+        .mock("id",
+              type: .nonNull(.scalar(GraphQLScalarType.mock(name: "ID")))),
         .mock("height",
               type: .nonNull(.entity(GraphQLObjectType.mock("Height")))),
         .mock("species",
@@ -887,6 +899,8 @@ final class AnimalKingdomIRCreationTests: XCTestCase {
 
     expected = (
       fields: [
+        .mock("id",
+              type: .nonNull(.scalar(GraphQLScalarType.mock(name: "ID")))),
         .mock("height",
               type: .nonNull(.entity(GraphQLObjectType.mock("Height")))),
         .mock("species",

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRCustomScalarTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRCustomScalarTests.swift
@@ -53,7 +53,7 @@ class IRCustomScalarTests: XCTestCase {
     expect(subject.customScalars).to(beEmpty())
   }
 
-  func test__givenScalarID__shouldAppendToScalarsSet() {
+  func test__givenScalarID__shouldAppendToCustomScalarsSet() {
     // given
     let scalar = GraphQLScalarType.mock(name: "ID")
 
@@ -61,8 +61,8 @@ class IRCustomScalarTests: XCTestCase {
     let subject = IR.Schema.ReferencedTypes.init([scalar], schemaRootTypes: .mock())
 
     // then
-    expect(subject.scalars).to(equal([scalar]))
-    expect(subject.customScalars).to(beEmpty())
+    expect(subject.customScalars).to(equal([scalar]))
+    expect(subject.scalars).to(beEmpty())
   }
 
   func test__givenCustomScalar__shouldAppendToCustomScalarsSet() {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
@@ -37,70 +37,6 @@ class SchemaMetadataTemplateTests: XCTestCase {
 
   // MARK: Typealias & Protocol Tests
 
-  func test__render__givenModuleEmbeddedInTarget_withInternalAccessModifier_shouldGenerateIDTypealias_withInternalAccess() {
-    // given
-    buildSubject(config: .mock(.embeddedInTarget(name: "CustomTarget", accessModifier: .internal)))
-
-    let expected = """
-    typealias ID = String
-
-    """
-
-    // when
-    let actual = renderTemplate()
-
-    // then
-    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
-  }
-
-  func test__render__givenModuleEmbeddedInTarget_withPublicAccessModifier_shouldGenerateIDTypealias_withPublicAccess() {
-    // given
-    buildSubject(config: .mock(.embeddedInTarget(name: "CustomTarget", accessModifier: .public)))
-
-    let expected = """
-    typealias ID = String
-
-    """
-
-    // when
-    let actual = renderTemplate()
-
-    // then
-    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
-  }
-
-  func test__render__givenModuleSwiftPackageManager_shouldGenerateIDTypealias_withPublicAccess() {
-    // given
-    buildSubject(config: .mock(.swiftPackageManager))
-
-    let expected = """
-    public typealias ID = String
-
-    """
-
-    // when
-    let actual = renderTemplate()
-
-    // then
-    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
-  }
-
-  func test__render__givenModuleOther_shouldGenerateIDTypealias_withPublicAccess() {
-    // given
-    buildSubject(config: .mock(.other))
-
-    let expected = """
-    public typealias ID = String
-
-    """
-
-    // when
-    let actual = renderTemplate()
-
-    // then
-    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
-  }
-
   func test__render__givenModuleEmbeddedInTarget_withInternalAccessModifier_shouldGenerateDetachedProtocols_withTypealias_withCorrectCasing_withInternalAccess() {
     // given
     buildSubject(
@@ -141,7 +77,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
 
     // then
     expect(actualTemplate)
-      .to(equalLineByLine(expectedTemplate, atLine: 3, ignoringExtraLines: true))
+      .to(equalLineByLine(expectedTemplate, ignoringExtraLines: true))
     expect(actualDetached)
       .to(equalLineByLine(expectedDetached))
   }
@@ -186,7 +122,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
 
     // then
     expect(actualTemplate)
-      .to(equalLineByLine(expectedTemplate, atLine: 3, ignoringExtraLines: true))
+      .to(equalLineByLine(expectedTemplate, ignoringExtraLines: true))
     expect(actualDetached)
       .to(equalLineByLine(expectedDetached))
   }
@@ -220,7 +156,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
 
     // then
     expect(actualTemplate)
-      .to(equalLineByLine(expectedTemplate, atLine: 3, ignoringExtraLines: true))
+      .to(equalLineByLine(expectedTemplate, ignoringExtraLines: true))
     expect(actualDetached)
       .to(beNil())
   }
@@ -254,7 +190,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
 
     // then
     expect(actualTemplate)
-      .to(equalLineByLine(expectedTemplate, atLine: 3, ignoringExtraLines: true))
+      .to(equalLineByLine(expectedTemplate, ignoringExtraLines: true))
     expect(actualDetached)
       .to(beNil())
   }
@@ -289,7 +225,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
 
     // then
     expect(actualTemplate)
-      .to(equalLineByLine(expectedTemplate, atLine: 3, ignoringExtraLines: true))
+      .to(equalLineByLine(expectedTemplate, ignoringExtraLines: true))
     expect(actualDetached)
       .to(beNil())
   }
@@ -309,7 +245,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 9, ignoringExtraLines: true))
   }
 
   func test__render__givenModuleEmbeddedInTarget_withPublicAccessModifier_shouldGenerateEnumDefinition_withPublicAccess() {
@@ -325,7 +261,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 9, ignoringExtraLines: true))
   }
 
   func test__render__givenModuleSwiftPackageManager_shouldGenerateEnumDefinition_withPublicModifier() {
@@ -341,7 +277,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
   }
 
   func test__render__givenModuleOther_shouldGenerateEnumDefinition_withPublicModifier() {
@@ -357,7 +293,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
   }
 
   func test__render__givenCocoapodsCompatibleImportStatements_true_shouldGenerateEnumDefinition_withApolloTargetName() {
@@ -373,7 +309,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 9, ignoringExtraLines: true))
   }
 
   func test__render__givenWithReferencedObjects_generatesObjectTypeFunctionCorrectlyCased() {
@@ -404,7 +340,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render__givenWithReferencedOtherTypes_generatesObjectTypeNotIncludingNonObjectTypesFunction() {
@@ -436,7 +372,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render__givenModuleEmbeddedInTarget_withInternalAccessModifier_rendersTypeNamespaceEnums_withInternalAccess() {
@@ -467,7 +403,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 22))
+    expect(actual).to(equalLineByLine(expected, atLine: 20))
   }
 
   func test__render__givenModuleEmbeddedInTarget_withPublicAccessModifier_rendersTypeNamespaceEnums_withPublicAccess() {
@@ -498,7 +434,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 22))
+    expect(actual).to(equalLineByLine(expected, atLine: 20))
   }
 
   func test__render__givenModuleSwiftPackageManager_rendersTypeNamespaceEnums_withPublicAccess() {
@@ -529,7 +465,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 26))
+    expect(actual).to(equalLineByLine(expected, atLine: 24))
   }
 
   func test__render__givenModuleOther_rendersTypeNamespaceEnums_withPublicAccess() {
@@ -560,7 +496,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let actual = renderTemplate()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 26))
+    expect(actual).to(equalLineByLine(expected, atLine: 24))
   }
 
   // MARK: Documentation Tests
@@ -582,7 +518,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let rendered = renderTemplate()
 
     // then
-    expect(rendered).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(rendered).to(equalLineByLine(expected, atLine: 9, ignoringExtraLines: true))
   }
 
   func test__render__givenSchemaDocumentation_exclude_hasDocumentation_shouldNotGenerateDocumentationComment() throws {
@@ -602,7 +538,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let rendered = renderTemplate()
 
     // then
-    expect(rendered).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(rendered).to(equalLineByLine(expected, atLine: 9, ignoringExtraLines: true))
   }
 
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -694,6 +694,45 @@ class SelectionSetTemplateTests: XCTestCase {
     }
   }
 
+  func test__render_selections__givenCustomScalar_ID_rendersFieldSelectionWithoutSuffix() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      id: ID!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        id
+      }
+    }
+    """
+
+    let expected = """
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("id", TestSchema.ID.self),
+      ] }
+    """
+
+    // when
+    try await buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
+  }
+
   func test__render_selections__givenFieldWithUppercasedName_rendersFieldSelections() async throws {
     // given
     schemaSDL = """
@@ -2699,6 +2738,42 @@ class SelectionSetTemplateTests: XCTestCase {
       // then
       expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
     }
+  }
+
+  func test__render_fieldAccessors__givenCustomScalar_ID_rendersFieldAccessorWithTypeNameWithoutSuffix() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      AllAnimals: [Animal!]
+    }
+
+    type Animal {
+      id: ID!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      AllAnimals {
+        id
+      }
+    }
+    """
+
+    let expected = """
+      public var id: TestSchema.ID { __data["id"] }
+    """
+
+    // when
+    try await buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "AllAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenFieldWithUpperCaseName_rendersFieldAccessorWithLowercaseName() async throws {

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/CocoaPodsProject.xcodeproj/project.pbxproj
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/CocoaPodsProject.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1B7ED6E41035FB2A0D763AD8 /* Pods_CocoaPodsProjectTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3E998DF0E4DCCF80C445451 /* Pods_CocoaPodsProjectTests.framework */; };
 		665BDA862AE30BE2004DD21F /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665BDA852AE30BE2004DD21F /* Object.swift */; };
 		B51EE231D8798C8408AB9CD5 /* Pods_CocoaPodsProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C684794938D6314DF12AB411 /* Pods_CocoaPodsProject.framework */; };
+		DE4790B02BFBD66E00939CCC /* ID.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4790AF2BFBD66E00939CCC /* ID.swift */; };
 		E607A69C29FB43F80059899E /* CocoaPodsProjectApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E607A69B29FB43F80059899E /* CocoaPodsProjectApp.swift */; };
 		E607A69E29FB43F80059899E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E607A69D29FB43F80059899E /* ContentView.swift */; };
 		E607A6A029FB43F80059899E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E607A69F29FB43F80059899E /* Assets.xcassets */; };
@@ -85,6 +86,7 @@
 		951B5BB1CBB3B06FF1E6F602 /* Pods-CocoaPodsProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsProject.debug.xcconfig"; path = "Target Support Files/Pods-CocoaPodsProject/Pods-CocoaPodsProject.debug.xcconfig"; sourceTree = "<group>"; };
 		C684794938D6314DF12AB411 /* Pods_CocoaPodsProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CocoaPodsProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3E998DF0E4DCCF80C445451 /* Pods_CocoaPodsProjectTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CocoaPodsProjectTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE4790AF2BFBD66E00939CCC /* ID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ID.swift; sourceTree = "<group>"; };
 		DF6B509D20E06102691FD98C /* Pods-CocoaPodsProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-CocoaPodsProjectTests/Pods-CocoaPodsProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
 		E607A69829FB43F80059899E /* CocoaPodsProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CocoaPodsProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E607A69B29FB43F80059899E /* CocoaPodsProjectApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaPodsProjectApp.swift; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 			isa = PBXGroup;
 			children = (
 				665BDA852AE30BE2004DD21F /* Object.swift */,
+				DE4790AF2BFBD66E00939CCC /* ID.swift */,
 				E607A72D29FB692F0059899E /* CustomDate.swift */,
 			);
 			path = CustomScalars;
@@ -574,7 +577,6 @@
 				E607A75F29FB692F0059899E /* PetRock.graphql.swift in Sources */,
 				E607A76129FB69300059899E /* Height.graphql.swift in Sources */,
 				665BDA862AE30BE2004DD21F /* Object.swift in Sources */,
-				E607A75329FB692F0059899E /* AllAnimalsCCNQuery.graphql.swift in Sources */,
 				E607A76C29FB69300059899E /* SchemaMetadata.graphql.swift in Sources */,
 				E607A76329FB69300059899E /* Query.graphql.swift in Sources */,
 				E607A75229FB692F0059899E /* DogQuery.graphql.swift in Sources */,
@@ -601,6 +603,7 @@
 				E607A75429FB692F0059899E /* ClassroomPetsQuery.graphql.swift in Sources */,
 				E607A74D29FB692F0059899E /* WarmBloodedDetails.graphql.swift in Sources */,
 				E607A69E29FB43F80059899E /* ContentView.swift in Sources */,
+				DE4790B02BFBD66E00939CCC /* ID.swift in Sources */,
 				E607A76B29FB69300059899E /* MeasurementsInput.graphql.swift in Sources */,
 				E607A74829FB692F0059899E /* PetDetails.graphql.swift in Sources */,
 				E607A76D29FB69300059899E /* HousePet.graphql.swift in Sources */,

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/CustomTargetProject.xcodeproj/project.pbxproj
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/CustomTargetProject.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		665BDA882AE30E9D004DD21F /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665BDA872AE30E9D004DD21F /* Object.swift */; };
 		DE454BCC28B43262009DC80E /* CustomTargetProject.h in Headers */ = {isa = PBXBuildFile; fileRef = DE454BCB28B43262009DC80E /* CustomTargetProject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DE4790B22BFBDA8500939CCC /* ID.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4790B12BFBDA8400939CCC /* ID.swift */; };
 		E6BACC1C29FC909F008B46F2 /* AnimalKingdomAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E6BACC1B29FC909F008B46F2 /* AnimalKingdomAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E6BACC2129FC90CC008B46F2 /* ApolloAPI in Frameworks */ = {isa = PBXBuildFile; productRef = E6BACC2029FC90CC008B46F2 /* ApolloAPI */; };
 		E6BACC5729FC9468008B46F2 /* PetDetailsMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BACC2329FC9468008B46F2 /* PetDetailsMutation.graphql.swift */; };
@@ -105,6 +106,7 @@
 		665BDA872AE30E9D004DD21F /* Object.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Object.swift; sourceTree = "<group>"; };
 		DE454BC928B43262009DC80E /* CustomTargetProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CustomTargetProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE454BCB28B43262009DC80E /* CustomTargetProject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomTargetProject.h; sourceTree = "<group>"; };
+		DE4790B12BFBDA8400939CCC /* ID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ID.swift; sourceTree = "<group>"; };
 		E6BACC1329FC8C8B008B46F2 /* apollo-codegen-config.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "apollo-codegen-config.json"; sourceTree = "<group>"; };
 		E6BACC1929FC909F008B46F2 /* AnimalKingdomAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AnimalKingdomAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6BACC1B29FC909F008B46F2 /* AnimalKingdomAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AnimalKingdomAPI.h; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 			isa = PBXGroup;
 			children = (
 				665BDA872AE30E9D004DD21F /* Object.swift */,
+				DE4790B12BFBDA8400939CCC /* ID.swift */,
 				E6BACC2A29FC9468008B46F2 /* CustomDate.swift */,
 			);
 			path = CustomScalars;
@@ -579,6 +582,7 @@
 				E6BACC5E29FC9468008B46F2 /* Rat.graphql.swift in Sources */,
 				E6BACC6129FC9468008B46F2 /* Dog.graphql.swift in Sources */,
 				E6BACC5C29FC9468008B46F2 /* SkinCovering.graphql.swift in Sources */,
+				DE4790B22BFBDA8500939CCC /* ID.swift in Sources */,
 				E6BACC6D29FC9468008B46F2 /* SchemaMetadata.graphql.swift in Sources */,
 				E6BACC6A29FC9468008B46F2 /* PetAdoptionInput.graphql.swift in Sources */,
 				665BDA882AE30E9D004DD21F /* Object.swift in Sources */,

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLNamedType+NameFormatting.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLNamedType+NameFormatting.swift
@@ -26,7 +26,8 @@ extension GraphQLScalarType {
   }
 
   override var formattedName: String {
-    if !isCustomScalar {
+    // ID should be suffixed if it's used as the name for any type other than built-in scalar ID.
+    if !isCustomScalar || name == "ID" {
       return swiftName
     }
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
@@ -22,8 +22,6 @@ struct SchemaMetadataTemplate: TemplateRenderer {
 
     return TemplateString(
     """
-    \(parentAccessLevel)typealias ID = String
-
     \(if: !config.output.schemaTypes.isInModule,
       TemplateString("""
       \(parentAccessLevel)typealias SelectionSet = \(schemaNamespace)_SelectionSet

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/GraphQLSchema.swift
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/GraphQLSchema.swift
@@ -72,7 +72,7 @@ public final class GraphQLScalarType: GraphQLNamedType {
     guard self.specifiedByURL == nil else { return true }
 
     switch name {
-    case "String", "Int", "Float", "Boolean", "ID":
+    case "String", "Int", "Float", "Boolean":
       return false
     default:
       return true


### PR DESCRIPTION
This changes the generation of the ID scalar to be treated as a custom scalar that can be modified by the user.

This is implemented by request from [#3379](https://github.com/apollographql/apollo-ios/issues/3379).