### PR TITLE
Default task descriptions

### DIFF
--- a/apollo-ios/Sources/Apollo/NetworkFetchInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/NetworkFetchInterceptor.swift
@@ -36,7 +36,7 @@ public class NetworkFetchInterceptor: ApolloInterceptor, Cancellable {
       return
     }
     
-    var taskDescription = Operation.operationName
+    var taskDescription = "\(Operation.operationType) \(Operation.operationName)"
     if let operationIdentifier = Operation.operationIdentifier {
         taskDescription += " \(operationIdentifier)"
     }

--- a/apollo-ios/Sources/Apollo/NetworkFetchInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/NetworkFetchInterceptor.swift
@@ -36,7 +36,11 @@ public class NetworkFetchInterceptor: ApolloInterceptor, Cancellable {
       return
     }
     
-    let task = self.client.sendRequest(urlRequest) { [weak self] result in
+    var taskDescription = Operation.operationName
+    if let operationIdentifier = Operation.operationIdentifier {
+        taskDescription += " \(operationIdentifier)"
+    }
+    let task = self.client.sendRequest(urlRequest, taskDescription: taskDescription) { [weak self] result in
       guard let self = self else {
         return
       }

--- a/apollo-ios/Sources/Apollo/NetworkFetchInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/NetworkFetchInterceptor.swift
@@ -36,10 +36,7 @@ public class NetworkFetchInterceptor: ApolloInterceptor, Cancellable {
       return
     }
     
-    var taskDescription = "\(Operation.operationType) \(Operation.operationName)"
-    if let operationIdentifier = Operation.operationIdentifier {
-        taskDescription += " \(operationIdentifier)"
-    }
+    let taskDescription = "\(Operation.operationType) \(Operation.operationName)"
     let task = self.client.sendRequest(urlRequest, taskDescription: taskDescription) { [weak self] result in
       guard let self = self else {
         return

--- a/apollo-ios/Sources/Apollo/URLSessionClient.swift
+++ b/apollo-ios/Sources/Apollo/URLSessionClient.swift
@@ -152,7 +152,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     sendRequest(
       request,
       taskDescription: nil,
-      rawTaskCompletionHandler: nil,
+      rawTaskCompletionHandler: rawTaskCompletionHandler,
       completion: completion
     )
   }


### PR DESCRIPTION
This PR adds task descriptions based on the operation type, name and identifier. [Task descriptions](https://developer.apple.com/documentation/foundation/urlsessiontask/1409798-taskdescription) are helpful in disambiguation `URLSessionTask`s in Instruments and debugging in Xcode.