### PR TITLE
chore: Update Swift Collections dependency

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     }
   ],


### PR DESCRIPTION
This updates the Swift Collections dependency to `1.1.1` because the [release notes](https://github.com/apple/swift-collections/releases/tag/1.1.1) specifically mention the release resolving issues uncovered since the `1.1.0` release.