### PR TITLE
test: New CI job to verify CLI version

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -222,6 +222,24 @@ jobs:
       run: |
         git diff --exit-code
 
+  verify-cli-binary-archive:
+    runs-on: macos-13
+    needs: [changes]
+    if: ${{ needs.changes.outputs.codegen  == 'true' }}
+    timeout-minutes: 5
+    name: Verify CLI Binary Archive - macOS
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Extract CLI Binary
+      shell: bash
+      working-directory: apollo-ios/CLI
+      run: tar -xf apollo-ios-cli.tar.gz apollo-ios-cli
+    - name: Verify Version
+      shell: bash
+      working-directory: apollo-ios/scripts
+      run: ./cli-version-check.sh
+
   run-cocoapods-integration-tests:
     runs-on: macos-13
     timeout-minutes: 20

--- a/apollo-ios-codegen/Sources/CodegenCLI/Constants.swift
+++ b/apollo-ios-codegen/Sources/CodegenCLI/Constants.swift
@@ -4,3 +4,4 @@ public enum Constants {
   public static let CLIVersion: String = "1.12.1"
   static let defaultFilePath: String = "./apollo-codegen-config.json"
 }
+

--- a/apollo-ios/scripts/cli-version-check.sh
+++ b/apollo-ios/scripts/cli-version-check.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+directory=$(dirname "$0")
+projectDir="$directory/../CLI"
+
+APOLLO_VERSION=$(sh "$directory/get-version.sh")
+FILE_PATH="$projectDir/apollo-ios-cli.tar.gz"
+tar -xf "$FILE_PATH"
+CLI_VERSION=$(./apollo-ios-cli --version)
+
+echo "Comparing Apollo version $APOLLO_VERSION with CLI version $CLI_VERSION"
+
+if [ "$APOLLO_VERSION" = "$CLI_VERSION" ]; then
+  echo "Success - matched!"
+else
+  echo "Failed - mismatch!"
+  exit 1
+fi


### PR DESCRIPTION
This PR is expected to fail the `verify-cli-binary-archive` CI job. It also includes a newline to the `apollo-ios-codegen/Sources/CodegenCLI/Constants.swift` file to force the CI job to execute because it will only run when there are changes to the codegen file tree.