### PR TITLE
Set integration tests to run on macos-13

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -261,7 +261,7 @@ jobs:
       uses: ./.github/actions/run-cocoapods-integration-tests
 
   run-integration-tests:
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: [tuist-generation, changes]
     if: ${{ needs.changes.outputs.ios  == 'true' }}
     timeout-minutes: 20
@@ -269,7 +269,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: ${{ env.XCODE_VERSION }}
+        xcode-version: 15.2
     - name: Checkout Repo
       uses: actions/checkout@v3
     - name: Setup Node 12.22.10

--- a/apollo-ios/ROADMAP.md
+++ b/apollo-ios/ROADMAP.md
@@ -1,6 +1,6 @@
 # 🔮 Apollo iOS Roadmap
 
-**Last updated: 2024-05-28**
+**Last updated: 2024-05-31**
 
 For up to date release notes, refer to the project's [Changelog](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md).
 


### PR DESCRIPTION
Integration tests need node 12.22.10 which does not have an image for arm64 devices. We need to rollback to using the macos-13 image for this job.