### PR TITLE
Add async/await to TestCacheProvider

### DIFF
--- a/Tests/ApolloInternalTestHelpers/SelectionSet+TestHelpers.swift
+++ b/Tests/ApolloInternalTestHelpers/SelectionSet+TestHelpers.swift
@@ -1,5 +1,5 @@
-@testable import ApolloAPI
-@testable import Apollo
+import ApolloAPI
+import Apollo
 
 public extension SelectionSet {
 

--- a/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
+++ b/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
@@ -67,7 +67,7 @@ class ParsingPerformanceTests: XCTestCase {
         statusCode: 200,
         httpVersion: nil,
         headerFields: [
-          "Content-Type": "multipart/mixed;boundary=graphql",
+          "Content-Type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0",
         ])!,
       rawData: rawData.crlfFormattedData(),
       parsedResponse: nil)

--- a/Tests/ApolloTests/Cache/CacheDependentInterceptorTests.swift
+++ b/Tests/ApolloTests/Cache/CacheDependentInterceptorTests.swift
@@ -11,10 +11,10 @@ class CacheDependentInterceptorTests: XCTestCase, CacheDependentTesting {
   var cache: (any NormalizedCache)!
   var store: ApolloStore!
   
-  override func setUpWithError() throws {
-    try super.setUpWithError()
-    
-    cache = try makeNormalizedCache()
+  override func setUp() async throws {
+    try await super.setUp()
+
+    cache = try await makeNormalizedCache()
     store = ApolloStore(cache: cache)
   }
 

--- a/Tests/ApolloTests/Cache/DeferOperationCacheReadTests.swift
+++ b/Tests/ApolloTests/Cache/DeferOperationCacheReadTests.swift
@@ -93,10 +93,10 @@ class DeferOperationCacheReadTests: XCTestCase, CacheDependentTesting {
   var server: MockGraphQLServer!
   var client: ApolloClient!
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  override func setUp() async throws {
+    try await super.setUp()
 
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
 
     server = MockGraphQLServer()

--- a/Tests/ApolloTests/Cache/DeferOperationCacheWriteTests.swift
+++ b/Tests/ApolloTests/Cache/DeferOperationCacheWriteTests.swift
@@ -89,10 +89,10 @@ class DeferOperationCacheWriteTests: XCTestCase, CacheDependentTesting, StoreLoa
   var cache: (any NormalizedCache)!
   var store: ApolloStore!
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  override func setUp() async throws {
+    try await super.setUp()
 
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     store = ApolloStore(cache: cache)
   }
 

--- a/Tests/ApolloTests/Cache/FetchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/FetchQueryTests.swift
@@ -15,10 +15,10 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
   var server: MockGraphQLServer!
   var client: ApolloClient!
   
-  override func setUpWithError() throws {
-    try super.setUpWithError()
-    
-    cache = try makeNormalizedCache()
+  override func setUp() async throws {
+    try await super.setUp()
+
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
     
     server = MockGraphQLServer()

--- a/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
@@ -16,10 +16,10 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   var cache: (any NormalizedCache)!
   var store: ApolloStore!
   
-  override func setUpWithError() throws {
-    try super.setUpWithError()
-    
-    cache = try makeNormalizedCache()
+  override func setUp() async throws {
+    try await super.setUp()
+
+    cache = try await makeNormalizedCache()
     store = ApolloStore(cache: cache)
   }
   

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -15,10 +15,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   var cache: (any NormalizedCache)!
   var store: ApolloStore!
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  override func setUp() async throws {
+    try await super.setUp()
 
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     store = ApolloStore(cache: cache)
   }
 

--- a/Tests/ApolloTests/Cache/SQLite/CachePersistenceTests.swift
+++ b/Tests/ApolloTests/Cache/SQLite/CachePersistenceTests.swift
@@ -8,7 +8,7 @@ import StarWarsAPI
 
 class CachePersistenceTests: XCTestCase {
 
-  func testFetchAndPersist() throws {
+  func testFetchAndPersist() async throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] { [
@@ -26,64 +26,66 @@ class CachePersistenceTests: XCTestCase {
     let query = MockQuery<GivenSelectionSet>()
     let sqliteFileURL = SQLiteTestCacheProvider.temporarySQLiteFileURL()
 
-    try SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { (cache) in
-      let store = ApolloStore(cache: cache)
+    let (cache, tearDown) = await SQLiteTestCacheProvider.makeNormalizedCache(fileURL: sqliteFileURL)
+    if let tearDown { self.addTeardownBlock(tearDown) }
+    let store = ApolloStore(cache: cache)
 
-      let server = MockGraphQLServer()
-      let networkTransport = MockNetworkTransport(server: server, store: store)
+    let server = MockGraphQLServer()
+    let networkTransport = MockNetworkTransport(server: server, store: store)
 
-      let client = ApolloClient(networkTransport: networkTransport, store: store)
+    let client = ApolloClient(networkTransport: networkTransport, store: store)
 
-      _ = server.expect(MockQuery<GivenSelectionSet>.self) { request in
-        [
-          "data": [
-            "hero": [
-              "name": "Luke Skywalker",
-              "__typename": "Human"
-            ]
+    _ = server.expect(MockQuery<GivenSelectionSet>.self) { request in
+      [
+        "data": [
+          "hero": [
+            "name": "Luke Skywalker",
+            "__typename": "Human"
           ]
         ]
-      }
+      ]
+    }
 
-      let networkExpectation = self.expectation(description: "Fetching query from network")
-      let newCacheExpectation = self.expectation(description: "Fetch query from new cache")
+    let networkExpectation = self.expectation(description: "Fetching query from network")
+    let newCacheExpectation = self.expectation(description: "Fetch query from new cache")
 
-      client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { outerResult in
-        defer { networkExpectation.fulfill() }
+    client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { outerResult in
+      defer { networkExpectation.fulfill() }
 
-        switch outerResult {
-        case .failure(let error):
-          XCTFail("Unexpected error: \(error)")
-          return
-        case .success(let graphQLResult):
-          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+      switch outerResult {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+        return
+      case .success(let graphQLResult):
+        XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
 
-          // Do another fetch from cache to ensure that data is cached before creating new cache
-          client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
-            try! SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { cache in
-              let newStore = ApolloStore(cache: cache)
-              let newClient = ApolloClient(networkTransport: networkTransport, store: newStore)
+        // Do another fetch from cache to ensure that data is cached before creating new cache
+        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
+          Task {
+            let (cache, _) = await SQLiteTestCacheProvider.makeNormalizedCache(fileURL: sqliteFileURL)
+            let newStore = ApolloStore(cache: cache)
+            let newClient = ApolloClient(networkTransport: networkTransport, store: newStore)
 
-              newClient.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { newClientResult in
-                defer { newCacheExpectation.fulfill() }
-                switch newClientResult {
-                case .success(let newClientGraphQLResult):
-                  XCTAssertEqual(newClientGraphQLResult.data?.hero?.name, "Luke Skywalker")
-                case .failure(let error):
-                  XCTFail("Unexpected error with new client: \(error)")
-                }
-                _ = newClient // Workaround for a bug - ensure that newClient is retained until this block is run
+            newClient.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { newClientResult in
+              defer { newCacheExpectation.fulfill() }
+              switch newClientResult {
+              case .success(let newClientGraphQLResult):
+                XCTAssertEqual(newClientGraphQLResult.data?.hero?.name, "Luke Skywalker")
+              case .failure(let error):
+                XCTFail("Unexpected error with new client: \(error)")
               }
+              _ = newClient // Workaround for a bug - ensure that newClient is retained until this block is run
             }
           }
+
         }
       }
-
-      self.waitForExpectations(timeout: 2, handler: nil)
     }
+
+    await fulfillment(of: [networkExpectation, newCacheExpectation], timeout: 2)
   }
 
-  func testFetchAndPersistWithPeriodArguments() throws {
+  func testFetchAndPersistWithPeriodArguments() async throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] { [
@@ -102,61 +104,62 @@ class CachePersistenceTests: XCTestCase {
 
     let sqliteFileURL = SQLiteTestCacheProvider.temporarySQLiteFileURL()
 
-    try SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { (cache) in
-      let store = ApolloStore(cache: cache)
+    let (cache, tearDown) = await SQLiteTestCacheProvider.makeNormalizedCache(fileURL: sqliteFileURL)
+    if let tearDown { self.addTeardownBlock(tearDown) }
+    let store = ApolloStore(cache: cache)
 
-      let server = MockGraphQLServer()
-      let networkTransport = MockNetworkTransport(server: server, store: store)
+    let server = MockGraphQLServer()
+    let networkTransport = MockNetworkTransport(server: server, store: store)
 
-      let client = ApolloClient(networkTransport: networkTransport, store: store)
+    let client = ApolloClient(networkTransport: networkTransport, store: store)
 
-      _ = server.expect(MockQuery<GivenSelectionSet>.self) { request in
-        [
-          "data": [
-            "hero": [
-              "name": "Luke Skywalker",
-              "__typename": "Human"
-            ]
+    _ = server.expect(MockQuery<GivenSelectionSet>.self) { request in
+      [
+        "data": [
+          "hero": [
+            "name": "Luke Skywalker",
+            "__typename": "Human"
           ]
         ]
-      }
+      ]
+    }
 
-      let networkExpectation = self.expectation(description: "Fetching query from network")
-      let newCacheExpectation = self.expectation(description: "Fetch query from new cache")
+    let networkExpectation = self.expectation(description: "Fetching query from network")
+    let newCacheExpectation = self.expectation(description: "Fetch query from new cache")
 
-      client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { outerResult in
-        defer { networkExpectation.fulfill() }
+    client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { outerResult in
+      defer { networkExpectation.fulfill() }
 
-        switch outerResult {
-        case .failure(let error):
-          XCTFail("Unexpected error: \(error)")
-          return
-        case .success(let graphQLResult):
-          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+      switch outerResult {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+        return
+      case .success(let graphQLResult):
+        XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
 
-          // Do another fetch from cache to ensure that data is cached before creating new cache
-          client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
-            try! SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { cache in
-              let newStore = ApolloStore(cache: cache)
-              let newClient = ApolloClient(networkTransport: networkTransport, store: newStore)
+        // Do another fetch from cache to ensure that data is cached before creating new cache
+        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
+          Task {
+            let (cache, _) = await SQLiteTestCacheProvider.makeNormalizedCache(fileURL: sqliteFileURL)
+            let newStore = ApolloStore(cache: cache)
+            let newClient = ApolloClient(networkTransport: networkTransport, store: newStore)
 
-              newClient.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { newClientResult in
-                defer { newCacheExpectation.fulfill() }
-                switch newClientResult {
-                case .success(let newClientGraphQLResult):
-                  XCTAssertEqual(newClientGraphQLResult.data?.hero?.name, "Luke Skywalker")
-                case .failure(let error):
-                  XCTFail("Unexpected error with new client: \(error)")
-                }
-                _ = newClient // Workaround for a bug - ensure that newClient is retained until this block is run
+            newClient.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { newClientResult in
+              defer { newCacheExpectation.fulfill() }
+              switch newClientResult {
+              case .success(let newClientGraphQLResult):
+                XCTAssertEqual(newClientGraphQLResult.data?.hero?.name, "Luke Skywalker")
+              case .failure(let error):
+                XCTFail("Unexpected error with new client: \(error)")
               }
+              _ = newClient // Workaround for a bug - ensure that newClient is retained until this block is run
             }
           }
         }
       }
-
-      self.waitForExpectations(timeout: 2, handler: nil)
     }
+
+    await fulfillment(of: [networkExpectation, newCacheExpectation], timeout: 2)
   }
 
   func testPassInConnectionDoesNotThrow() {
@@ -169,7 +172,7 @@ class CachePersistenceTests: XCTestCase {
     }
   }
 
-  func testClearCache() throws {
+  func testClearCache() async throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] { [
@@ -187,73 +190,76 @@ class CachePersistenceTests: XCTestCase {
     let query = MockQuery<GivenSelectionSet>()
     let sqliteFileURL = SQLiteTestCacheProvider.temporarySQLiteFileURL()
 
-    try SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { (cache) in
-      let store = ApolloStore(cache: cache)
+    let (cache, tearDown) = await SQLiteTestCacheProvider.makeNormalizedCache(fileURL: sqliteFileURL)
+    if let tearDown { self.addTeardownBlock(tearDown) }
+    let store = ApolloStore(cache: cache)
 
-      let server = MockGraphQLServer()
-      let networkTransport = MockNetworkTransport(server: server, store: store)
+    let server = MockGraphQLServer()
+    let networkTransport = MockNetworkTransport(server: server, store: store)
 
-      let client = ApolloClient(networkTransport: networkTransport, store: store)
+    let client = ApolloClient(networkTransport: networkTransport, store: store)
 
-      _ = server.expect(MockQuery<GivenSelectionSet>.self) { request in
-        [
-          "data": [
-            "hero": [
-              "name": "Luke Skywalker",
-              "__typename": "Human"
-            ]
+    _ = server.expect(MockQuery<GivenSelectionSet>.self) { request in
+      [
+        "data": [
+          "hero": [
+            "name": "Luke Skywalker",
+            "__typename": "Human"
           ]
         ]
-      }
-
-      let networkExpectation = self.expectation(description: "Fetching query from network")
-      let emptyCacheExpectation = self.expectation(description: "Fetch query from empty cache")
-      let cacheClearExpectation = self.expectation(description: "cache cleared")
-
-      client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { outerResult in
-        defer { networkExpectation.fulfill() }
-
-        switch outerResult {
-        case .failure(let error):
-          XCTFail("Unexpected failure: \(error)")
-        case .success(let graphQLResult):
-          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
-        }
-
-        client.clearCache(completion: { result in
-          switch result {
-          case .success:
-            break
-          case .failure(let error):
-            XCTFail("Error clearing cache: \(error)")
-          }
-          cacheClearExpectation.fulfill()
-        })
-
-        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
-          defer { emptyCacheExpectation.fulfill() }
-
-          switch innerResult {
-          case .success:
-            XCTFail("This should have returned an error")
-          case .failure(let error):
-            if let resultError = error as? JSONDecodingError {
-              switch resultError {
-              case .missingValue:
-                // Correct error!
-                break
-              default:
-                XCTFail("Unexpected JSON error: \(error)")
-              }
-            } else {
-              XCTFail("Unexpected error: \(error)")
-            }
-          }
-        }
-      }
-
-      self.waitForExpectations(timeout: 2, handler: nil)
+      ]
     }
+
+    let networkExpectation = self.expectation(description: "Fetching query from network")
+    let emptyCacheExpectation = self.expectation(description: "Fetch query from empty cache")
+    let cacheClearExpectation = self.expectation(description: "cache cleared")
+
+    client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { outerResult in
+      defer { networkExpectation.fulfill() }
+
+      switch outerResult {
+      case .failure(let error):
+        XCTFail("Unexpected failure: \(error)")
+      case .success(let graphQLResult):
+        XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+      }
+
+      client.clearCache(completion: { result in
+        switch result {
+        case .success:
+          break
+        case .failure(let error):
+          XCTFail("Error clearing cache: \(error)")
+        }
+        cacheClearExpectation.fulfill()
+      })
+
+      client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
+        defer { emptyCacheExpectation.fulfill() }
+
+        switch innerResult {
+        case .success:
+          XCTFail("This should have returned an error")
+        case .failure(let error):
+          if let resultError = error as? JSONDecodingError {
+            switch resultError {
+            case .missingValue:
+              // Correct error!
+              break
+            default:
+              XCTFail("Unexpected JSON error: \(error)")
+            }
+          } else {
+            XCTFail("Unexpected error: \(error)")
+          }
+        }
+      }
+    }
+
+    await fulfillment(
+      of: [networkExpectation, emptyCacheExpectation, cacheClearExpectation],
+      timeout: 2
+    )
   }
 
 }

--- a/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
+++ b/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
@@ -14,10 +14,10 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
   var cache: (any NormalizedCache)!
   var store: ApolloStore!
   
-  override func setUpWithError() throws {
-    try super.setUpWithError()
-    
-    cache = try makeNormalizedCache()
+  override func setUp() async throws {
+    try await super.setUp()
+
+    cache = try await makeNormalizedCache()
     store = ApolloStore(cache: cache)
   }
   

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -16,10 +16,10 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   var server: MockGraphQLServer!
   var client: ApolloClient!
   
-  override func setUpWithError() throws {
-    try super.setUpWithError()
-    
-    cache = try makeNormalizedCache()
+  override func setUp() async throws {
+    try await super.setUp()
+
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
     
     server = MockGraphQLServer()


### PR DESCRIPTION
This adds `async/await` support and improves the teardown logic of this test helper.