### PR TITLE
enhancement: Set URLRequest cache policy on GET requests

### DIFF
--- a/apollo-ios/Sources/Apollo/JSONRequest.swift
+++ b/apollo-ios/Sources/Apollo/JSONRequest.swift
@@ -98,7 +98,8 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
       if let urlForGet = transformer.createGetURL() {
         request.url = urlForGet
         request.httpMethod = GraphQLHTTPMethod.GET.rawValue
-        
+        request.cachePolicy = requestCachePolicy
+
         // GET requests shouldn't have a content-type since they do not provide actual content.
         request.allHTTPHeaderFields?.removeValue(forKey: "Content-Type")
       } else {
@@ -148,6 +149,22 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
     )
     
     return body
+  }
+
+  /// Convert the Apollo iOS cache policy into a matching cache policy for URLRequest.
+  private var requestCachePolicy: URLRequest.CachePolicy {
+    switch cachePolicy {
+    case .returnCacheDataElseFetch:
+      return .returnCacheDataElseLoad
+    case .fetchIgnoringCacheData:
+      return .reloadIgnoringLocalCacheData
+    case .fetchIgnoringCacheCompletely:
+      return .reloadIgnoringLocalAndRemoteCacheData
+    case .returnCacheDataDontFetch:
+      return .returnCacheDataDontLoad
+    case .returnCacheDataAndFetch:
+      return .reloadRevalidatingCacheData
+    }
   }
 
   // MARK: - Equtable/Hashable Conformance


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-ios/issues/3432.

There is currently no way for a user to opt-out of the URLRequest default caching behaviour. This PR simply sets a comparable cache policy on `URLRequest` for `GET` requests.

* `returnCacheDataElseFetch` == `returnCacheDataElseLoad`: Direct comparison
* `fetchIgnoringCacheData` == `reloadIgnoringLocalCacheData`: The Apollo iOS version of this cache policy means that only the request will ignore cached data but the response will still be cached. It seems correct to ignore any iOS cached responses but still use any remote (CDN) cached responses.
* `fetchIgnoringCacheCompletely` == `reloadIgnoringLocalAndRemoteCacheData`: The Apollo iOS version of this cache policy will ignore cached data for the request but it will also not cache any response data. The equivalent `URLRequest` policy here is to ignore all local (iOS) and remote (CDN) cached data and always go to the server for a response.
* `returnCacheDataDontFetch` == `returnCacheDataDontLoad`: Direct comparison
* `returnCacheDataAndFetch` == `reloadRevalidatingCacheData`: The Apollo iOS request chain will handle the return-cache-data portion of this policy but we extend that to any iOS cached responses, for and-fetch,  by making iOS ensure any cached responses are still valid, otherwise fetch from the server.