### PR TITLE
Bring back deprecated CodingKey for localCacheMutation in selectionSetInitializers

### DIFF
--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -602,6 +602,24 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     expect(decoded).to(equal(expected))
   }
 
+  func test__decode_selectionSetInitializers__givenLocalCacheMutations_shouldReturnIgnoreOption() throws {
+    // given
+    let subject = """
+    {
+      "localCacheMutations": true
+    }
+    """.asData
+
+    // when
+    let decoded = try JSONDecoder().decode(
+      ApolloCodegenConfiguration.SelectionSetInitializers.self,
+      from: subject
+    )
+
+    // then
+    expect(decoded).to(equal([]))
+  }
+
   // MARK: - OperationDocumentFormat Tests
 
   func encodedValue(_ case: ApolloCodegenConfiguration.OperationDocumentFormat) -> String {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -1263,6 +1263,10 @@ extension ApolloCodegenConfiguration.SelectionSetInitializers {
     case operations
     case namedFragments
     case definitionsNamed
+
+    /// Deprecated
+    /// Local Cache Mutations will now always have initializers generated.
+    case localCacheMutations
   }
 
   public init(from decoder: any Decoder) throws {


### PR DESCRIPTION
This fixes a decoding error when the deprecated option `localCacheMutations` is present in the JSON config. We should ignore the key when decoding, but not throw an error if it's present.

This issue was surfaced from [this comment on an unrelated issue](https://github.com/apollographql/apollo-ios/issues/3428#issuecomment-2305590461).