### PR TITLE
fix: Adds visionOS deployment to ApolloTestSupport podspec

### DIFF
--- a/apollo-ios/ApolloTestSupport.podspec
+++ b/apollo-ios/ApolloTestSupport.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.14'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '5.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source_files = 'Sources/ApolloTestSupport/*.swift'
   s.dependency 'Apollo', '= ' + version


### PR DESCRIPTION
Looks like we'd simply forgotten to add a deployment target for visionOS to the ApolloTestSupport podspec. This brings it up to support the same deployment platforms as the Apollo podspec and all SPM packages.