### PR TITLE
refactor: extracted DataDict.asJSONDictionary()

### DIFF
--- a/apollo-ios/Sources/Apollo/GraphQLResult.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLResult.swift
@@ -55,10 +55,19 @@ extension GraphQLResult {
   /// - Returns: A `[String: Any]` JSON dictionary representing the ``GraphQLResult``.
   public func asJSONDictionary() -> [String: Any] {
     var dict: [String: Any] = [:]
-    if let data { dict["data"] = convert(value: data.__data) }
+    if let data { dict["data"] = data.__data.asJSONDictionary() }
     if let errors { dict["errors"] = errors.map { $0.asJSONDictionary() } }
     if let extensions { dict["extensions"] = extensions }
     return dict
+  }
+}
+
+extension DataDict {
+  /// Converts a ``DataDict`` into a basic JSON dictionary for use.
+  ///
+  /// - Returns: A `[String: Any]` JSON dictionary representing the ``DataDict``.
+  public func asJSONDictionary() -> [String: Any] {
+    _data.mapValues(convert(value:))
   }
   
   private func convert(value: Any) -> Any {


### PR DESCRIPTION
Hey there 👋 

recently I found the need to encode a `DataDict` instance into a JSON object. I found that this functionality is already provided but only for `GraphQLResult` instances instead.

 I refactored the relevant code to also expose a `DataDict.asJSONDictionary()` method that performs the same logic as the one in `GraphQLResult`.