### PR TITLE
Support decoding Decimal as String

### DIFF
--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -172,4 +172,18 @@ class JSONTests: XCTestCase {
     let converted = JSONConverter.convert(result)
     XCTAssertEqual(converted, expected)
   }
+
+  func testJSONDecodeDecimalAsString() throws {
+    let decimal1 = Decimal(0.0123456789)
+    let decimal2 = Decimal(0.0123456789e-10)
+
+    let jsonValue1 = JSONValue(decimal1)
+    let jsonValue2 = JSONValue(decimal2)
+
+    let string1 = try String(_jsonValue: jsonValue1)
+    let string2 = try String(_jsonValue: jsonValue2)
+
+    XCTAssertEqual(string1, decimal1.description)
+    XCTAssertEqual(string2, decimal2.description)
+  }
 }

--- a/apollo-ios/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/apollo-ios/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -3,7 +3,7 @@ import Foundation
 extension String: JSONDecodable, JSONEncodable {
   /// The ``JSONDecodable`` initializer for a `String`.
   ///
-  /// This initializer will accept a `jsonValue` of a `String`, `Int` or `Double`.
+  /// This initializer will accept a `jsonValue` of a `String`, `Int`, `Double` or `Decimal`.
   /// This allows for conversion of custom scalars that are represented as any of these types to
   /// convert using the default custom scalar typealias of `String`.
   ///
@@ -18,7 +18,9 @@ extension String: JSONDecodable, JSONEncodable {
     case let int64 as Int64:
       self = String(int64)
     case let double as Double:
-      self = String(double)
+        self = String(double)
+    case let decimal as Decimal:
+        self = String(describing: decimal)
     default:
         throw JSONDecodingError.couldNotConvert(value: value, to: String.self)
     }


### PR DESCRIPTION
Allows converting `Decimal` to `String` when decoding.
Currently, an error is being thrown.