### PR TITLE
ci: Adds a manually triggered action for Xcode Beta version testing

### DIFF
--- a/.github/workflows/ci-tests-xcode-beta.yml
+++ b/.github/workflows/ci-tests-xcode-beta.yml
@@ -1,4 +1,4 @@
-name: "CI Tests"
+name: "CI Tests (Xcode 16.0 Beta)"
 
 on:
   workflow_dispatch

--- a/.github/workflows/ci-tests-xcode-beta.yml
+++ b/.github/workflows/ci-tests-xcode-beta.yml
@@ -1,0 +1,334 @@
+name: "CI Tests"
+
+on:
+  workflow_dispatch
+
+env:
+  XCODE_VERSION: "16.0"
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      ios: ${{ steps.filter.outputs.ios }}
+      codegen: ${{ steps.filter.outputs.codegen }}
+      pagination: ${{ steps.filter.outputs.pagination }}
+      tuist: ${{ steps.filter.outputs.tuist }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            ios:
+              - 'apollo-ios/**'
+              - 'Tests/ApolloInternalTestHelpers/**'
+              - 'Tests/ApolloServerIntegrationTests/**'
+              - 'Tests/ApolloTests/**'
+            codegen:
+              - 'apollo-ios-codegen/**'
+              - 'Tests/ApolloCodegenInternalTestHelpers/**'
+              - 'Tests/ApolloCodegenTests/**'
+              - 'Tests/CodegenCLITests/**'
+              - 'Tests/CodegenIntegrationTests/**'
+              - 'Tests/TestCodeGenConfigurations/**'
+            pagination:
+              - 'apollo-ios-pagination/**'
+              - 'Tests/ApolloInternalTestHelpers/**'
+              - 'apollo-ios/**'
+            tuist:
+              - '.tuist-version'
+
+  tuist-generation:
+    runs-on: macos-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.ios == 'true' || needs.changes.outputs.codegen  == 'true' || needs.changes.outputs.pagination  == 'true' || needs.changes.outputs.tuist == 'true' }}
+    timeout-minutes: 8
+    name: Run Tuist Generation
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Run Tuist Generation
+      uses: ./.github/actions/run-tuist-generation
+    - name: Cache Build Dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ./ApolloDev.xcodeproj
+          ./ApolloDev.xcworkspace
+          ./Derived/*
+        key: ${{ github.run_id }}-dependencies
+
+  run-swift-builds:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: apollo-ios
+          - package: apollo-ios-codegen
+          - package: apollo-ios-pagination
+    name: Run swift build for SPM packages
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Run Swift Build
+      shell: bash
+      run: |
+        cd ${{ matrix.package }} && swift build
+
+  build-and-unit-test:
+    runs-on: macos-latest
+    needs: [tuist-generation, changes]
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS_current
+          - destination: platform=macOS,arch=x86_64
+            scheme: ApolloTests
+            test-plan: Apollo-CITestPlan
+            name: Apollo Unit Tests - macOS
+            run-js-tests: false
+            should-run: ${{ needs.changes.outputs.ios }}
+          # Codegen CLI Test
+          - destination: platform=macOS,arch=x86_64
+            scheme: CodegenCLITests
+            test-plan: CodegenCLITestPlan
+            name: Codegen CLI Unit Tests - macOS
+            run-js-tests: false
+            should-run: ${{ needs.changes.outputs.codegen }}
+          # CodegenLib Test
+          - destination: platform=macOS,arch=x86_64
+            scheme: ApolloCodegenTests
+            test-plan: Apollo-Codegen-CITestPlan
+            name: Codegen Lib Unit Tests - macOS
+            run-js-tests: true
+            should-run: ${{ needs.changes.outputs.codegen }}
+          # ApolloPagination Tests
+          - destination: platform=macOS,arch=x86_64
+            scheme: ApolloPaginationTests
+            test-plan: Apollo-PaginationTestPlan
+            name: ApolloPagination Unit Tests - macOS
+            run-js-tests: false
+            should-run: ${{ needs.changes.outputs.pagination }}
+    name: ${{ matrix.name }}
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Retrieve Build Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ./ApolloDev.xcodeproj
+          ./ApolloDev.xcworkspace
+          ./Derived/*
+        key: ${{ github.run_id }}-dependencies
+        fail-on-cache-miss: true
+    # Caching for apollo-ios and apollo-ios-codegen SPM dependencies
+    # - uses: actions/cache@v3
+    #   with:
+    #     path: ./DerivedData/SourcePackages
+    #     key: ${{ runner.os }}-spm-${{ hashFiles('./apollo-ios/Package.resolved') }}-${{ hashFiles('./apollo-ios-codegen/Package.resolved') }}
+    # - name: Run Tuist Generation
+    #   uses: tuist/tuist-action@0.13.0
+    #   with:
+    #       command: 'generate'
+    #       arguments: ''
+    - name: Build and Test
+      if: ${{ matrix.should-run == true || matrix.should-run == 'true' }}
+      id: build-and-test
+      uses: ./.github/actions/build-and-run-unit-tests
+      with:
+        destination: ${{ matrix.destination }}
+        scheme: ${{ matrix.scheme }}
+        test-plan: ${{ matrix.test-plan }}
+    - name: Run-JS-Tests
+      if: ${{ matrix.run-js-tests == true }}
+      shell: bash
+      working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/
+      run: |
+        npm install && npm test
+    - name: Save xcodebuild logs
+      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}-logs
+        path: |
+          DerivedData/Logs/Build
+    - name: Save crash logs
+      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}-crashes
+        path: |
+          ~/Library/Logs/DiagnosticReports
+    - name: Zip Result Bundle
+      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      shell: bash
+      working-directory: TestResults
+      run: |
+        zip -r ResultBundle.zip ResultBundle.xcresult
+    - name: Save test results
+      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}-results
+        path: |
+          TestResults/ResultBundle.zip
+
+  run-codegen-test-configurations:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    name: Codegen Test Configurations - macOS
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Test Codegen Configurations
+      shell: bash
+      run: |
+        ./scripts/run-test-codegen-configurations.sh -t
+  
+  verify-frontend-bundle-latest:
+    runs-on: macos-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.codegen  == 'true' }}
+    timeout-minutes: 5
+    name: Verify Frontend Bundle Latest - macOS
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Build JS Bundle
+      shell: bash
+      working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript
+      run: npm install && ./auto_rollup.sh
+    - name: Verify Latest
+      shell: bash
+      run: |
+        git diff --exit-code
+
+  verify-cli-binary-archive:
+    runs-on: macos-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.codegen  == 'true' }}
+    timeout-minutes: 5
+    name: Verify CLI Binary Archive - macOS
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Extract CLI Binary
+      shell: bash
+      working-directory: apollo-ios/CLI
+      run: tar -xf apollo-ios-cli.tar.gz apollo-ios-cli
+    - name: Verify Version
+      shell: bash
+      working-directory: apollo-ios/scripts
+      run: ./cli-version-check.sh
+
+  run-cocoapods-integration-tests:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    name: Cocoapods Integration Tests - macOS
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ env.XCODE_VERSION }}
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Export ENV Variables
+      shell: bash
+      working-directory: apollo-ios
+      run: |
+        apollo_ios_sha=$(git rev-parse HEAD)
+        echo "APOLLO_IOS_SHA=$apollo_ios_sha" >> ${GITHUB_ENV}
+    - name: Run CocoaPods Integration Tests
+      id: run-cocoapods-integration-tests
+      uses: ./.github/actions/run-cocoapods-integration-tests
+
+  run-integration-tests:
+    runs-on: macos-13
+    needs: [tuist-generation, changes]
+    if: ${{ needs.changes.outputs.ios  == 'true' }}
+    timeout-minutes: 20
+    name: Apollo Integration Tests - macOS
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: 15.2
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Setup Node 12.22.10
+      uses: actions/setup-node@v3
+      with:
+        node-version: 12.22.10
+    - name: Setup Upload Server
+      shell: bash
+      run: |
+        sudo chmod -R +rwx SimpleUploadServer
+        cd SimpleUploadServer && npm install && npm start &
+    - name: Setup Node 18.15.0
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.15.0
+    - name: Setup Subscription Server
+      shell: bash
+      run: |
+        sh ./scripts/install-apollo-server-docs-example-server.sh
+        cd ../docs-examples/apollo-server/v3/subscriptions-graphql-ws && npm start &
+    - name: Setup Star Wars Server
+      shell: bash
+      run: |
+        sh ./scripts/install-or-update-starwars-server.sh
+        cd ../starwars-server && npm start &
+    - name: Retrieve Build Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ./ApolloDev.xcodeproj
+          ./ApolloDev.xcworkspace
+          ./Derived/*
+        key: ${{ github.run_id }}-dependencies
+        fail-on-cache-miss: true
+    - name: Build and Test
+      uses: ./.github/actions/build-and-run-unit-tests
+      with:
+        destination: platform=macOS,arch=x86_64
+        scheme: ApolloServerIntegrationTests
+        test-plan: Apollo-IntegrationTestPlan
+    - name: Save xcodebuild logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: macOS-Integration-logs
+        path: |
+          DerivedData/Logs/Build
+    - name: Save crash logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: macOS-Integration-crashes
+        path: |
+          ~/Library/Logs/DiagnosticReports
+    - name: Zip Result Bundle
+      shell: bash
+      working-directory: TestResults
+      run: |
+        zip -r ResultBundle.zip ResultBundle.xcresult
+    - name: Save test results
+      uses: actions/upload-artifact@v3
+      with:
+        name: macOS-Integration-results
+        path: |
+          TestResults/ResultBundle.zip


### PR DESCRIPTION
I've duplicated our `ci-tests.yml` action and edited it to run on the beta Xcode `16.0` which is available on the `macos-latest` image; the integration tests are still on `macos-13` due to the Node version limitation.

This should allow us to manually trigger the workflow (for now) against branches that either fix builds for Xcode 16 or something we care about checking for compatibility for. I didn't make it part of the required PR checks because there are failures at the moment and it would hold up everything. Once we get the code stable for Xcode 16 we should look at making it a required check on all PRs.