### PR TITLE
feature: Add function to set journal mode on sqlite databases

### DIFF
--- a/apollo-ios/Sources/ApolloSQLite/JournalMode.swift
+++ b/apollo-ios/Sources/ApolloSQLite/JournalMode.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public enum JournalMode: String {
+  /// The rollback journal is deleted at the conclusion of each transaction. This is the default behaviour.
+  case delete = "DELETE"
+  /// Commits transactions by truncating the rollback journal to zero-length instead of deleting it.
+  case truncate = "TRUNCATE"
+  /// Prevents the rollback journal from being deleted at the end of each transaction. Instead, the header
+  /// of the journal is overwritten with zeros.
+  case persist = "PERSIST"
+  /// Stores the rollback journal in volatile RAM. This saves disk I/O but at the expense of database
+  /// safety and integrity.
+  case memory = "MEMORY"
+  /// Uses a write-ahead log instead of a rollback journal to implement transactions. The WAL journaling
+  /// mode is persistent; after being set it stays in effect across multiple database connections and after
+  /// closing and reopening the database.
+  case wal = "WAL"
+  /// Disables the rollback journal completely
+  case off = "OFF"
+}

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -24,12 +24,6 @@ public protocol SQLiteDatabase {
   
   func clearDatabase(shouldVacuumOnClear: Bool) throws
 
-  func setJournalMode<T: RawRepresentable>(mode: T) throws where T.RawValue == String
-
-}
-
-public extension SQLiteDatabase {
-  func setJournalMode<T>(mode: T) throws where T : RawRepresentable, T.RawValue == String { }
 }
 
 public extension SQLiteDatabase {

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -9,7 +9,7 @@ public struct DatabaseRow {
 }
 
 public protocol SQLiteDatabase {
-  
+
   init(fileURL: URL) throws
   
   func createRecordsTableIfNeeded() throws
@@ -23,7 +23,13 @@ public protocol SQLiteDatabase {
   func deleteRecords(matching pattern: CacheKey) throws
   
   func clearDatabase(shouldVacuumOnClear: Bool) throws
-  
+
+  func setJournalMode<T: RawRepresentable>(mode: T) throws where T.RawValue == String
+
+}
+
+public extension SQLiteDatabase {
+  func setJournalMode<T>(mode: T) throws where T : RawRepresentable, T.RawValue == String { }
 }
 
 public extension SQLiteDatabase {

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
@@ -11,25 +11,6 @@ public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
   private let keyColumn: SQLite.Expression<CacheKey>
   private let recordColumn: SQLite.Expression<String>
 
-  public enum JournalMode: String {
-    /// The rollback journal is deleted at the conclusion of each transaction. This is the default behaviour.
-    case delete = "DELETE"
-    /// Commits transactions by truncating the rollback journal to zero-length instead of deleting it.
-    case truncate = "TRUNCATE"
-    /// Prevents the rollback journal from being deleted at the end of each transaction. Instead, the header
-    /// of the journal is overwritten with zeros.
-    case persist = "PERSIST"
-    /// Stores the rollback journal in volatile RAM. This saves disk I/O but at the expense of database
-    /// safety and integrity.
-    case memory = "MEMORY"
-    /// Uses a write-ahead log instead of a rollback journal to implement transactions. The WAL journaling
-    /// mode is persistent; after being set it stays in effect across multiple database connections and after 
-    /// closing and reopening the database.
-    case wal = "WAL"
-    /// Disables the rollback journal completely
-    case off = "OFF"
-  }
-
   public init(fileURL: URL) throws {
     self.records = Table(Self.tableName)
     self.keyColumn = Expression<CacheKey>(Self.keyColumnName)
@@ -88,8 +69,8 @@ public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
 
   /// Sets the journal mode for the current database.
   ///
-  /// - Parameter mode: Use ``JournalMode``.
-  public func setJournalMode<T>(mode: T) throws where T : RawRepresentable, T.RawValue == String {
+  /// - Parameter mode: The journal mode controls how the journal file is stored and processed.
+  public func setJournalMode(mode: JournalMode) throws {
     try self.db.run("PRAGMA journal_mode = \(mode.rawValue)")
   }
 }


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-ios/issues/3399.

There are many other [`PRAGMA` commands that sqlite supports](https://www.sqlite.org/pragma.html) so there were a few ways this could have been implemented:
1. Make the `execute` or `run` functions public on `SQLiteDatabase` but this is potentially the most destructive as it's a wide open door to executing anything against the connected database.
2. Create a new `setPragma` function that would execute the `PRAGMA <statement>` command. This narrows the scope to only `PRAGMA` statements but this is also potentially destructive as I am not familiar with all the pragma statements and their effects.
3. Create a new `setJournalMode` function that only allows the journal mode to be set. This is very narrow in scope but the safest since it solves the requested feature and it's a single statement to grok.

I chose option 3, so this PR adds a protocol function to allow sqlite database implementations to set the journal mode of the connected database. `JournalMode` pragma values were taken from https://www.sqlite.org/pragma.html#pragma_journal_mode.