### PR TITLE
ci: Fix Xcode beta version number

### DIFF
--- a/.github/workflows/ci-tests-xcode-beta.yml
+++ b/.github/workflows/ci-tests-xcode-beta.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch
 
 env:
-  XCODE_VERSION: "16.0"
+  XCODE_VERSION: "16.0.0"
 
 jobs:
   changes:


### PR DESCRIPTION
I'm assuming this maybe has to be the full version number?

<img width="833" alt="Screenshot 2024-07-04 at 5 00 26 PM" src="https://github.com/apollographql/apollo-ios-dev/assets/146856/99350e2c-a81c-4b92-ab81-f03084fd79dc">
