### PR TITLE
Disabling flaky test

### DIFF
--- a/Tests/TestPlans/Apollo-CITestPlan.xctestplan
+++ b/Tests/TestPlans/Apollo-CITestPlan.xctestplan
@@ -14,6 +14,9 @@
   "testTargets" : [
     {
       "parallelizable" : true,
+      "skippedTests" : [
+        "URLSessionClientTests\/testCancellingTaskThroughClientDoesNotCallCompletion()"
+      ],
       "target" : {
         "containerPath" : "container:ApolloDev.xcodeproj",
         "identifier" : "471B6A9B0B0EB6244F71ECA6",

--- a/Tests/TestPlans/Apollo-UnitTestPlan.xctestplan
+++ b/Tests/TestPlans/Apollo-UnitTestPlan.xctestplan
@@ -17,8 +17,7 @@
       "skippedTests" : [
         "GraphQLFileTests",
         "MultipartFormDataTests",
-        "StoreConcurrencyTests",
-        "URLSessionClientTests\/testCancellingTaskThroughClientDoesNotCallCompletion()"
+        "StoreConcurrencyTests"
       ],
       "target" : {
         "containerPath" : "container:ApolloDev.xcodeproj",

--- a/Tests/TestPlans/Apollo-UnitTestPlan.xctestplan
+++ b/Tests/TestPlans/Apollo-UnitTestPlan.xctestplan
@@ -17,7 +17,8 @@
       "skippedTests" : [
         "GraphQLFileTests",
         "MultipartFormDataTests",
-        "StoreConcurrencyTests"
+        "StoreConcurrencyTests",
+        "URLSessionClientTests\/testCancellingTaskThroughClientDoesNotCallCompletion()"
       ],
       "target" : {
         "containerPath" : "container:ApolloDev.xcodeproj",


### PR DESCRIPTION
Disabling the `testCancellingTaskThroughClientDoesNotCallCompletion` for now because it is flaky and failing inconsistently.