### PR TITLE
[ApolloPagination] Remove convenience subscribe methods from `GraphQLQueryPager` and `AsyncGraphQLQueryPager`

### DIFF
--- a/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
@@ -1,6 +1,7 @@
 import Apollo
 import ApolloAPI
 import ApolloInternalTestHelpers
+import Combine
 import XCTest
 
 @testable import ApolloPagination
@@ -13,12 +14,19 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
   private var networkTransport: MockNetworkTransport!
   private var client: ApolloClient!
 
+  private var subscriptions: Set<AnyCancellable> = []
+
   override func setUp() {
     super.setUp()
     store = ApolloStore(cache: InMemoryNormalizedCache())
     server = MockGraphQLServer()
     networkTransport = MockNetworkTransport(server: server, store: store)
     client = ApolloClient(networkTransport: networkTransport, store: store)
+  }
+
+  override func tearDown() {
+    super.tearDown()
+    subscriptions = []
   }
 
   func test_forwardInit_simple() async throws {
@@ -284,7 +292,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
     let subscriptionExpectation = expectation(description: "Subscription")
     subscriptionExpectation.expectedFulfillmentCount = 2
     var expectedViewModels: [ViewModel]?
-    anyPager.subscribe { (result: Result<([ViewModel], UpdateSource), Error>) in
+    anyPager.sink { (result: Result<([ViewModel], UpdateSource), Error>) in
       switch result {
       case .success((let viewModels, _)):
         expectedViewModels = viewModels
@@ -293,7 +301,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       default:
         XCTFail("Failed to get view models from pager.")
       }
-    }
+    }.store(in: &subscriptions)
 
     await fetchFirstPage(pager: anyPager)
     await fulfillment(of: [fetchExpectation], timeout: 1)
@@ -316,7 +324,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
     let initialExpectation = expectation(description: "Initial")
     let secondExpectation = expectation(description: "Second")
     var expectedViewModel: String?
-    anyPager.subscribe { (result: Result<(String?, UpdateSource), Error>) in
+    anyPager.sink { (result: Result<(String?, UpdateSource), Error>) in
       switch result {
       case .success((let viewModel, _)):
         let oldValue = expectedViewModel
@@ -329,7 +337,7 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
       default:
         XCTFail("Failed to get view models from pager.")
       }
-    }
+    }.store(in: &subscriptions)
 
     await fetchFirstPage(pager: anyPager)
     await fulfillment(of: [initialExpectation], timeout: 1.0)

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
@@ -193,16 +193,6 @@ public class AsyncGraphQLQueryPager<Model>: Publisher {
     }
   }
 
-
-  /// Subscribe to the results of the pager, with the management of the subscriber being stored internally to the `AnyGraphQLQueryPager`.
-  /// - Parameter completion: The closure to trigger when new values come in.
-  public func subscribe(completion: @MainActor @escaping (Output) -> Void) {
-    let cancellable = publisher.sink { result in
-      Task { await completion(result) }
-    }
-    _ = $cancellables.mutate { $0.insert(cancellable) }
-  }
-
   /// Load the next page, if available.
   /// - Parameters:
   ///   - cachePolicy: The Apollo `CachePolicy` to use. Defaults to `returnCacheDataAndFetch`.

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -180,14 +180,6 @@ public class GraphQLQueryPager<Model>: Publisher {
     pager.reset()
   }
 
-  /// Subscribe to the results of the pager, with the management of the subscriber being stored internally to the `AnyGraphQLQueryPager`.
-  /// - Parameter completion: The closure to trigger when new values come in. Guaranteed to run on the main thread.
-  public func subscribe(completion: @escaping @MainActor (Output) -> Void) {
-    publisher.sink { result in
-      Task { await completion(result) }
-    }.store(in: &cancellables)
-  }
-
   /// Load the next page, if available.
   /// - Parameters:
   ///   - cachePolicy: The Apollo `CachePolicy` to use. Defaults to `returnCacheDataAndFetch`.


### PR DESCRIPTION

> [!CAUTION]
> This is a breaking change!

This pull request removes the `subscribe` convenience methods from both `GraphQLQueryPager` and `AsyncGraphQLQueryPager`. 

These methods dispatch completion updates from the underlying Combine publisher to the main thread and manage the `AnyCancellable` internal to the `GraphQLQueryPager` and `AsyncGraphQLQueryPager`. However, these behaviors are better handled by the caller: 

- The caller can dispatch the results to the main thread using `receive(on: RunLoop.main)`.
- The caller can manage the `AnyCancellable` themselves, tying it to the lifetime of the relevant objects instead of the lifetime of the pager. 

____

Changes in the test cases:

* [`Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift`](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cR4): The `subscribe` method is replaced with `sink` in several test cases. The `Combine` framework is imported and a `subscriptions` set is added to store `AnyCancellable` instances. The `tearDown` method is overridden to empty the `subscriptions` set after each test. [[1]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cR4) [[2]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cR17-R18) [[3]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cR27-R31) [[4]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL287-R295) [[5]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL296-R304) [[6]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL319-R327) [[7]](diffhunk://#diff-59a184662b7113ca556c2ff1481eaee2d6fa8dc3f06860cda2cf19acf6fc218cL332-R340)
* [`Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift`](diffhunk://#diff-28d8e35fdde972609288a83c7dbed4ec5071b0ccfdd831a05706ada1d10ad882L144-R146): The `subscribe` method is replaced with `sink` and `receive(on: RunLoop.main)` in several test cases. [[1]](diffhunk://#diff-28d8e35fdde972609288a83c7dbed4ec5071b0ccfdd831a05706ada1d10ad882L144-R146) [[2]](diffhunk://#diff-28d8e35fdde972609288a83c7dbed4ec5071b0ccfdd831a05706ada1d10ad882R156) [[3]](diffhunk://#diff-28d8e35fdde972609288a83c7dbed4ec5071b0ccfdd831a05706ada1d10ad882L273-R278) [[4]](diffhunk://#diff-28d8e35fdde972609288a83c7dbed4ec5071b0ccfdd831a05706ada1d10ad882R292)

Changes in the `ApolloPagination` library:

* [`apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift`](diffhunk://#diff-bbd20683d6ef1206d7aae2b688f4b2124f812c95aae7af409761c48c322399a1L196-L205): The `subscribe` method is removed from the `AsyncGraphQLQueryPager` class.
* [`apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift`](diffhunk://#diff-15b3e5571b28a433475df3ef139318cd9aa539ef1302cd4e4600639fbb8d57aaL183-L190): The `subscribe` method is removed from the `GraphQLQueryPager` class.