### PR TITLE
docs: Fixes the tutorial server URL

### DIFF
--- a/docs/source/tutorial/tutorial-add-graphql-schema.mdx
+++ b/docs/source/tutorial/tutorial-add-graphql-schema.mdx
@@ -8,7 +8,7 @@ This tutorial uses a modified version of the GraphQL server you build as part of
 
 <img src="images/sandbox_landing.png" alt="The Sandbox query explorer" class="screenshot"/>
 
-You'll know that this Sandbox instance is pointed at our server because its URL, `https://apollo-fullstack-tutorial.herokuapp.com`, is in the box at the top left of the page. If Sandbox is properly connected, you'll see a green dot:
+You'll know that this Sandbox instance is pointed at our server because its URL, `https://apollo-fullstack-tutorial.herokuapp.com/graphql`, is in the box at the top left of the page. If Sandbox is properly connected, you'll see a green dot:
 
 <img src="images/sandbox_green_dot.png" alt="A closeup of the URL box with a dot indicating it's connected" class="screenshot"/>
 


### PR DESCRIPTION
The URL we had does not work in explorer. It is also different from the URL used in the schema download configuration JSON sample.