### PR TITLE
fix: Disfavour deprecated `watch` function

### DIFF
--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -187,6 +187,7 @@ extension ApolloClient: ApolloClientProtocol {
 
 extension ApolloClient {
 
+  @_disfavoredOverload
   @available(*, deprecated,
               renamed: "watch(query:cachePolicy:refetchOnFailedUpdates:context:callbackQueue:resultHandler:)")
   public func watch<Query: GraphQLQuery>(


### PR DESCRIPTION
When the `watch(query:cachePolicy:context:callbackQueue:resultHandler:)` function was deprecated the new function introduced a single new parameter with a default which meant that using the minimally required parameters to call the function (`watch(query:resultHandler:)`) matches both signatures. This generates a perpetual deprecation warning with no way to get rid of it other than to use the new `refetchOnFailedUpdates` parameter in the function call.

Marking the deprecated function with `@_disfavoredOverload` allows the minimally required function call to be used again without the deprecation warning. I'm really surprised that nobody has complained about this before.