### PR TITLE
chore: Required swift-tools-version update

### DIFF
--- a/apollo-ios-codegen/Package.swift
+++ b/apollo-ios-codegen/Package.swift
@@ -1,5 +1,7 @@
 // swift-tools-version:5.9
+//
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// Swift 5.9 is available from Xcode 15.0.
 
 import PackageDescription
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
@@ -23,7 +23,7 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
     let casedSchemaNamespace = config.schemaNamespace.firstUppercased
 
     return TemplateString("""
-    // swift-tools-version:5.7
+    // swift-tools-version:5.9
 
     import PackageDescription
 

--- a/apollo-ios-pagination/Package.swift
+++ b/apollo-ios-pagination/Package.swift
@@ -1,4 +1,7 @@
-// swift-tools-version: 5.9
+// swift-tools-version:5.9
+//
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+// Swift 5.9 is available from Xcode 15.0.
 
 import PackageDescription
 

--- a/apollo-ios/Package.swift
+++ b/apollo-ios/Package.swift
@@ -1,5 +1,8 @@
 // swift-tools-version:5.9
+//
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// Swift 5.9 is available from Xcode 15.0.
+
 
 import PackageDescription
 


### PR DESCRIPTION
* Adds a comment to the Apollo libraries indicating which version of Xcode provides the required Swift Tools version.
* Updates the SPM package template swift-tools-version to match the Apollo libraries.