### PR TITLE
cI: Release Automation Step 1

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -10,6 +10,7 @@ on:
 env:
   BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
   VERSION_NUMBER: ${{ github.event.inputs.versionNumber }}
+  CURRENT_SHA: ${{ github.sha }}
 
 jobs:
   create-release-pr:
@@ -48,7 +49,7 @@ jobs:
           Release ${{ env.VERSION_NUMBER }}
         body: |
           #### Diff
-          [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ github.sha }}).
+          [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ env.CURRENT_SHA }}).
 
           #### Things to do in this PR
           - [ ] Update [`CHANGELOG.md`](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) with all relevant changes since the prior version. _Please include PR numbers and mention contributors for external PR submissions._

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
+  VERSION_NUMBER: ${{ github.event.inputs.versionNumber }}
 
 jobs:
   create-release-pr:
@@ -32,7 +33,7 @@ jobs:
       run: |
         previousVersion=$(sh apollo-ios/scripts/get-version.sh)
         echo "PREVIOUS_VERSION=$previousVersion" >> ${GITHUB_ENV}
-        sh ./scripts/set-version.sh ${{ github.event.inputs.versionNumber }}
+        sh ./scripts/set-version.sh ${{ env.VERSION_NUMBER }}
         (cd SwiftScripts && swift run DocumentationGenerator)
         make archive-cli-to-apollo-package
     - name: Create Pull Request
@@ -40,11 +41,11 @@ jobs:
       with:
         branch: ${{ env.BRANCH_NAME }}
         commit-message: |
-          Setting up Release ${{ github.event.inputs.versionNumber }}
+          Setting up Release ${{ env.VERSION_NUMBER }}
 
           Created By GitHub Action Workflow
         title: |
-          Release ${{ github.event.inputs.versionNumber }}
+          Release ${{ env.VERSION_NUMBER }}
         body: |
           #### Diff
           [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ github.sha }}).

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -28,13 +28,23 @@ jobs:
           ${{ secrets.APOLLO_IOS_DEV_DEPLOY_KEY }}
     - name: Configure Git
       uses: ./.github/actions/configure-git
-    - name: Run Commands
+    - name: Get Previous Version
       shell: bash
       run: |
         previousVersion=$(sh apollo-ios/scripts/get-version.sh)
         echo "PREVIOUS_VERSION=$previousVersion" >> ${GITHUB_ENV}
+    - name: Set New Version
+      shell: bash
+      run: |
         sh ./scripts/set-version.sh "${{ env.VERSION_NUMBER }}"
-        (cd SwiftScripts && swift run DocumentationGenerator)
+    - name: Generate Documentation
+      shell: bash
+      run: |
+        cd SwiftScripts
+        swift run DocumentationGenerator
+    - name: Archive CLI
+      shell: bash
+      run: |
         make archive-cli-to-apollo-package
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -53,4 +53,11 @@ jobs:
           [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ github.sha }}).
 
           #### Things to do in this PR
