### PR TITLE
docs: Selection Set Initializers

### DIFF
--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -301,7 +301,7 @@ let configuration = ApolloCodegenConfiguration(
 
 Operation files are generated from all the GraphQL operation definitions matched by your configuration's [`operationSearchPaths`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/fileinput/operationsearchpaths). Each operation (query, mutation, or subscription) and fragment definition will be created in a separate file.
 
-> To learn more about GraphQL operations, check out [Defining operations](../fetching/fetching-data#defining-operations)
+> To learn more about GraphQL operations, check out [Defining operations](../fetching/fetching-data#defining-operations).
 
 The `output.operations` property value determines the location of the generated operation files:
 
@@ -529,6 +529,8 @@ Manually initialized selection sets can be used for a number of purposes, includ
 
 You can configure initializers to be generated for all operations, all named fragments, or only select operations or named fragments instead. Initializers are always generated for local cache mutations. [SelectionSetInitializers](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/selectionsetinitializers) functions like an `OptionSet`, allowing you to combine multiple different instances together to indicate all the types you would like to generate initializers for.
 
+> To learn more about how to use Selection Set Initializers, check out [Using Selection Set Initializers](../development/selection-set-initializers).
+
 <MultiCodeBlock>
 
 ```json title="CLI Configuration JSON"
@@ -537,7 +539,7 @@ You can configure initializers to be generated for all operations, all named fra
     "operations": false
     "namedFragments" : false,
     "definitionsNamed": [
-      "MyOperation,
+      "MyOperation",
       "MyFragment"
     ]
   },
@@ -555,6 +557,8 @@ let configuration = ApolloCodegenConfiguration(
   )
 )
 ```
+
+</MultiCodeBlock>
 
 ### Schema Customization
 

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -426,13 +426,8 @@ The top-level properties are:
   "deprecatedEnumCases": "include",
   "schemaDocumentation": "include",
   "selectionSetInitializers" : {
-    "operations": false,
-    "namedFragments": false,
-    "localCacheMutations" : true,
-    "definitionsNamed": [
-      "MyOperation",
-      "MyFragment"
-    ]
+    "operations": true,
+    "namedFragments": true
   },
   "operationDocumentFormat" : ["definition", "operationId"],
   "cocoapodsCompatibleImportStatements": false,
@@ -481,9 +476,8 @@ let configuration = ApolloCodegenConfiguration(
     deprecatedEnumCases: .include,
     schemaDocumentation: .include,
     selectionSetInitializers: [
-      .localCacheMutations,
-      .operation(named: "MyOperation"),
-      .fragment(named: "MyFragment")
+      .operations,
+      .namedFragments
     ],
     operationDocumentFormat: [.document, .operationId],
     cocoapodsCompatibleImportStatements: false,
@@ -519,6 +513,40 @@ let configuration = ApolloCodegenConfiguration(
 ```
 
 </MultiCodeBlock>
+
+### Selection Set Initializers
+
+You can get initializers for your generated selection sets by using the [selectionSetInitializers](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/selectionsetinitializers) option.
+
+Manually initialized selection sets can be used for a number of purposes, including:
+* Adding custom data to the normalized cache
+* Setting up fixture data for SwiftUI previews or loading states
+* An alternative to [Test Mocks](#test-mocks) for unit testing
+
+You can configure initializers to be generated for all operations, all named fragments, or only select operations or named fragments instead. Initializers are always generated for local cache mutations. [SelectionSetInitializers](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/selectionsetinitializers) functions like an `OptionSet`, allowing you to combine multiple different instances together to indicate all the types you would like to generate initializers for.
+
+<MultiCodeBlock>
+
+```json title="CLI Configuration JSON"
+"options": {
+  "selectionSetInitializers" : {
+    "operations": true,
+    "namedFragments" : true
+  },
+}
+```
+
+```swift title="Swift Codegen Setup"
+let configuration = ApolloCodegenConfiguration(
+  // Other properties not shown
+  options: ApolloCodegenConfiguration.OutputOptions(
+    selectionSetInitializers: [
+      .operations,
+      .namedFragments
+    ]
+  )
+)
+```
 
 ### Schema Customization
 
@@ -880,7 +908,8 @@ Below is an example that illustrates an `apollo-codegen-config.json` where every
     "pruneGeneratedFiles" : false,
     "schemaDocumentation" : "exclude",
     "selectionSetInitializers" : {
-      "localCacheMutations" : true
+      "operations": true,
+      "namedFragments" : true
     },
     "warningsOnDeprecatedUsage" : "exclude",
     "operationDocumentFormat" : ["definition", "operationId"],

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -426,8 +426,12 @@ The top-level properties are:
   "deprecatedEnumCases": "include",
   "schemaDocumentation": "include",
   "selectionSetInitializers" : {
-    "operations": true,
-    "namedFragments": true
+    "operations": false,
+    "namedFragments": false,
+    "definitionsNamed": [
+      "MyOperation",
+      "MyFragment"
+    ]
   },
   "operationDocumentFormat" : ["definition", "operationId"],
   "cocoapodsCompatibleImportStatements": false,
@@ -476,8 +480,8 @@ let configuration = ApolloCodegenConfiguration(
     deprecatedEnumCases: .include,
     schemaDocumentation: .include,
     selectionSetInitializers: [
-      .operations,
-      .namedFragments
+      .operation(named: "MyOperation"),
+      .fragment(named: "MyFragment")
     ],
     operationDocumentFormat: [.document, .operationId],
     cocoapodsCompatibleImportStatements: false,
@@ -530,8 +534,12 @@ You can configure initializers to be generated for all operations, all named fra
 ```json title="CLI Configuration JSON"
 "options": {
   "selectionSetInitializers" : {
-    "operations": true,
-    "namedFragments" : true
+    "operations": false
+    "namedFragments" : false,
+    "definitionsNamed": [
+      "MyOperation,
+      "MyFragment"
+    ]
   },
 }
 ```
@@ -541,8 +549,8 @@ let configuration = ApolloCodegenConfiguration(
   // Other properties not shown
   options: ApolloCodegenConfiguration.OutputOptions(
     selectionSetInitializers: [
-      .operations,
-      .namedFragments
+      .operation(named: "MyOperation"),
+      .fragment(named: "MyFragment")
     ]
   )
 )
@@ -908,8 +916,12 @@ Below is an example that illustrates an `apollo-codegen-config.json` where every
     "pruneGeneratedFiles" : false,
     "schemaDocumentation" : "exclude",
     "selectionSetInitializers" : {
-      "operations": true,
-      "namedFragments" : true
+      "operations": false,
+      "namedFragments" : false,
+      "definitionsNamed": [
+        "MyOperation",
+        "MyFragment"
+      ]
     },
     "warningsOnDeprecatedUsage" : "exclude",
     "operationDocumentFormat" : ["definition", "operationId"],

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -124,7 +124,7 @@
     ],
     "Development & Testing": [
       {
-        "Selection Set Initializers": "/development/selection-set-initializers.mdx",
+        "Selection Set Initializers": "/development/selection-set-initializers",
         "Test Mocks": "/testing/test-mocks",
         "Including Apollo as an XCFramework": "/development/using-xcframework"
       },

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -124,6 +124,7 @@
     ],
     "Development & Testing": [
       {
+        "Selection Set Initializers": "/development/selection-set-initializers.mdx",
         "Test Mocks": "/testing/test-mocks",
         "Including Apollo as an XCFramework": "/development/using-xcframework"
       },

--- a/docs/source/development/selection-set-initializers.mdx
+++ b/docs/source/development/selection-set-initializers.mdx
@@ -1,0 +1,143 @@
+---
+title: Using Selection Set Initializers
+---
+
+Being able to create instances of your generated operation models can be useful in a number of different ways: adding custom data to the normalized cache; setting up fixture data for SwiftUI previews or loading states; and as an alternative to [Test Mocks](../testing/test-mocks.mdx). Apollo iOS provides Selection Set Initializers to facilitate this.
+
+When code generation is configured to generate selection set initializers each Swift struct will have an initializer that accepts values for the selected fields (properties) defined in the struct, as well as some inherited fields.
+
+> To learn more about how to configure Selection Set Initializers, check out [Codegen Configuration](../code-generation/codegen-configuration#selection-set-initializers).
+
+## Usage
+
+Generated operation models are immutable and selection set initializers provide a type-safe way to create instances of your operation models.
+
+For example, given the following generated operation model (details are omitted to focus on the relevant parts of the struct):
+
+```swift
+public class HerosQuery: GraphQLQuery {
+  public struct Data: GraphAPI.SelectionSet {
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("hero", Hero.self),
+    ] }
+
+    public var hero: Hero { __data["hero"] }
+
+    public init(
+      hero: Hero
+    ) { ... }
+
+    /// Hero
+    ///
+    /// Parent Type: `Character`
+    public struct Hero: GraphAPI.SelectionSet {
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("id", String.self),
+        .field("name", String.self),
+        .field("friends", [Friend]?.self),
+        .inlineFragment(AsHuman.self),
+        .inlineFragment(AsDroid.self),
+      ] }
+
+      public var id: String { __data["id"] }
+      public var name: String { __data["name"] }
+      public var friends: [Friend]? { __data["friends"] }
+
+      public var asDroid: AsDroid? { _asInlineFragment() }
+
+      public init(
+        __typename: String,
+        id: String,
+        name: String,
+        friends: [Friend]? = nil
+      ) { ... }
+
+      /// Hero.Friend
+      ///
+      /// Parent Type: `Character`
+      public struct Friend: GraphAPI.SelectionSet {
+        public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("name", String.self),
+        ] }
+
+        public var id: String { __data["id"] }
+        public var name: String { __data["name"] }
+
+        public init(
+          __typename: String,
+          id: String,
+          name: String
+        ) { ... }
+      }
+
+      /// Hero.AsDroid
+      ///
+      /// Parent Type: `Droid`
+      public struct AsDroid: GraphAPI.InlineFragment {
+        public static var __selections: [ApolloAPI.Selection] { [
+          .field("primaryFunction", String?.self),
+        ] }
+
+        public var primaryFunction: String? { __data["primaryFunction"] }
+        public var id: String { __data["id"] }
+        public var name: String { __data["name"] }
+        public var friends: [Friend]? { __data["friends"] }
+
+        public init(
+          primaryFunction: String? = nil,
+          id: String,
+          name: String,
+          friends: [Friend]? = nil
+        ) { ... }
+      }
+    }
+  }
+}
+```
+
+To create an instance of the `HerosQuery` class you would do the following:
+
+```swift
+let modelData = HerosQuery.Data.init(
+  hero: HerosQuery.Data.Hero(
+    __typename: "Human",
+    id: "luke-skywalker",
+    name: "Luke Skywalker",
+    friends: [
+      HerosQuery.Data.Hero.Friend(
+        __typename: "Wookie",
+        id: "chewbacca",
+        name: "Chewbacca"
+      )
+    ]
+  )
+)
+```
+
+### Type conditions
+
+If you use a [type condition](https://www.apollographql.com/docs/ios/fetching/type-conditions) in your operation you will notice that a struct is generated to match the type (`AsDroid` in the example above) but the generated initializer does not accept a value of that type.
+
+In this case you must create an object of the required type and then use the `asRootEntityType` property to initialize the selection set:
+
+```swift
+let droid = HerosQuery.Data.Hero.AsDroid(
+  primaryFunction: "Etiquette and translation",
+  id: "c-3po",
+  name: "C-3PO",
+  friends: [
+    HerosQuery.Data.Hero.Friend(
+      __typename: "Droid",
+      id: "r2-d2",
+      name: "R2-D2"
+    )
+  ]
+)
+
+let modelData = HerosQuery.Data.init(
+  hero: droid.asRootEntityType
+)
+```

--- a/docs/source/development/selection-set-initializers.mdx
+++ b/docs/source/development/selection-set-initializers.mdx
@@ -2,7 +2,7 @@
 title: Using Selection Set Initializers
 ---
 
-Being able to create instances of your generated operation models can be useful in a number of different ways: adding custom data to the normalized cache; setting up fixture data for SwiftUI previews or loading states; and as an alternative to [Test Mocks](../testing/test-mocks.mdx). Apollo iOS provides Selection Set Initializers to facilitate this.
+Being able to create instances of your generated operation models can be useful in a number of different ways: adding custom data to the normalized cache; setting up fixture data for SwiftUI previews or loading states; and as an alternative to [Test Mocks](../testing/test-mocks). Apollo iOS provides Selection Set Initializers to facilitate this.
 
 When code generation is configured to generate selection set initializers each Swift struct will have an initializer that accepts values for the selected fields (properties) defined in the struct, as well as some inherited fields.
 
@@ -17,9 +17,7 @@ For example, given the following generated operation model (details are omitted 
 ```swift
 public class HerosQuery: GraphQLQuery {
   public struct Data: GraphAPI.SelectionSet {
-    public static var __selections: [ApolloAPI.Selection] { [
-      .field("hero", Hero.self),
-    ] }
+    ...
 
     public var hero: Hero { __data["hero"] }
 
@@ -31,14 +29,7 @@ public class HerosQuery: GraphQLQuery {
     ///
     /// Parent Type: `Character`
     public struct Hero: GraphAPI.SelectionSet {
-      public static var __selections: [ApolloAPI.Selection] { [
-        .field("__typename", String.self),
-        .field("id", String.self),
-        .field("name", String.self),
-        .field("friends", [Friend]?.self),
-        .inlineFragment(AsHuman.self),
-        .inlineFragment(AsDroid.self),
-      ] }
+      ...
 
       public var id: String { __data["id"] }
       public var name: String { __data["name"] }
@@ -57,11 +48,7 @@ public class HerosQuery: GraphQLQuery {
       ///
       /// Parent Type: `Character`
       public struct Friend: GraphAPI.SelectionSet {
-        public static var __selections: [ApolloAPI.Selection] { [
-          .field("__typename", String.self),
-          .field("id", String.self),
-          .field("name", String.self),
-        ] }
+        ...
 
         public var id: String { __data["id"] }
         public var name: String { __data["name"] }
@@ -77,9 +64,7 @@ public class HerosQuery: GraphQLQuery {
       ///
       /// Parent Type: `Droid`
       public struct AsDroid: GraphAPI.InlineFragment {
-        public static var __selections: [ApolloAPI.Selection] { [
-          .field("primaryFunction", String?.self),
-        ] }
+        ...
 
         public var primaryFunction: String? { __data["primaryFunction"] }
         public var id: String { __data["id"] }
@@ -101,7 +86,7 @@ public class HerosQuery: GraphQLQuery {
 To create an instance of the `HerosQuery` class you would do the following:
 
 ```swift
-let modelData = HerosQuery.Data.init(
+let modelData = HerosQuery.Data(
   hero: HerosQuery.Data.Hero(
     __typename: "Human",
     id: "luke-skywalker",
@@ -119,7 +104,7 @@ let modelData = HerosQuery.Data.init(
 
 ### Type conditions
 
-If you use a [type condition](https://www.apollographql.com/docs/ios/fetching/type-conditions) in your operation you will notice that a struct is generated to match the type (`AsDroid` in the example above) but the generated initializer does not accept a value of that type.
+If you use a [type condition](../fetching/type-conditions) in your operation you will notice that a struct is generated to match the type (`AsDroid` in the example above) but the generated initializer does not accept a value of that type.
 
 In this case you must create an object of the required type and then use the `asRootEntityType` property to initialize the selection set:
 
@@ -137,7 +122,7 @@ let droid = HerosQuery.Data.Hero.AsDroid(
   ]
 )
 
-let modelData = HerosQuery.Data.init(
+let modelData = HerosQuery.Data(
   hero: droid.asRootEntityType
 )
 ```


### PR DESCRIPTION
Adding documentation for the configuration of Selection Set Initializers.

_Still to be added is a section on the usage of Selection Set Initializers in the "Development & Testing" section of the docs._