### PR TITLE
[ApolloPagination] Make `isLoadingAll` publicly accessible, remove special logic

### DIFF
--- a/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
@@ -347,7 +347,9 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
     let lastPageExpectation = Mocks.Hero.FriendsQuery.expectationForSecondPage(server: server)
     try await pager.loadAll()
     await fulfillment(of: [firstPageExpectation, lastPageExpectation], timeout: 5)
-    guard let value = try await pager.currentValue?.get() else { return XCTFail() }
+    if try await pager.currentValue?.get() == nil {
+      XCTFail()
+    }
   }
 
   func test_equatable() async {

--- a/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerTests.swift
@@ -345,13 +345,9 @@ final class AsyncGraphQLQueryPagerTests: XCTestCase {
 
     let firstPageExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
     let lastPageExpectation = Mocks.Hero.FriendsQuery.expectationForSecondPage(server: server)
-    let loadAllExpectation = expectation(description: "Load all pages")
-    let subscriber = await pager.subscribe { _ in
-      loadAllExpectation.fulfill()
-    }
     try await pager.loadAll()
-    await fulfillment(of: [firstPageExpectation, lastPageExpectation, loadAllExpectation], timeout: 5)
-    subscriber.cancel()
+    await fulfillment(of: [firstPageExpectation, lastPageExpectation], timeout: 5)
+    guard let value = try await pager.currentValue?.get() else { return XCTFail() }
   }
 
   func test_equatable() async {

--- a/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
@@ -180,13 +180,9 @@ final class BidirectionalPaginationTests: XCTestCase, CacheDependentTesting {
     let previousPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForPreviousPage(server: server)
     let lastPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForLastPage(server: server)
 
-    let loadAllExpectation = expectation(description: "Load all pages")
-    await pager.subscribe(onUpdate: { _ in
-      loadAllExpectation.fulfill()
-    }).store(in: &cancellables)
     try await pager.loadAll()
     await fulfillment(
-      of: [firstPageExpectation, lastPageExpectation, previousPageExpectation, loadAllExpectation],
+      of: [firstPageExpectation, lastPageExpectation, previousPageExpectation],
       timeout: 5
     )
 
@@ -290,7 +286,9 @@ final class BidirectionalPaginationTests: XCTestCase, CacheDependentTesting {
     var currentValue: GraphQLQueryPager<PaginationOutput<BidirectionalPaginationTests.Query, BidirectionalPaginationTests.Query>>.Output?
     pager.sink { result in
       currentValue = result
-      loadAllExpectation.fulfill()
+      if !pager.isLoadingAll {
+        loadAllExpectation.fulfill()
+      }
     }.store(in: &cancellables)
     pager.loadAll()
     XCTAssertTrue(pager.isLoadingAll)

--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -239,12 +239,9 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
 
     let firstPageExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
     let lastPageExpectation = Mocks.Hero.FriendsQuery.expectationForSecondPage(server: server)
-    let loadAllExpectation = expectation(description: "Load all pages")
-    await pager.subscribe(onUpdate: { _ in
-      loadAllExpectation.fulfill()
-    }).store(in: &cancellables)
     try await pager.loadAll()
-    await fulfillment(of: [firstPageExpectation, lastPageExpectation, loadAllExpectation], timeout: 5)
+    await fulfillment(of: [firstPageExpectation, lastPageExpectation], timeout: 5)
+    guard let value = try await pager.currentValue?.get() else { return XCTFail() }
   }
 
   func test_failingFetch_finishes() async throws {

--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -241,7 +241,9 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
     let lastPageExpectation = Mocks.Hero.FriendsQuery.expectationForSecondPage(server: server)
     try await pager.loadAll()
     await fulfillment(of: [firstPageExpectation, lastPageExpectation], timeout: 5)
-    guard let value = try await pager.currentValue?.get() else { return XCTFail() }
+    if try await pager.currentValue?.get() == nil {
+      XCTFail()
+    }
   }
 
   func test_failingFetch_finishes() async throws {

--- a/Tests/ApolloPaginationTests/ReversePaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ReversePaginationTests.swift
@@ -101,12 +101,9 @@ final class ReversePaginationTests: XCTestCase, CacheDependentTesting {
 
     let firstPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForLastItem(server: server)
     let lastPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForPreviousItem(server: server)
-    let loadAllExpectation = expectation(description: "Load all pages")
-    await pager.subscribe(onUpdate: { _ in
-      loadAllExpectation.fulfill()
-    }).store(in: &cancellables)
     try await pager.loadAll()
-    await fulfillment(of: [firstPageExpectation, lastPageExpectation, loadAllExpectation], timeout: 5)
+    await fulfillment(of: [firstPageExpectation, lastPageExpectation], timeout: 5)
+    guard let value = try await pager.currentValue?.get() else { return XCTFail() }
   }
 
   private func createPager() -> AsyncGraphQLQueryPagerCoordinator<Query, Query> {

--- a/Tests/ApolloPaginationTests/ReversePaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ReversePaginationTests.swift
@@ -103,7 +103,9 @@ final class ReversePaginationTests: XCTestCase, CacheDependentTesting {
     let lastPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForPreviousItem(server: server)
     try await pager.loadAll()
     await fulfillment(of: [firstPageExpectation, lastPageExpectation], timeout: 5)
-    guard let value = try await pager.currentValue?.get() else { return XCTFail() }
+    if try await pager.currentValue?.get() == nil {
+      XCTFail()
+    }
   }
 
   private func createPager() -> AsyncGraphQLQueryPagerCoordinator<Query, Query> {

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPager.swift
@@ -14,6 +14,7 @@ public class AsyncGraphQLQueryPager<Model>: Publisher {
 
   public var canLoadNext: Bool { get async { await pager.canLoadNext } }
   public var canLoadPrevious: Bool { get async { await pager.canLoadPrevious } }
+  public var isLoadingAll: Bool { get async { await pager.isLoadingAll } }
 
   init<Pager: AsyncGraphQLQueryPagerCoordinator<InitialQuery, PaginatedQuery>, InitialQuery, PaginatedQuery>(
     pager: Pager,

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
@@ -9,6 +9,7 @@ public protocol AsyncPagerType {
   associatedtype PaginatedQuery: GraphQLQuery
   var canLoadNext: Bool { get async }
   var canLoadPrevious: Bool { get async }
+  var isLoadingAll: Bool { get async }
   func reset() async
   func loadPrevious(cachePolicy: CachePolicy) async throws
   func loadNext(cachePolicy: CachePolicy) async throws
@@ -22,7 +23,7 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
   private var firstPageWatcher: GraphQLQueryWatcher<InitialQuery>?
   private var nextPageWatchers: [GraphQLQueryWatcher<PaginatedQuery>] = []
   let initialQuery: InitialQuery
-  var isLoadingAll: Bool = false
+  @Published var isLoadingAll: Bool = false
   var isFetching: Bool = false
   let nextPageResolver: (PaginationInfo) -> PaginatedQuery?
   let previousPageResolver: (PaginationInfo) -> PaginatedQuery?
@@ -37,9 +38,10 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
   var publishers: (
     previousPageVarMap: Published<OrderedDictionary<Set<JSONValue>, PaginatedQuery.Data>>.Publisher,
     initialPageResult: Published<InitialQuery.Data?>.Publisher,
-    nextPageVarMap: Published<OrderedDictionary<Set<JSONValue>, PaginatedQuery.Data>>.Publisher
+    nextPageVarMap: Published<OrderedDictionary<Set<JSONValue>, PaginatedQuery.Data>>.Publisher,
+    isLoadingAll: Published<Bool>.Publisher
   ) {
-    return ($previousPageVarMap, $initialPageResult, $nextPageVarMap)
+    return ($previousPageVarMap, $initialPageResult, $nextPageVarMap, $isLoadingAll)
   }
 
   typealias ResultType = Result<(PaginationOutput<InitialQuery, PaginatedQuery>, UpdateSource), Error>

--- a/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AsyncGraphQLQueryPagerCoordinator.swift
@@ -173,14 +173,7 @@ actor AsyncGraphQLQueryPagerCoordinator<InitialQuery: GraphQLQuery, PaginatedQue
     onUpdate: @escaping (Result<(PaginationOutput<InitialQuery, PaginatedQuery>, UpdateSource), Error>) -> Void
   ) -> AnyCancellable {
     $currentValue.compactMap({ $0 })
-      .sink { [weak self] result in
-        Task { [weak self] in
-          guard let self else { return }
-          let isLoadingAll = await self.isLoadingAll
-          guard !isLoadingAll else { return }
-          onUpdate(result)
-        }
-      }
+      .sink(receiveValue: onUpdate)
   }
 
   /// Reloads all data, starting at the first query, resetting pagination state.

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -14,6 +14,7 @@ public class GraphQLQueryPager<Model>: Publisher {
 
   public var canLoadNext: Bool { pager.canLoadNext }
   public var canLoadPrevious: Bool { pager.canLoadPrevious }
+  public var isLoadingAll: Bool { pager.isLoadingAll }
 
   init<Pager: GraphQLQueryPagerCoordinator<InitialQuery, PaginatedQuery>, InitialQuery, PaginatedQuery>(
     pager: Pager,


### PR DESCRIPTION
> [!CAUTION]
> This is a breaking change!

This pull request introduces the `isLoadingAll` property to both `GraphQLQueryPager` and `AsyncGraphQLQueryPager`.  Additionally, it removes the logic in the `AsyncGraphQLQueryPagerCoordinator`'s `subscribe` function which intentionally does not forward updates to subscribers while `loadingAll`. 

The existing logic was built on the assumption that callers of `loadAll` will not want any updates until we can furnish all data. However, with a public `isLoadingAll` property, consumers of the API can manage this behavior themselves. This does mean that users will receive each page as it comes in via the `loadAll` function unless they specifically want to defer the update (through use of the `isLoadingAll` property).