### PR TITLE
fix: `ObjectData` type check

### DIFF
--- a/Tests/ApolloTests/CacheKeyResolutionTests.swift
+++ b/Tests/ApolloTests/CacheKeyResolutionTests.swift
@@ -84,6 +84,91 @@ class CacheKeyResolutionTests: XCTestCase {
     ))
   }
 
+  func test__schemaConfiguration__givenData_asInt_equalToBoolFalse_shouldNotConvertToBool() {
+    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+      return try? CacheKeyInfo(jsonValue: json["id"])
+    }
+
+    let object: JSONObject = [
+      "__typename": "Omega",
+      "id": 0
+    ]
+
+    let objectDict = NetworkResponseExecutionSource().opaqueObjectDataWrapper(for: object)
+    let actual = MockSchemaMetadata.cacheKey(for: objectDict)
+
+    expect(actual).to(equal("Omega:0"))
+  }
+
+  func test__schemaConfiguration__givenData_asInt_equalToBoolTrue_shouldNotConvertToBool() {
+    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+      return try? CacheKeyInfo(jsonValue: json["id"])
+    }
+
+    let object: JSONObject = [
+      "__typename": "Omega",
+      "id": 1
+    ]
+
+    let objectDict = NetworkResponseExecutionSource().opaqueObjectDataWrapper(for: object)
+    let actual = MockSchemaMetadata.cacheKey(for: objectDict)
+
+    expect(actual).to(equal("Omega:1"))
+  }
+
+  func test__schemaConfiguration__givenData_asInt_outsideBoolRange_shouldReturnCacheReference() {
+    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+      return try? CacheKeyInfo(jsonValue: json["id"])
+    }
+
+    let object: JSONObject = [
+      "__typename": "Omega",
+      "id": 2
+    ]
+
+    let objectDict = NetworkResponseExecutionSource().opaqueObjectDataWrapper(for: object)
+    let actual = MockSchemaMetadata.cacheKey(for: objectDict)
+
+    expect(actual).to(equal("Omega:2"))
+  }
+
+  func test__schemaConfiguration__givenData_asBool_true_shouldNotConvertToInt() {
+    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+      return try? CacheKeyInfo(jsonValue: json["id"])
+    }
+
+    let object: JSONObject = [
+      "__typename": "Omega",
+      "id": true
+    ]
+
+    let objectDict = NetworkResponseExecutionSource().opaqueObjectDataWrapper(for: object)
+    let actual = MockSchemaMetadata.cacheKey(for: objectDict)
+
+    expect(actual).to(beNil())
+  }
+
+  func test__schemaConfiguration__givenData_asBool_false_shouldNotConvertToInt() {
+    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+      return try? CacheKeyInfo(jsonValue: json["id"])
+    }
+
+    let object: JSONObject = [
+      "__typename": "Omega",
+      "id": false
+    ]
+
+    let objectDict = NetworkResponseExecutionSource().opaqueObjectDataWrapper(for: object)
+    let actual = MockSchemaMetadata.cacheKey(for: objectDict)
+
+    expect(actual).to(beNil())
+  }
+
   func test__multipleSchemaConfigurations_withDifferentCacheKeyProvidersDefinedInExtensions_shouldReturnDifferentCacheKeys() {
     let object: JSONObject = [
       "__typename": "MockSchemaObject",

--- a/apollo-ios/Sources/ApolloAPI/ObjectData.swift
+++ b/apollo-ios/Sources/ApolloAPI/ObjectData.swift
@@ -11,6 +11,9 @@ public struct ObjectData {
   public let _transformer: any _ObjectData_Transformer
   public let _rawData: [String: AnyHashable]
 
+  private static let boolTrue = AnyHashable(true)
+  private static let boolFalse = AnyHashable(false)
+
   public init(
     _transformer: any _ObjectData_Transformer,
     _rawData: [String: AnyHashable]
@@ -22,18 +25,18 @@ public struct ObjectData {
   @inlinable public subscript(_ key: String) -> (any ScalarType)? {
     guard let rawValue = _rawData[key] else { return nil }
     var value: AnyHashable = rawValue
-    
-    // Attempting cast to `Int` to ensure we always use `Int` vs `Int32` or `Int64` for consistency and ScalarType casting,
-    // also need to attempt `Bool` cast first to ensure a bool doesn't get inadvertently converted to `Int`
-    switch value {
-    case let boolVal as Bool:
+
+    // This check is based on AnyHashable using a canonical representation of the type-erased value so
+    // instances wrapping the same value of any type compare as equal. Therefore while Int(1) and Int(0)
+    // might be representable as Bool they will never equal Bool(true) nor Bool(false).
+    if let boolVal = value as? Bool, (value == AnyHashable(true) || value == AnyHashable(false)) {
       value = boolVal
-    case let intVal as Int:
-      value = intVal
-    default:
-      break
+
+    // Cast to `Int` to ensure we always use `Int` vs `Int32` or `Int64` for consistency and ScalarType casting
+    } else if let intValue = value as? Int {
+      value = intValue
     }
-    
+
     return _transformer.transform(value)
   }
 

--- a/apollo-ios/Sources/ApolloAPI/ObjectData.swift
+++ b/apollo-ios/Sources/ApolloAPI/ObjectData.swift
@@ -11,6 +11,9 @@ public struct ObjectData {
   public let _transformer: any _ObjectData_Transformer
   public let _rawData: [String: AnyHashable]
 
+  public static let _boolTrue = AnyHashable(true)
+  public static let _boolFalse = AnyHashable(false)
+
   public init(
     _transformer: any _ObjectData_Transformer,
     _rawData: [String: AnyHashable]
@@ -26,7 +29,7 @@ public struct ObjectData {
     // This check is based on AnyHashable using a canonical representation of the type-erased value so
     // instances wrapping the same value of any type compare as equal. Therefore while Int(1) and Int(0)
     // might be representable as Bool they will never equal Bool(true) nor Bool(false).
-    if let boolVal = value as? Bool, (value == AnyHashable(true) || value == AnyHashable(false)) {
+    if let boolVal = value as? Bool, (value == Self._boolTrue || value == Self._boolFalse) {
       value = boolVal
 
     // Cast to `Int` to ensure we always use `Int` vs `Int32` or `Int64` for consistency and ScalarType casting

--- a/apollo-ios/Sources/ApolloAPI/ObjectData.swift
+++ b/apollo-ios/Sources/ApolloAPI/ObjectData.swift
@@ -11,9 +11,6 @@ public struct ObjectData {
   public let _transformer: any _ObjectData_Transformer
   public let _rawData: [String: AnyHashable]
 
-  private static let boolTrue = AnyHashable(true)
-  private static let boolFalse = AnyHashable(false)
-
   public init(
     _transformer: any _ObjectData_Transformer,
     _rawData: [String: AnyHashable]

--- a/apollo-ios/Sources/ApolloAPI/ObjectData.swift
+++ b/apollo-ios/Sources/ApolloAPI/ObjectData.swift
@@ -11,8 +11,8 @@ public struct ObjectData {
   public let _transformer: any _ObjectData_Transformer
   public let _rawData: [String: AnyHashable]
 
-  public static let _boolTrue = AnyHashable(true)
-  public static let _boolFalse = AnyHashable(false)
+  @usableFromInline internal static let _boolTrue = AnyHashable(true)
+  @usableFromInline internal static let _boolFalse = AnyHashable(false)
 
   public init(
     _transformer: any _ObjectData_Transformer,


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3414

Checking whether `AnyHashable` can be cast to a `Bool` is not enough to infer behaviour from the original type. The only way to do that is to compare against the two possible `Bool` values; `true` and `false`. This is possible because of the way `AnyHashable` does equality comparison.