-          - [] Update [`CHANGELOG.md`](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) with all relevant changes since the prior version. _Please include PR numbers and mention contributors for external PR submissions._
+          - [ ] Update [`CHANGELOG.md`](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) with all relevant changes since the prior version. _Please include PR numbers and mention contributors for external PR submissions._
+
+          #### Things to do as part of releasing
+          - [ ] Add tag of format `major.minor.patch` to GitHub.
+          - [ ] Create a release on GitHub with the new tag, using the latest [`CHANGELOG.md`](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) contents.
+          - [ ] Attach CLI binary to the GitHub release. _Use the `make archive-cli-for-release` command which builds both Intel and ARM architectures, and creates the tar archive for you._
+          - [ ] Run `pod trunk push Apollo.podspec` and `pod trunk push ApolloTestSupport.podspec` to publish to CocoaPods. _You will need write permissions for this, please contact one of the [maintainers](https://github.com/apollographql/apollo-ios/blob/main/README.md#maintainers) if you need access to do this._
+          - [ ] Run "[Release New Version](https://github.com/apollographql/apollo-ios-xcframework/actions/workflows/release-new-version.yml)" workflow in `apollo-ios-xcframework`

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,10 +1,7 @@
 name: "Create Release PR"
 
 on:
-  # temporary for testing
-  pull_request_target:
-    branches:
-      - main
+  pull_request:
     types: [opened, synchronize, reopened]
   # workflow_dispatch:
   #   inputs:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   BRANCH_NAME: "release/19.8.29"
-  versionNumer: "19.8.29"
+  versionNumber: "19.8.29"
 
 jobs:
   create-release-pr:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,16 +1,21 @@
 name: "Create Release PR"
 
 on:
-  workflow_dispatch:
-    inputs:
-      versionNumber:
-        description: 'Version Number'
-        required: true
+  # temporary for testing
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+  # workflow_dispatch:
+  #   inputs:
+  #     versionNumber:
+  #       description: 'Version Number'
+  #       required: true
 
 env:
   BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
+  versionNumer: "19.8.29"
 
-# github.event.inputs.versionNumber
 jobs:
   create-release-pr:
     runs-on: macos-latest
@@ -33,7 +38,7 @@ jobs:
       run: |
         previousVersion=$(sh apollo-ios/scripts/get-version.sh)
         echo "PREVIOUS_VERSION=$previousVersion" >> ${GITHUB_ENV}
-        sh ./scripts/set-version.sh ${{ github.event.inputs.versionNumber }}
+        sh ./scripts/set-version.sh ${{ env.versionNumber }}
         (cd SwiftScripts && swift run DocumentationGenerator)
         make archive-cli-to-apollo-package
     - name: Create Pull Request
@@ -41,11 +46,11 @@ jobs:
       with:
         branch: ${{ env.BRANCH_NAME }}
         commit-message: |
-          Setting up Release ${{ github.event.inputs.versionNumber }}
+          Setting up Release ${{ env.versionNumber }}
 
           Created By GitHub Action Workflow
         title: |
-          Release ${{ github.event.inputs.versionNumber }}
+          Release ${{ env.versionNumber }}
         body: |
           #### Diff
           [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ github.sha }}).

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,54 @@
+name: "Create Release PR"
+
+on:
+  workflow_dispatch:
+    inputs:
+      versionNumber:
+        description: 'Version Number'
+        required: true
+
+env:
+  BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
+
+# github.event.inputs.versionNumber
+jobs:
+  create-release-pr:
+    runs-on: macos-latest
+    timeout-minutes: 5
+    name: "Create Release PR"
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        ref: main
+    - name: Setup SSH Keys
+      uses: webfactory/ssh-agent@v0.7.0
+      with:
+        ssh-private-key: |
+          ${{ secrets.APOLLO_IOS_DEV_DEPLOY_KEY }}
+    - name: Configure Git
+      uses: ./.github/actions/configure-git
+    - name: Run Commands
+      shell: bash
+      run: |
+        previousVersion=$(sh apollo-ios/scripts/get-version.sh)
+        echo "PREVIOUS_VERSION=$previousVersion" >> ${GITHUB_ENV}
+        sh ./scripts/set-version.sh ${{ github.event.inputs.versionNumber }}
+        (cd SwiftScripts && swift run DocumentationGenerator)
+        make archive-cli-to-apollo-package
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        branch: ${{ env.BRANCH_NAME }}
+        commit-message: |
+          Setting up Release ${{ github.event.inputs.versionNumber }}
+
+          Created By GitHub Action Workflow
+        title: |
+          Release ${{ github.event.inputs.versionNumber }}
+        body: |
+          #### Diff
+          [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ github.sha }}).
+
+          #### Things to do in this PR
+          - [] Update [`CHANGELOG.md`](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) with all relevant changes since the prior version. _Please include PR numbers and mention contributors for external PR submissions._

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -66,6 +66,6 @@ jobs:
           #### Things to do as part of releasing
           - [ ] Add tag of format `major.minor.patch` to GitHub.
           - [ ] Create a release on GitHub with the new tag, using the latest [`CHANGELOG.md`](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) contents.
