### PR TITLE
ci: Setting up release publishing

### DIFF
--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -1,0 +1,25 @@
+name: "Repo Dispatch"
+description: "Sends a dispatch to another repo to trigger a workflow."
+inputs:
+  access-token:
+    description: "The Personal Access Token with proper permissions to the given repository."
+    required: true
+  repo:
+    description: "The name of the repository to dispatch to."
+    required: true
+  client-payload:
+    description: "The JSON client payload to send with the dispatch."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Repository Dispatch
+      shell: bash
+      run: |
+        curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ inputs.access-token }}" \
+          -H "Content-Type: application/json" \
+          https://api.github.com/repos/apollographql/${{ inputs.repo }}/dispatches \
+          -d "${{ inputs.client-payload }}"

--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -14,6 +14,8 @@ jobs:
     if: ${{ github.event.pull_request.merged }}
     runs-on: macos-latest
     name: Split and Push Subtrees
+    outputs:
+      releaseVersion: ${{ steps.getVersion.outputs.RELEASE_VERSION }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
@@ -67,3 +69,29 @@ jobs:
       run: |
         git fetch
         git push
+    - name: Get Version
+      id: getVersion
+      shell: bash
+      run: |
+        releaseVersion=$(sh apollo-ios/scripts/get-version.sh)
+        echo "RELEASE_VERSION=$releaseVersion" >> "$GITHUB_OUTPUT"
+  publish-release:
+    if: success('split-subtrees') && github.event.pull_request.base.ref == "release/${{ needs.split-subtrees.outputs.releaseVersion }}"
+    needs: split-subtrees
+    runs-on: macos-latest
+    name: Publish Release
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup SSH Keys
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.APOLLO_IOS_DEV_DEPLOY_KEY }}
+      - name: Configure Git
+        uses: ./.github/actions/configure-git
+      - name: Trigger publish-release workflow
+        shell: bash
+        run: |
+          gh auth login -p ssh
+          gh workflow run publish-release.yml

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,89 @@
+name: "Publish Release"
+
+on:
+  workflow_dispatch
+
+jobs:
+  publish-release:
+    runs-on: macos-latest
+    name: Publish Release
+    steps:
+      # Checkout apollo-ios-dev repo
+      - name: Checkout apollo-ios-dev Repo
+        uses: actions/checkout@v4
+
+      # Checkout apollo-ios repo
+      - name: Checkout apollo-ios Repo
+        uses: actions/checkout@v4
+        with:
+          repository: apollographql/apollo-ios
+          path: "../apollo-ios"
+          ref: main
+
+      # Checkout apollo-ios-codegen repo
+      - name: Checkout apollo-ios-codegen Repo
+        uses: actions/checkout@v4
+        with:
+          repository: apollographql/apollo-ios-codegen
+          path: "../apollo-ios-codegen"
+          ref: main
+
+      # Setup SSH Keys
+      - name: Setup SSH Keys
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.APOLLO_IOS_DEPLOY_KEY }}
+            ${{ secrets.APOLLO_IOS_CODEGEN_DEPLOY_KEY }}
+            ${{ secrets.APOLLO_IOS_DEV_DEPLOY_KEY }}
+
+      # Configure Git
+      - name: Configure Git
+        uses: ./.github/actions/configure-git
+
+      # Get version
+      - name: Get Version
+        shell: bash
+        run: |
+          releaseVersion=$(sh apollo-ios/scripts/get-version.sh)
+          echo "RELEASE_VERSION=$releaseVersion" >> ${GITHUB_ENV}
+
+      # Tag Dev, ios, and codegen repos
+      - name: Tag Commits
+        shell: bash
+        run: |
+          git tag ${{ env.RELEASE_VERSION }}
+          git push --tags
+          cd ../apollo-ios
+          git tag ${{ env.RELEASE_VERSION }}
+          git push --tags
+          cd ../apollo-ios-codegen
+          git tag ${{ env.RELEASE_VERSION }}
+          git push --tags
+
+      # Create Draft Release on GitHub with tag of version
+      - name: Create Draft Release
+        shell: bash
+        run: |
+          gh auth login -p ssh
+          gh create release ${{ env.RELEASE_VERSION }} '/apollo-ios/CLI/apollo-ios-cli.tar.gz#apollo-ios-cli.tar.gz' -d --repo "apollographql/apollo-ios"
+
+      # Trigger "Release New Version" workflow in the apollo-ios-xcframework repo
+      - name: Dispatch apollo-ios-xcframework
+        uses: ./.github/actions/repo-dispatch
+        with:
+          access-token: ${{ secrets.APOLLO_IOS_PAT }}
+          repo: "apollo-ios-xcframework"
+          client-payload: "{\"event_type\":\"release-new-version\",\"client_payload\":{\"versionNumber\":\"${{ env.RELEASE_VERSION }}\"}}"
+
+      # Push Pods for Apollo iOS and Test Support
+      - name: Push Cocoapods
+        shell: bash
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          gem install cocoapods
+          set -eo pipefail
+          cd apollo-ios
+          pod trunk push ApolloTest.podspec
+          pod trunk push ApolloTestSupport.podspec

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -85,5 +85,5 @@ jobs:
           gem install cocoapods
           set -eo pipefail
           cd apollo-ios
-          pod trunk push ApolloTest.podspec
+          pod trunk push Apollo.podspec
           pod trunk push ApolloTestSupport.podspec


### PR DESCRIPTION
This PR sets up the publishing portion of automating our release process. Some of the steps may (likely will) require some tweaking once we have had a chance to test it in practice to ensure everything is configured exactly correct, using proper tokens etc.