### PR TITLE
fix: `legacyResponse` property

### DIFF
--- a/apollo-ios/Sources/Apollo/HTTPResponse.swift
+++ b/apollo-ios/Sources/Apollo/HTTPResponse.swift
@@ -22,8 +22,8 @@ public class HTTPResponse<Operation: GraphQLOperation> {
   public var legacyResponse: GraphQLResponse<Operation.Data>? = nil
   
   /// A set of cache records from the response
-  var cacheRecords: RecordSet?
-  
+  public var cacheRecords: RecordSet?
+
   /// Designated initializer
   ///
   /// - Parameters:

--- a/apollo-ios/Sources/Apollo/HTTPResponse.swift
+++ b/apollo-ios/Sources/Apollo/HTTPResponse.swift
@@ -19,8 +19,9 @@ public class HTTPResponse<Operation: GraphQLOperation> {
   /// [optional] The data as parsed into a `GraphQLResponse` for legacy caching purposes. If you're not using the 
   /// `JSONResponseParsingInterceptor`, you probably shouldn't be using this property.
   @available(*, deprecated, message: "Do not use. This property will be removed in a future version.")
-  public var legacyResponse: GraphQLResponse<Operation.Data>? = nil
-  
+  public var legacyResponse: GraphQLResponse<Operation.Data>? { _legacyResponse }
+  var _legacyResponse: GraphQLResponse<Operation.Data>? = nil
+
   /// A set of cache records from the response
   public var cacheRecords: RecordSet?
 
@@ -49,6 +50,7 @@ extension HTTPResponse: Equatable where Operation.Data: Equatable {
     lhs.httpResponse == rhs.httpResponse &&
     lhs.rawData == rhs.rawData &&
     lhs.parsedResponse == rhs.parsedResponse &&
+    lhs._legacyResponse == rhs._legacyResponse &&
     lhs.cacheRecords == rhs.cacheRecords
   }
 }
@@ -60,6 +62,7 @@ extension HTTPResponse: Hashable where Operation.Data: Hashable {
     hasher.combine(httpResponse)
     hasher.combine(rawData)
     hasher.combine(parsedResponse)
+    hasher.combine(_legacyResponse)
     hasher.combine(cacheRecords)
   }
 }

--- a/apollo-ios/Sources/Apollo/IncrementalJSONResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/IncrementalJSONResponseParsingInterceptor.swift
@@ -101,14 +101,15 @@ public struct IncrementalJSONResponseParsingInterceptor: ApolloInterceptor {
           }
         }
 
+        createdResponse._legacyResponse = nil
+
         parsedResult = currentResult
         parsedCacheRecords = currentCacheRecords
 
       } else {
-        let graphQLResponse = GraphQLResponse(
-          operation: request.operation,
-          body: body
-        )
+        let graphQLResponse = GraphQLResponse(operation: request.operation, body: body)
+        createdResponse._legacyResponse = graphQLResponse
+
         let (result, cacheRecords) = try graphQLResponse.parseResult(withCachePolicy: request.cachePolicy)
 
         parsedResult = result

--- a/apollo-ios/Sources/Apollo/JSONResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/JSONResponseParsingInterceptor.swift
@@ -57,8 +57,9 @@ public struct JSONResponseParsingInterceptor: ApolloInterceptor {
       }
 
       let graphQLResponse = GraphQLResponse(operation: request.operation, body: body)
+      createdResponse._legacyResponse = graphQLResponse
+
       let (result, cacheRecords) = try graphQLResponse.parseResult(withCachePolicy: request.cachePolicy)
-      
       createdResponse.parsedResponse = result
       createdResponse.cacheRecords = cacheRecords
       


### PR DESCRIPTION
When the `legacyResponse` property of `HTTPResponse` was deprecated setting the value was also removed; this was incorrect as it created a hidden breaking change for interceptors that might have been using the value.

The value cannot simply be set though, as it was before, because of Swift's inability to disable the deprecation warning. Instead there is now an internal property that stores the legacy response value and `legacyResponse` becomes a computed property that simply forwards the new internal property value.

The `cacheRecords` property that was added to eliminate the need to re-parse the legacy response has also been made public for interceptors that need cache records and do not want to have to parse the response a second time.