### PR TITLE
chore: Create draft release for `apollo-ios-codegen` when publishing a release

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -67,4 +67,6 @@ jobs:
           - [ ] Update [CHANGELOG.md](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) with all relevant changes since the prior version. _Please include PR numbers and mention contributors for external PR submissions._
 
           #### Things to do as part of releasing
-          - [ ] Update and publish the draft release created by CI using the latest [CHANGELOG.md](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) contents
+          - [ ] Run the []'Publish Release' workflow](https://github.com/apollographql/apollo-ios-dev/actions/workflows/publish-release.yml) in apollo-ios-dev
+          - [ ] Update and publish the [draft release in apollo-ios](https://github.com/apollographql/apollo-ios/releases) created by CI using the latest [CHANGELOG.md](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) contents
+          - [ ] Update and publish the [draft release in apollo-ios-codegen](https://github.com/apollographql/apollo-ios-codegen/releases) created by CI (copy and paste the previous release contents and update the version number and link)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -62,10 +62,17 @@ jobs:
           git push --tags
 
       # Create Draft Release on GitHub with tag of version
-      - name: Create Draft Release
+      - name: Create Draft Release (`apollo-ios`)
         shell: bash
         run: |
           gh release create ${{ env.RELEASE_VERSION }} 'apollo-ios/CLI/apollo-ios-cli.tar.gz#apollo-ios-cli.tar.gz' -d --repo "apollographql/apollo-ios" -t "${{ env.RELEASE_VERSION }}"
+        env:
+          GH_TOKEN: ${{ secrets.APOLLO_IOS_PAT }}
+      
+      - name: Create Draft Release (`apollo-ios-codegen`)
+        shell: bash
+        run: |
+          gh release create ${{ env.RELEASE_VERSION }} -d --repo "apollographql/apollo-ios-codegen" -t "${{ env.RELEASE_VERSION }}"
         env:
           GH_TOKEN: ${{ secrets.APOLLO_IOS_PAT }}
 


### PR DESCRIPTION
When doing the release for 1.14.0 I noticed that there was no draft release created in the `apollo-ios-codegen` repo and I had to manually create releases for 1.13.0 and 1.14.0. This should now do that automatically for us.