### PR TITLE
Add CI Workflow to create release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,16 +1,21 @@
 name: "Create Release PR"
 
 on:
-  workflow_dispatch:
-    inputs:
-      versionNumber:
-        description: 'Version Number'
-        required: true
+  # temporary for testing
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+  # workflow_dispatch:
+  #   inputs:
+  #     versionNumber:
+  #       description: 'Version Number'
+  #       required: true
 
 env:
   BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
+  versionNumer: "19.8.29"
 
-# github.event.inputs.versionNumber
 jobs:
   create-release-pr:
     runs-on: macos-latest
@@ -33,7 +38,7 @@ jobs:
       run: |
         previousVersion=$(sh apollo-ios/scripts/get-version.sh)
         echo "PREVIOUS_VERSION=$previousVersion" >> ${GITHUB_ENV}
-        sh ./scripts/set-version.sh ${{ github.event.inputs.versionNumber }}
+        sh ./scripts/set-version.sh ${{ env.versionNumber }}
         (cd SwiftScripts && swift run DocumentationGenerator)
         make archive-cli-to-apollo-package
     - name: Create Pull Request
@@ -41,11 +46,11 @@ jobs:
       with:
         branch: ${{ env.BRANCH_NAME }}
         commit-message: |
-          Setting up Release ${{ github.event.inputs.versionNumber }}
+          Setting up Release ${{ env.versionNumber }}
 
           Created By GitHub Action Workflow
         title: |
-          Release ${{ github.event.inputs.versionNumber }}
+          Release ${{ env.versionNumber }}
         body: |
           #### Diff
           [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ github.sha }}).

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,54 @@
+name: "Create Release PR"
+
+on:
+  workflow_dispatch:
+    inputs:
+      versionNumber:
+        description: 'Version Number'
+        required: true
+
+env:
+  BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
+
+# github.event.inputs.versionNumber
+jobs:
+  create-release-pr:
+    runs-on: macos-latest
+    timeout-minutes: 5
+    name: "Create Release PR"
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        ref: main
+    - name: Setup SSH Keys
+      uses: webfactory/ssh-agent@v0.7.0
+      with:
+        ssh-private-key: |
+          ${{ secrets.APOLLO_IOS_DEV_DEPLOY_KEY }}
+    - name: Configure Git
+      uses: ./.github/actions/configure-git
+    - name: Run Commands
+      shell: bash
+      run: |
+        previousVersion=$(sh apollo-ios/scripts/get-version.sh)
+        echo "PREVIOUS_VERSION=$previousVersion" >> ${GITHUB_ENV}
+        sh ./scripts/set-version.sh ${{ github.event.inputs.versionNumber }}
+        (cd SwiftScripts && swift run DocumentationGenerator)
+        make archive-cli-to-apollo-package
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        branch: ${{ env.BRANCH_NAME }}
+        commit-message: |
+          Setting up Release ${{ github.event.inputs.versionNumber }}
+
+          Created By GitHub Action Workflow
+        title: |
+          Release ${{ github.event.inputs.versionNumber }}
+        body: |
+          #### Diff
+          [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ github.sha }}).
+
+          #### Things to do in this PR
+          - [] Update [`CHANGELOG.md`](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) with all relevant changes since the prior version. _Please include PR numbers and mention contributors for external PR submissions._


### PR DESCRIPTION
This is the first step in automating our release process as much as possible. The plan is to have this manually triggered CI job that can create the initial PR and handle all the basic tasks associated with that. Then a separate CI job that will be triggered on merge of release PRs to handle the tasks associated with that (tagging, creating release on github repo etc)

Currently planning to leave CHANGELOG handling as a manual process and get as many other parts of the CI process as possible automated and then revisit the possibility of automating CHANGELOG handling as well.