### PR TITLE
ci: Fixing release-check workflow

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -253,7 +253,7 @@ jobs:
       uses: ./.github/actions/run-cocoapods-integration-tests
 
   run-integration-tests:
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: tuist-generation
     timeout-minutes: 20
     name: Apollo Integration Tests - macOS


### PR DESCRIPTION
The `release-check` workflow keeps failing integration tests due to a node installation error:
```
Attempting to download 12.22.10...
Not found in manifest. Falling back to download directly from Node
Error: Unable to find Node version '[12](https://github.com/apollographql/apollo-ios-dev/actions/runs/9631580897/job/26563574892#step:4:13).22.10' for platform darwin and architecture arm64.
```

The integration tests pass on the `ci-tests` workflow that runs on PR's, it looks like the `release-check` workflow had the integration tests job updated to use `macos-latest` like the rest of the jobs while the `ci-tests` workflow is still using `macos-13` for the integration tests and this issue appears to be stemming from the switch from macos-13 to macos-14 for the runner.

Other discussion of the same issue here: https://github.com/actions/setup-node/issues/1017#issuecomment-2077478383

Reverting the integration tests job to `macos-13` for now to get this passing again but we will need to upgrade the node version to be able to bring this job forward to `macos-14`.