### PR TITLE
ci: Update Xcode 16 beta version

### DIFF
--- a/.github/workflows/ci-tests-xcode-beta.yml
+++ b/.github/workflows/ci-tests-xcode-beta.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  XCODE_VERSION: "16.0-beta"
+  XCODE_VERSION: "16.1-beta"
 
 jobs:
   changes:


### PR DESCRIPTION
It looks like GitHub has dropped the 16.0 betas for the 16.1 betas. This is affecting two PRs currently:
1. https://github.com/apollographql/apollo-ios-dev/actions/runs/10476740121/job/29016318937?pr=465#step:2:20
2. https://github.com/apollographql/apollo-ios-dev/actions/runs/10438379023/job/28962529979?pr=463#step:2:20

This changeset simply targets the 16.1 beta version instead.