### PR TITLE
ci: Continue on error if unit test fails

### DIFF
--- a/.github/workflows/ci-tests-xcode-beta.yml
+++ b/.github/workflows/ci-tests-xcode-beta.yml
@@ -150,6 +150,7 @@ jobs:
     - name: Build and Test
       if: ${{ matrix.should-run == true || matrix.should-run == 'true' }}
       id: build-and-test
+      continue-on-error: true
       uses: ./.github/actions/build-and-run-unit-tests
       with:
         destination: ${{ matrix.destination }}
@@ -157,6 +158,7 @@ jobs:
         test-plan: ${{ matrix.test-plan }}
     - name: Run-JS-Tests
       if: ${{ matrix.run-js-tests == true }}
+      continue-on-error: true
       shell: bash
       working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/
       run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -150,6 +150,7 @@ jobs:
     - name: Build and Test
       if: ${{ matrix.should-run == true || matrix.should-run == 'true' }}
       id: build-and-test
+      continue-on-error: true
       uses: ./.github/actions/build-and-run-unit-tests
       with:
         destination: ${{ matrix.destination }}
@@ -157,6 +158,7 @@ jobs:
         test-plan: ${{ matrix.test-plan }}
     - name: Run-JS-Tests
       if: ${{ matrix.run-js-tests == true }}
+      continue-on-error: true
       shell: bash
       working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/
       run: |
@@ -305,6 +307,7 @@ jobs:
         key: ${{ github.run_id }}-dependencies
         fail-on-cache-miss: true
     - name: Build and Test
+      continue-on-error: true
       uses: ./.github/actions/build-and-run-unit-tests
       with:
         destination: platform=macOS,arch=x86_64


### PR DESCRIPTION
I've noticed that if the `build-and-test` step fails there is no collection of the build logs which makes it impossible to diagnose a test failure. This change is to indicate that the job should still continue even if one of the unit test (Swift or JS) steps fails.