### PR TITLE
ci: Fix GH action to accurately show test result

### DIFF
--- a/.github/workflows/ci-tests-xcode-beta.yml
+++ b/.github/workflows/ci-tests-xcode-beta.yml
@@ -150,7 +150,6 @@ jobs:
     - name: Build and Test
       if: ${{ matrix.should-run == true || matrix.should-run == 'true' }}
       id: build-and-test
-      continue-on-error: true
       uses: ./.github/actions/build-and-run-unit-tests
       with:
         destination: ${{ matrix.destination }}
@@ -158,7 +157,6 @@ jobs:
         test-plan: ${{ matrix.test-plan }}
     - name: Run-JS-Tests
       if: ${{ matrix.run-js-tests == true }}
-      continue-on-error: true
       shell: bash
       working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/
       run: |

--- a/.github/workflows/ci-tests-xcode-beta.yml
+++ b/.github/workflows/ci-tests-xcode-beta.yml
@@ -162,27 +162,27 @@ jobs:
       run: |
         npm install && npm test
     - name: Save xcodebuild logs
-      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.name }}-logs
         path: |
           DerivedData/Logs/Build
     - name: Save crash logs
-      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.name }}-crashes
         path: |
           ~/Library/Logs/DiagnosticReports
     - name: Zip Result Bundle
-      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      if: ${{ failure() }}
       shell: bash
       working-directory: TestResults
       run: |
         zip -r ResultBundle.zip ResultBundle.xcresult
     - name: Save test results
-      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.name }}-results

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -162,27 +162,27 @@ jobs:
       run: |
         npm install && npm test
     - name: Save xcodebuild logs
-      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.name }}-logs
         path: |
           DerivedData/Logs/Build
     - name: Save crash logs
-      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.name }}-crashes
         path: |
           ~/Library/Logs/DiagnosticReports
     - name: Zip Result Bundle
-      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      if: ${{ failure() }}
       shell: bash
       working-directory: TestResults
       run: |
         zip -r ResultBundle.zip ResultBundle.xcresult
     - name: Save test results
-      if: ${{ steps.build-and-test.outcome != 'skipped' }}
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.name }}-results

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -150,7 +150,6 @@ jobs:
     - name: Build and Test
       if: ${{ matrix.should-run == true || matrix.should-run == 'true' }}
       id: build-and-test
-      continue-on-error: true
       uses: ./.github/actions/build-and-run-unit-tests
       with:
         destination: ${{ matrix.destination }}
@@ -158,7 +157,6 @@ jobs:
         test-plan: ${{ matrix.test-plan }}
     - name: Run-JS-Tests
       if: ${{ matrix.run-js-tests == true }}
-      continue-on-error: true
       shell: bash
       working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/
       run: |
@@ -307,7 +305,6 @@ jobs:
         key: ${{ github.run_id }}-dependencies
         fail-on-cache-miss: true
     - name: Build and Test
-      continue-on-error: true
       uses: ./.github/actions/build-and-run-unit-tests
       with:
         destination: platform=macOS,arch=x86_64


### PR DESCRIPTION
This is a revert and improvement of #458.

* `continue-on-error` inaccurately reflects the test outcome as succeeded. [Here is the workflow summary](https://github.com/apollographql/apollo-ios-dev/actions/runs/10854978416) for #479 which is _correctly_ failing a codegen test but _incorrectly_ showing the entire CI run as successful. At the time of doing #458 I'd assumed it would still fail the step but allow other downstream jobs to still go ahead, turns out that's not how it works. 😬 
* Uses `failure()` as the `if` condition for the downstream logging jobs.