### PR TITLE
Fix newline at end of generated operation

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/DeferredFragmentsMetadataTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/DeferredFragmentsMetadataTemplateTests.swift
@@ -49,8 +49,8 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     )
   }
   
-  private func renderSubject() -> String {
-    subject.render().description
+  private func renderSubject() -> String? {
+    subject.render()?.description
   }
   
   // MARK: - Deferred Inline Fragments

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -1076,6 +1076,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(
       """
       }
+
       """,
       atLine: 73,
       ignoringExtraLines: false
@@ -1120,6 +1121,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(
       """
       }
+      
       """,
       atLine: 37,
       ignoringExtraLines: false

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/DeferredFragmentsMetadataTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/DeferredFragmentsMetadataTemplate.swift
@@ -23,11 +23,11 @@ struct DeferredFragmentsMetadataTemplate {
   /// Renders metadata definitions for the deferred fragments of an Operation.
   ///
   /// - Returns: The `TemplateString` for the deferred fragments metadata definitions.
-  func render() -> TemplateString {
+  func render() -> TemplateString? {
     let deferredFragmentPathTypeInfo = DeferredFragmentsPathTypeInfo(
       from: operation.rootField.selectionSet.selections
     )
-    guard !deferredFragmentPathTypeInfo.isEmpty else { return "" }
+    guard !deferredFragmentPathTypeInfo.isEmpty else { return nil }
 
     return """
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -42,11 +42,12 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
         ).renderBody())
       }
     }
-    \(section: DeferredFragmentsMetadataTemplate(
+    \(DeferredFragmentsMetadataTemplate(
       operation: operation,
       config: config,
       renderAccessControl: { accessControlModifier(for: .parent) }()
     ).render())
+
     """)
   }
     


### PR DESCRIPTION
The use of the `\(section:)` interpolation method for `DeferredFragmentsMetadataTemplate` was causing the new line at the end of the generated operation files to be deleted. This corrects that.