-          - [ ] Attach CLI binary to the GitHub release. _Use the `make archive-cli-for-release` command which builds both Intel and ARM architectures, and creates the tar archive for you._
+          - [ ] Attach CLI binary to the GitHub release.
           - [ ] Run `pod trunk push Apollo.podspec` and `pod trunk push ApolloTestSupport.podspec` to publish to CocoaPods. _You will need write permissions for this, please contact one of the [maintainers](https://github.com/apollographql/apollo-ios/blob/main/README.md#maintainers) if you need access to do this._
           - [ ] Run "[Release New Version](https://github.com/apollographql/apollo-ios-xcframework/actions/workflows/release-new-version.yml)" workflow in `apollo-ios-xcframework`

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -10,7 +10,6 @@ on:
 env:
   BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
   VERSION_NUMBER: ${{ github.event.inputs.versionNumber }}
-  CURRENT_SHA: ${{ github.sha }}
 
 jobs:
   create-release-pr:
@@ -34,7 +33,7 @@ jobs:
       run: |
         previousVersion=$(sh apollo-ios/scripts/get-version.sh)
         echo "PREVIOUS_VERSION=$previousVersion" >> ${GITHUB_ENV}
-        sh ./scripts/set-version.sh ${{ env.VERSION_NUMBER }}
+        sh ./scripts/set-version.sh "${{ env.VERSION_NUMBER }}"
         (cd SwiftScripts && swift run DocumentationGenerator)
         make archive-cli-to-apollo-package
     - name: Create Pull Request
@@ -49,7 +48,7 @@ jobs:
           Release ${{ env.VERSION_NUMBER }}
         body: |
           #### Diff
-          [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ env.CURRENT_SHA }}).
+          [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ github.sha }}).
 
           #### Things to do in this PR
           - [ ] Update [`CHANGELOG.md`](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) with all relevant changes since the prior version. _Please include PR numbers and mention contributors for external PR submissions._

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,17 +1,14 @@
 name: "Create Release PR"
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  # workflow_dispatch:
-  #   inputs:
-  #     versionNumber:
-  #       description: 'Version Number'
-  #       required: true
+  workflow_dispatch:
+    inputs:
+      versionNumber:
+        description: 'Version Number'
+        required: true
 
 env:
-  BRANCH_NAME: "release/19.8.29"
-  versionNumber: "19.8.29"
+  BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
 
 jobs:
   create-release-pr:
@@ -35,7 +32,7 @@ jobs:
       run: |
         previousVersion=$(sh apollo-ios/scripts/get-version.sh)
         echo "PREVIOUS_VERSION=$previousVersion" >> ${GITHUB_ENV}
-        sh ./scripts/set-version.sh ${{ env.versionNumber }}
+        sh ./scripts/set-version.sh ${{ github.event.inputs.versionNumber }}
         (cd SwiftScripts && swift run DocumentationGenerator)
         make archive-cli-to-apollo-package
     - name: Create Pull Request
@@ -43,11 +40,11 @@ jobs:
       with:
         branch: ${{ env.BRANCH_NAME }}
         commit-message: |
-          Setting up Release ${{ env.versionNumber }}
+          Setting up Release ${{ github.event.inputs.versionNumber }}
 
           Created By GitHub Action Workflow
         title: |
-          Release ${{ env.versionNumber }}
+          Release ${{ github.event.inputs.versionNumber }}
         body: |
           #### Diff
           [See diff since last version](https://github.com/apollographql/apollo-ios-dev/compare/${{ env.PREVIOUS_VERSION }}...${{ github.sha }}).

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -10,7 +10,7 @@ on:
   #       required: true
 
 env:
-  BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
+  BRANCH_NAME: "release/19.8.29"
   versionNumer: "19.8.29"
 
 jobs:


### PR DESCRIPTION
This is the first step in automating our release process as much as possible. The plan is to have this manually triggered CI job that can create the initial PR and handle all the basic tasks associated with that. Then a separate CI job that will be triggered on merge of release PRs to handle the tasks associated with that (tagging, creating release on github repo etc)

Currently planning to leave CHANGELOG handling as a manual process and get as many other parts of the CI process as possible automated and then revisit the possibility of automating CHANGELOG handling as well.

Sample Release PR created by this workflow: https://github.com/apollographql/apollo-ios-dev/pull/394

The "Things to do as part of releasing" section will be the focus of the workflow that triggers from merging the release PR.