### PR TITLE
Fixing integration tests

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -260,7 +260,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: ${{ env.XCODE_VERSION }}
+        xcode-version: 15.2
     - name: Checkout Repo
       uses: actions/checkout@v3
     - name: Setup Node 12.22.10


### PR DESCRIPTION
Looks like the integration tests need to be pinned to xcode 15.2 since they are running on macos 13, this matches what is being done in the `ci-tests` workflow currently