### PR TITLE
Fix a leak related to use of function used in a closure

### DIFF
--- a/apollo-ios/Sources/Apollo/ApolloStore.swift
+++ b/apollo-ios/Sources/Apollo/ApolloStore.swift
@@ -202,8 +202,12 @@ public class ApolloStore {
 
   public class ReadTransaction {
     fileprivate let cache: any NormalizedCache
+      
+    fileprivate lazy var loader: DataLoader<CacheKey, Record> = DataLoader { [weak self] batchLoad in
+          guard let self else { return [:] }
+          return try cache.loadRecords(forKeys: batchLoad)
+    }
 
-    fileprivate lazy var loader: DataLoader<CacheKey, Record> = DataLoader(self.cache.loadRecords)
     fileprivate lazy var executor = GraphQLExecutor(
       executionSource: CacheDataExecutionSource(transaction: self)
     ) 


### PR DESCRIPTION
There is a leak in fileprivate lazy var loader: DataLoader<CacheKey, Record> because the method implicitly uses self. Making the capture explicit and breaking the retain cycle here. This was also covered in WWDC 2024 analyze heap memory talk https://developer.apple.com/wwdc24/10173?time=1748

Leak detected via instruments
<img width="1330" alt="Screenshot 2024-08-07 at 11 41 24 PM" src="https://github.com/user-attachments/assets/e3719417-b8ae-4fe2-ac2e-e399cc89605b">
