### PR TITLE
fix: Removes local cache mutation type condition setter

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
@@ -139,7 +139,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     let actual = subject.test_render(childEntity: allAnimals.computed)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
   }
 
   // MARK: - Accessor Tests
@@ -263,7 +263,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
-  func test__render_inlineFragmentAccessors__rendersAccessorWithGetterAndSetter() async throws {
+  func test__render_inlineFragmentAccessors__rendersAccessorWithGetterOnly() async throws {
     // given
     schemaSDL = """
     type Query {
@@ -290,10 +290,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     """
 
     let expected = """
-      public var asDog: AsDog? {
-        get { _asInlineFragment() }
-        set { if let newData = newValue?.__data._data { __data._data = newData }}
-      }
+      public var asDog: AsDog? { _asInlineFragment() }
     """
 
     // when
@@ -391,7 +388,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     let actual = subject.test_render(childEntity: allAnimals.computed)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 21, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
   }
 
   // MARK: - Casing Tests
@@ -435,7 +432,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
       public struct AsDog: Myschema.MutableInlineFragment {
     """
 
-    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
   }
 
   func test__casingForMutableInlineFragment__givenUppercasedSchemaName_generatesUppercasedNamespace() async throws {
@@ -477,7 +474,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
       public struct AsDog: MYSCHEMA.MutableInlineFragment {
     """
 
-    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
   }
 
   func test__casingForMutableInlineFragment__givenCapitalizedSchemaName_generatesCapitalizedNamespace() async throws {
@@ -519,6 +516,6 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
       public struct AsDog: MySchema.MutableInlineFragment {
     """
 
-    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
   }
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -478,16 +478,7 @@ struct SelectionSetTemplate {
 
     let typeName = inlineFragment.renderedTypeName
     return """
-      \(renderAccessControl())var \(typeName.firstLowercased): \(typeName)? {\
-      \(if: isMutable,
-      """
-
-        get { _asInlineFragment() }
-        set { if let newData = newValue?.__data._data { __data._data = newData }}
-      }
-      """,
-        else: " _asInlineFragment() }"
-      )
+      \(renderAccessControl())var \(typeName.firstLowercased): \(typeName)? { _asInlineFragment() }
       """
   }
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3443.

Simply removes the setter for mutable inline fragments (type conditions). The correct way to initialize with the type condition is to use `asRootEntityType`.