### PR TITLE
Fix MockSchemaMetadata actor isolation

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockSchemaMetadata.swift
+++ b/Tests/ApolloInternalTestHelpers/MockSchemaMetadata.swift
@@ -9,31 +9,39 @@ public class MockSchemaMetadata: SchemaMetadata {
   public init() { }
 
   public static var _configuration: SchemaConfiguration.Type = SchemaConfiguration.self
-  public static var configuration: any ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
+  public static let configuration: any ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
 
+  @MainActor
   private static let testObserver = TestObserver() { _ in
-    stub_objectTypeForTypeName = nil
-    stub_cacheKeyInfoForType_Object = nil
+    stub_objectTypeForTypeName(nil)
+    stub_cacheKeyInfoForType_Object(nil)
   }
 
-  public static var stub_objectTypeForTypeName: ((String) -> Object?)? {
-    didSet {
-      if stub_objectTypeForTypeName != nil { testObserver.start() }
+  private static var _objectTypeForTypeName: ((String) -> Object?)?
+  public static var objectTypeForTypeName: ((String) -> Object?)? {
+      _objectTypeForTypeName
+  }
+
+  @MainActor
+  public static func stub_objectTypeForTypeName(_ stub: ((String) -> Object?)?) {
+    _objectTypeForTypeName = stub
+    if _objectTypeForTypeName != nil {
+      testObserver.start()
     }
   }
 
-  public static var stub_cacheKeyInfoForType_Object: ((Object, ObjectData) -> CacheKeyInfo?)? {
-    get {
-      _configuration.stub_cacheKeyInfoForType_Object
-    }
-    set {
-      _configuration.stub_cacheKeyInfoForType_Object = newValue
-      if newValue != nil { testObserver.start() }
+  @MainActor
+  public static func stub_cacheKeyInfoForType_Object(
+    _ stub: ((Object, ObjectData) -> CacheKeyInfo?)?
+  ){
+    _configuration.stub_cacheKeyInfoForType_Object = stub
+    if stub != nil {
+      testObserver.start()
     }
   }
 
   public static func objectType(forTypename __typename: String) -> Object? {
-    if let stub = stub_objectTypeForTypeName {
+    if let stub = objectTypeForTypeName {
       return stub(__typename)
     }
 

--- a/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerCoordinatorTests.swift
+++ b/Tests/ApolloPaginationTests/AsyncGraphQLQueryPagerCoordinatorTests.swift
@@ -19,17 +19,18 @@ final class AsyncGraphQLQueryPagerCoordinatorTests: XCTestCase, CacheDependentTe
   var client: ApolloClient!
   var cancellables: [AnyCancellable] = []
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  @MainActor
+  override func setUp() async throws {
+    try await super.setUp()
 
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
 
     server = MockGraphQLServer()
     let networkTransport = MockNetworkTransport(server: server, store: store)
 
     client = ApolloClient(networkTransport: networkTransport, store: store)
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
   }
 
   override func tearDownWithError() throws {

--- a/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
@@ -19,17 +19,18 @@ final class BidirectionalPaginationTests: XCTestCase, CacheDependentTesting {
   var client: ApolloClient!
   var cancellables: [AnyCancellable] = []
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  @MainActor
+  override func setUp() async throws {
+    try await super.setUp()
 
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
 
     server = MockGraphQLServer()
     let networkTransport = MockNetworkTransport(server: server, store: store)
 
     client = ApolloClient(networkTransport: networkTransport, store: store)
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
   }
 
   override func tearDownWithError() throws {

--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -19,17 +19,18 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
   var client: ApolloClient!
   var cancellables: [AnyCancellable] = []
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  @MainActor
+  override func setUp() async throws {
+    try await super.setUp()
 
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
 
     server = MockGraphQLServer()
     let networkTransport = MockNetworkTransport(server: server, store: store)
 
     client = ApolloClient(networkTransport: networkTransport, store: store)
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
   }
 
   override func tearDownWithError() throws {

--- a/Tests/ApolloPaginationTests/GraphQLQueryPagerCoordinatorTests.swift
+++ b/Tests/ApolloPaginationTests/GraphQLQueryPagerCoordinatorTests.swift
@@ -18,17 +18,18 @@ final class GraphQLQueryPagerCoordinatorTests: XCTestCase, CacheDependentTesting
   var client: ApolloClient!
   var cancellables: [AnyCancellable] = []
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  @MainActor
+  override func setUp() async throws {
+    try await super.setUp()
 
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
 
     server = MockGraphQLServer()
     let networkTransport = MockNetworkTransport(server: server, store: store)
 
     client = ApolloClient(networkTransport: networkTransport, store: store)
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
   }
 
   override func tearDownWithError() throws {

--- a/Tests/ApolloPaginationTests/ReversePaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ReversePaginationTests.swift
@@ -19,17 +19,18 @@ final class ReversePaginationTests: XCTestCase, CacheDependentTesting {
   var client: ApolloClient!
   var cancellables: [AnyCancellable] = []
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  @MainActor
+  override func setUp() async throws {
+    try await super.setUp()
 
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
 
     server = MockGraphQLServer()
     let networkTransport = MockNetworkTransport(server: server, store: store)
 
     client = ApolloClient(networkTransport: networkTransport, store: store)
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
   }
 
   override func tearDownWithError() throws {

--- a/Tests/ApolloPaginationTests/SubscribeTests.swift
+++ b/Tests/ApolloPaginationTests/SubscribeTests.swift
@@ -16,17 +16,18 @@ final class SubscribeTest: XCTestCase, CacheDependentTesting {
   var client: ApolloClient!
   var cancellables: [AnyCancellable] = []
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  @MainActor
+  override func setUp() async throws {
+    try await super.setUp()
 
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
 
     server = MockGraphQLServer()
     let networkTransport = MockNetworkTransport(server: server, store: store)
 
     client = ApolloClient(networkTransport: networkTransport, store: store)
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
   }
 
   override func tearDownWithError() throws {

--- a/Tests/ApolloServerIntegrationTests/StarWarsServerCachingRoundtripTests.swift
+++ b/Tests/ApolloServerIntegrationTests/StarWarsServerCachingRoundtripTests.swift
@@ -21,10 +21,10 @@ class StarWarsServerCachingRoundtripTests: XCTestCase, CacheDependentTesting {
   var store: ApolloStore!
   var client: ApolloClient!
   
-  override func setUpWithError() throws {
-    try super.setUpWithError()
-    
-    cache = try makeNormalizedCache()
+  override func setUp() async throws {
+    try await super.setUp()
+
+    cache = try await makeNormalizedCache()
     store = ApolloStore(cache: cache)
     let provider = DefaultInterceptorProvider(store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,

--- a/Tests/ApolloServerIntegrationTests/StarWarsServerTests.swift
+++ b/Tests/ApolloServerIntegrationTests/StarWarsServerTests.swift
@@ -48,12 +48,12 @@ class StarWarsServerTests: XCTestCase, CacheDependentTesting {
   var cache: (any NormalizedCache)!
   var client: ApolloClient!
   
-  override func setUpWithError() throws {
-    try super.setUpWithError()
-    
+  override func setUp() async throws {
+    try await super.setUp()
+
     config = DefaultConfig()
-    
-    cache = try makeNormalizedCache()
+
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
     
     client = ApolloClient(networkTransport: config.network(store: store), store: store)

--- a/Tests/ApolloServerIntegrationTests/StarWarsWebSocketTests.swift
+++ b/Tests/ApolloServerIntegrationTests/StarWarsWebSocketTests.swift
@@ -16,10 +16,10 @@ class StarWarsWebSocketTests: XCTestCase, CacheDependentTesting {
   var cache: (any NormalizedCache)!
   var client: ApolloClient!
   
-  override func setUpWithError() throws {
-    try super.setUpWithError()
+  override func setUp() async throws {
+    try await super.setUp()
         
-    cache = try makeNormalizedCache()
+    cache = try await makeNormalizedCache()
     let store = ApolloStore(cache: cache)
     
     let networkTransport = WebSocketTransport(

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -249,19 +249,19 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
   }
 
-
+  @MainActor
   func test_readObject_givenFragmentWithTypeSpecificProperty() throws {
     // given
     struct Types {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = { typename in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ typename in
       switch typename {
       case "Droid": return Types.Droid
       default: return nil
       }
-    }
+    })
 
     class GivenSelectionSet: MockFragment {
       typealias Schema = MockSchemaMetadata
@@ -306,18 +306,19 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
   }
 
+  @MainActor
   func test_readObject_givenFragmentWithMissingTypeSpecificProperty() throws {
     // given
     struct Types {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = { typename in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ typename in
       switch typename {
       case "Droid": return Types.Droid
       default: return nil
       }
-    }
+    })
 
     class GivenSelectionSet: MockFragment {
       typealias Schema = MockSchemaMetadata
@@ -863,18 +864,19 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
   }
 
+  @MainActor
   func test_updateCacheMutation_updateNestedFieldOnTypeCase_updatesObjects() throws {
     // given
     struct Types {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = { typename in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ typename in
       switch typename {
       case "Droid": return Types.Droid
       default: return nil
       }
-    }
+    })
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
@@ -963,18 +965,19 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
   }
 
+  @MainActor
   func test_updateCacheMutation_updateNestedFieldOnNamedFragment_updatesObjects() throws {
     // given
     struct Types {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = { typename in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ typename in
       switch typename {
       case "Droid": return Types.Droid
       default: return nil
       }
-    }
+    })
 
     struct GivenFragment: MockMutableRootSelectionSet, Fragment {
       typealias Schema = MockSchemaMetadata
@@ -1093,18 +1096,19 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
   }
 
+  @MainActor
   func test_updateCacheMutation_updateNestedFieldOnOptionalNamedFragment_updatesObjects() throws {
     // given
     struct Types {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = { typename in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ typename in
       switch typename {
       case "Droid": return Types.Droid
       default: return nil
       }
-    }
+    })
 
     struct GivenFragment: MockMutableRootSelectionSet, Fragment {
       typealias Schema = MockSchemaMetadata
@@ -1695,18 +1699,18 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   // MARK: - Write w/Selection Set Initializers
 
-  func test_writeDataForOperation_givenSelectionSetManuallyInitialized_withNullValueForField_fieldHasNullValue() throws {
+  @MainActor func test_writeDataForOperation_givenSelectionSetManuallyInitialized_withNullValueForField_fieldHasNullValue() throws {
     // given
     struct Types {
       static let Query = Object(typename: "Query", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Query": return Types.Query
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Data: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1760,19 +1764,19 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
   }
 
-  func test_writeDataForOperation_givenSelectionSetManuallyInitializedWithInclusionConditions_writesFieldsForInclusionConditions() throws {
+  @MainActor func test_writeDataForOperation_givenSelectionSetManuallyInitializedWithInclusionConditions_writesFieldsForInclusionConditions() throws {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
       static let Query = Object(typename: "Query", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Data: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1914,7 +1918,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
   }
 
-  func test_writeDataForOperation_givenSelectionSetManuallyInitializedWithTypeCases_writesFieldForTypeCasesWithManuallyProvidedImplementedInterfaces() throws {
+  @MainActor func test_writeDataForOperation_givenSelectionSetManuallyInitializedWithTypeCases_writesFieldForTypeCasesWithManuallyProvidedImplementedInterfaces() throws {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
@@ -1922,12 +1926,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       static let Character = Interface(name: "Character")
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: return nil
       }
-    }
+    })
 
     class GivenQuery: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -2009,20 +2013,20 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [writeCompletedExpectation], timeout: Self.defaultWaitTimeout)
   }
 
-  func test_writeDataForOperation_givenSelectionSetManuallyInitializedWithNamedFragmentInInclusionConditionIsFulfilled_writesFieldsForNamedFragment() throws {
+  @MainActor func test_writeDataForOperation_givenSelectionSetManuallyInitializedWithNamedFragmentInInclusionConditionIsFulfilled_writesFieldsForNamedFragment() throws {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
       static let Query = Object(typename: "Query", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Query": return Types.Query
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     struct GivenFragment: MockMutableRootSelectionSet, Fragment {
       static var fragmentDefinition: StaticString { "" }
@@ -2148,20 +2152,20 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
   }
 
-  func test_writeDataForOperation_givenSelectionSetManuallyInitializedWithNamedFragmentInInclusionConditionNotFulfilled_doesNotAttemptToWriteFieldsForNamedFragment() throws {
+  @MainActor func test_writeDataForOperation_givenSelectionSetManuallyInitializedWithNamedFragmentInInclusionConditionNotFulfilled_doesNotAttemptToWriteFieldsForNamedFragment() throws {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
       static let Query = Object(typename: "Query", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Query": return Types.Query
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     struct GivenFragment: MockMutableRootSelectionSet, Fragment {
       static var fragmentDefinition: StaticString { "" }

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -294,7 +294,8 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       wait(for: [serverRequestExpectation, otherFetchCompletedExpectation, noUpdatedResultExpectation], timeout: Self.defaultWaitTimeout)
     }
   }
-  
+
+  @MainActor
   func testWatchedQueryGetsUpdatedWhenSameObjectHasChangedInAnotherQueryWithDifferentVariables() throws {
     class GivenSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] { [
@@ -310,7 +311,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
     }
 
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
 
     let watchedQuery = MockQuery<GivenSelectionSet>()
     watchedQuery.__variables = ["episode": "EMPIRE"]
@@ -515,7 +516,8 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       wait(for: [serverRequestExpectation, otherFetchCompletedExpectation, updatedWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
     }
   }
-  
+
+  @MainActor
   func testListInWatchedQueryGetsUpdatedByListOfKeysFromOtherQuery() throws {
     class HeroAndFriendsIdsSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[
@@ -571,7 +573,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         }
       }
     }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
     
     let watchedQuery = MockQuery<HeroAndFriendsNameSelectionSet>()
     
@@ -660,7 +662,8 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       wait(for: [serverRequestExpectation, otherFetchCompletedExpectation, updatedWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
     }
   }
-  
+
+  @MainActor
   func testWatchedQueryRefetchesFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
     class HeroAndFriendsIDsSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[
@@ -716,7 +719,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
     }
 
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
     
     let watchedQuery = MockQuery<HeroAndFriendsNameWithIDsSelectionSet>()
     
@@ -826,6 +829,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
   }
 
+  @MainActor
   func testWatchedQuery_givenRefetchOnFailedUpdates_false_doesNotRefetchFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
     class HeroAndFriendsIDsSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[
@@ -881,7 +885,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
     }
 
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
 
     let watchedQuery = MockQuery<HeroAndFriendsNameWithIDsSelectionSet>()
 
@@ -1092,6 +1096,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
   }
 
+  @MainActor
   func testWatchedQuery_givenCachePolicyReturnCacheDataDontFetch_doesNotRefetchFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
     // given
     struct HeroAndFriendsNamesSelectionSet: MockMutableRootSelectionSet {
@@ -1206,7 +1211,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
     }
 
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
 
     let watchedQuery = MockQuery<HeroAndFriendsNamesSelectionSet>()
 
@@ -1503,6 +1508,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
   }
 
+  @MainActor
   func testWatchedQueryDependentKeysAreUpdatedAfterDirectStoreUpdate() {
     // given
     struct HeroAndFriendsNamesWithIDsSelectionSet: MockMutableRootSelectionSet {
@@ -1567,7 +1573,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
     }
 
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
 
     typealias HeroAndFriendsNamesWithIDsQuery = MockQuery<HeroAndFriendsNamesWithIDsSelectionSet>
     let watchedQuery = HeroAndFriendsNamesWithIDsQuery()
@@ -1671,6 +1677,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
   }
 
+  @MainActor
   func testWatchedQueryDependentKeysAreUpdatedAfterOtherFetchReturnsChangedData() {
     class HeroAndFriendsNameWithIDsSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[
@@ -1701,7 +1708,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
     }
     
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
 
     let watchedQuery = MockQuery<HeroAndFriendsNameWithIDsSelectionSet>()
 
@@ -1821,6 +1828,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
   }
 
+  @MainActor
   func testQueryWatcherDoesNotHaveARetainCycle() {
     class HeroAndFriendsNameWithIDsSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[
@@ -1850,7 +1858,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         }
       }
     }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
 
     let watchedQuery = MockQuery<HeroAndFriendsNameWithIDsSelectionSet>()
 

--- a/Tests/ApolloTests/CacheKeyResolutionTests.swift
+++ b/Tests/ApolloTests/CacheKeyResolutionTests.swift
@@ -4,10 +4,11 @@ import Nimble
 import ApolloAPI
 import ApolloInternalTestHelpers
 
+@MainActor
 class CacheKeyResolutionTests: XCTestCase {
 
   func test__schemaConfiguration__givenData_whenCacheKeyInfoIsNil_shouldReturnNil() {
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { _, _ in nil }
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ _, _ in nil })
 
     let object: JSONObject = [
       "id": "α"
@@ -20,10 +21,10 @@ class CacheKeyResolutionTests: XCTestCase {
   }
 
   func test__schemaConfiguration__givenData_whenUnknownType_withCacheKeyInfoForUnknownType_shouldReturnInfoWithTypeName() {
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in nil })
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ (_, json) in
       return try? CacheKeyInfo(jsonValue: json["id"])
-    }
+    })
 
     let object: JSONObject = [
       "__typename": "Omega",
@@ -37,8 +38,8 @@ class CacheKeyResolutionTests: XCTestCase {
   }
 
   func test__schemaConfiguration__givenData_whenUnknownType_nilCacheKeyInfo_shouldReturnNil() {
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in nil }
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in nil })
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ (_, json) in nil })
 
     let object: JSONObject = [
       "__typename": "Omega",
@@ -59,8 +60,8 @@ class CacheKeyResolutionTests: XCTestCase {
       "id": "α"
     ]
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in Alpha }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in nil }
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in Alpha })
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ (_, json) in nil })
 
     let objectDict = NetworkResponseExecutionSource().opaqueObjectDataWrapper(for: object)
     let actual = MockSchemaMetadata.cacheKey(for: objectDict)
@@ -74,7 +75,7 @@ class CacheKeyResolutionTests: XCTestCase {
       "id": "β"
     ]
 
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
 
     let objectDict = NetworkResponseExecutionSource().opaqueObjectDataWrapper(for: object)
     let actual = MockSchemaMetadata.cacheKey(for: objectDict)
@@ -85,10 +86,10 @@ class CacheKeyResolutionTests: XCTestCase {
   }
 
   func test__schemaConfiguration__givenData_asInt_equalToBoolFalse_shouldNotConvertToBool() {
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in nil })
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ (_, json) in
       return try? CacheKeyInfo(jsonValue: json["id"])
-    }
+    })
 
     let object: JSONObject = [
       "__typename": "Omega",
@@ -102,10 +103,10 @@ class CacheKeyResolutionTests: XCTestCase {
   }
 
   func test__schemaConfiguration__givenData_asInt_equalToBoolTrue_shouldNotConvertToBool() {
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in nil })
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ (_, json) in
       return try? CacheKeyInfo(jsonValue: json["id"])
-    }
+    })
 
     let object: JSONObject = [
       "__typename": "Omega",
@@ -119,10 +120,10 @@ class CacheKeyResolutionTests: XCTestCase {
   }
 
   func test__schemaConfiguration__givenData_asInt_outsideBoolRange_shouldReturnCacheReference() {
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in nil })
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ (_, json) in
       return try? CacheKeyInfo(jsonValue: json["id"])
-    }
+    })
 
     let object: JSONObject = [
       "__typename": "Omega",
@@ -136,10 +137,10 @@ class CacheKeyResolutionTests: XCTestCase {
   }
 
   func test__schemaConfiguration__givenData_asBool_true_shouldNotConvertToInt() {
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in nil })
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ (_, json) in
       return try? CacheKeyInfo(jsonValue: json["id"])
-    }
+    })
 
     let object: JSONObject = [
       "__typename": "Omega",
@@ -153,10 +154,10 @@ class CacheKeyResolutionTests: XCTestCase {
   }
 
   func test__schemaConfiguration__givenData_asBool_false_shouldNotConvertToInt() {
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in nil }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in nil })
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ (_, json) in
       return try? CacheKeyInfo(jsonValue: json["id"])
-    }
+    })
 
     let object: JSONObject = [
       "__typename": "Omega",
@@ -192,10 +193,10 @@ class CacheKeyResolutionTests: XCTestCase {
   func test__schemaConfiguration__givenData_whenKnownType_isCacheKeyProvider_withUniqueKeyGroupId_shouldReturnCacheReference() {
     let Delta = Object(typename: "Delta", implementedInterfaces: [])
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in Delta }
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = { (_, json) in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in Delta })
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object({ (_, json) in
         .init(id: "δ", uniqueKeyGroup: "GreekLetters")
-    }
+    })
 
     let object: JSONObject = [
       "__typename": "Delta",

--- a/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
@@ -176,6 +176,7 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     XCTAssertEqual(luke["name"] as? String, "Luke Skywalker")
   }
 
+  @MainActor
   func test__execute__givenObjectWithCacheKey_andNestedArrayOfObjectsWithCacheKey_normalizesRecordsToIndividualReferences() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
@@ -199,7 +200,7 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
       }
     }
 
-    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
 
     let object: JSONObject = [
       "hero": [
@@ -275,6 +276,7 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     XCTAssertEqual(hero["catchphrase"] as? String, "Beeeeeeeeeeeeeep")
   }
 
+  @MainActor
   func test__execute__givenDifferentAliasedFieldsOnTwoTypeCasesWithSameAlias_givenIsFirstType_hasRecordWithFieldValueUsingNonaliasedFieldName() throws {
     // given
     struct Types {
@@ -282,13 +284,13 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       case "Droid": return Types.Droid
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class GivenSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[
@@ -332,6 +334,7 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     XCTAssertNil(hero["primaryFunction"])
   }
 
+  @MainActor
   func test__execute__givenDifferentAliasedFieldsOnTwoTypeCasesWithSameAlias_givenIsSecondType_hasRecordWithFieldValueUsingNonaliasedFieldName() throws {
     // given
     struct Types {
@@ -339,13 +342,13 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       case "Droid": return Types.Droid
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class GivenSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[
@@ -390,6 +393,7 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     XCTAssertNil(hero["name"])
   }
 
+  @MainActor
   func test__execute__givenSameFieldWithDifferentArgumentValueOnSameNestedFieldOnTwoTypeCases_givenIsFirstType_hasRecordForFieldNameWithFirstTypesArgument() throws {
     // given
     struct Types {
@@ -397,13 +401,14 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       case "Droid": return Types.Droid
       default: XCTFail(); return nil
       }
-    }
+    })
+
     class GivenSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[
         .field("hero", Hero.self),
@@ -462,6 +467,7 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     XCTAssertNil(han["height"])
   }
 
+  @MainActor
   func test__execute__givenSameFieldWithDifferentArgumentValueOnSameNestedFieldOnTwoTypeCases_givenIsSecondType_hasRecordForFieldNameWithFirstTypesArgument() throws {
     // given
     struct Types {
@@ -469,13 +475,13 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       case "Droid": return Types.Droid
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class GivenSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] {[

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -787,7 +787,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
   // MARK: - Inline Fragments
 
-  func test__inlineFragment__withoutTypenameMatchingCondition_selectsTypeCaseField() throws {
+  @MainActor func test__inlineFragment__withoutTypenameMatchingCondition_selectsTypeCaseField() throws {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
@@ -819,7 +819,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
       }
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName =  { typeName in
+    MockSchemaMetadata.stub_objectTypeForTypeName({ typeName in
       switch typeName {
       case "Human":
         return Types.Human
@@ -827,7 +827,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
         fail()
         return nil
       }
-    }
+    })
 
     let object: JSONObject = [
       "child": [
@@ -1117,7 +1117,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
   // MARK: - Fragments
 
-  func test__fragment__asObjectType_matchingParentType_selectsFragmentFields() throws {
+  @MainActor func test__fragment__asObjectType_matchingParentType_selectsFragmentFields() throws {
     // given
     struct Types {
       static let MockChildObject = Object(typename: "MockChildObject", implementedInterfaces: [])
@@ -1150,7 +1150,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
       }
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName =  { _ in return Types.MockChildObject }
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in return Types.MockChildObject })
 
     let object: JSONObject = [
       "__typename": "MockChildObject",
@@ -1368,7 +1368,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     expect(data.name).to(beNil())
   }
 
-  func test__booleanCondition_include_typeCase__givenVariableIsTrue_typeCaseMatchesParentType_getsValuesForTypeCaseFields() throws {
+  @MainActor func test__booleanCondition_include_typeCase__givenVariableIsTrue_typeCaseMatchesParentType_getsValuesForTypeCaseFields() throws {
     // given
     struct Types {
       static let Person = Object(typename: "Person", implementedInterfaces: [])
@@ -1388,7 +1388,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
         ]}
       }
     }
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in Types.Person }
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in Types.Person })
     let object: JSONObject = [
       "__typename": "Person",
       "name": "Luke Skywalker",
@@ -1404,7 +1404,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     expect(data.name).to(equal("Luke Skywalker"))
   }
 
-  func test__booleanCondition_include_typeCase__givenVariableIsFalse_typeCaseMatchesParentType_doesNotGetValuesForTypeCaseFields() throws {
+  @MainActor func test__booleanCondition_include_typeCase__givenVariableIsFalse_typeCaseMatchesParentType_doesNotGetValuesForTypeCaseFields() throws {
     // given
     struct Types {
       static let Person = Object(typename: "Person", implementedInterfaces: [])
@@ -1424,7 +1424,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
         ]}
       }
     }
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in Types.Person }
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in Types.Person })
     let object: JSONObject = [
       "__typename": "Person",
       "name": "Luke Skywalker",
@@ -1440,7 +1440,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     expect(data.name).to(beNil())
   }
 
-  func test__booleanCondition_include_typeCase__givenVariableIsTrue_typeCaseDoesNotMatchParentType_doesNotGetValuesForTypeCaseFields() throws {
+  @MainActor func test__booleanCondition_include_typeCase__givenVariableIsTrue_typeCaseDoesNotMatchParentType_doesNotGetValuesForTypeCaseFields() throws {
     // given
     struct Types {
       static let Person = Object(typename: "Person", implementedInterfaces: [])
@@ -1460,7 +1460,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
         ]}
       }
     }
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in Object.mock }
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in Object.mock })
     let object: JSONObject = [
       "__typename": "Person",
       "name": "Luke Skywalker",
@@ -1476,7 +1476,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     expect(data.name).to(beNil())
   }
 
-  func test__booleanCondition_include_singleFieldOnNestedTypeCase__givenVariableIsTrue_typeCaseMatchesParentType_getsValuesForTypeCaseFields() throws {
+  @MainActor func test__booleanCondition_include_singleFieldOnNestedTypeCase__givenVariableIsTrue_typeCaseMatchesParentType_getsValuesForTypeCaseFields() throws {
     // given
     struct Types {
       static let Person = Object(typename: "Person", implementedInterfaces: [])
@@ -1496,7 +1496,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
         ]}
       }
     }
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in Types.Person }
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in Types.Person })
     let object: JSONObject = [
       "__typename": "Person",
       "name": "Luke Skywalker",
@@ -1512,7 +1512,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     expect(data.name).to(equal("Luke Skywalker"))
   }
 
-  func test__booleanCondition_include_singleFieldOnNestedTypeCase__givenVariableIsFalse_typeCaseMatchesParentType_getsValuesForTypeCaseFields() throws {
+  @MainActor func test__booleanCondition_include_singleFieldOnNestedTypeCase__givenVariableIsFalse_typeCaseMatchesParentType_getsValuesForTypeCaseFields() throws {
     // given
     struct Types {
       static let Person = Object(typename: "Person", implementedInterfaces: [])
@@ -1532,7 +1532,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
         ]}
       }
     }
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in Types.Person }
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in Types.Person })
     let object: JSONObject = [
       "__typename": "Person",
       "name": "Luke Skywalker",
@@ -1548,7 +1548,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     expect(data.name).to(beNil())
   }
 
-  func test__booleanCondition_include_typeCaseOnNamedFragment__givenVariableIsTrue_typeCaseMatchesParentType_getsValuesForTypeCaseFields() throws {
+  @MainActor func test__booleanCondition_include_typeCaseOnNamedFragment__givenVariableIsTrue_typeCaseMatchesParentType_getsValuesForTypeCaseFields() throws {
     // given
     struct Types {
       static let Person = Object(typename: "Person", implementedInterfaces: [])
@@ -1573,7 +1573,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
         ]}
       }
     }
-    MockSchemaMetadata.stub_objectTypeForTypeName = { _ in Types.Person }
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in Types.Person })
     let object: JSONObject = [
       "__typename": "Person",
       "name": "Luke Skywalker",
@@ -2024,19 +2024,19 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
   // MARK: Fulfilled Fragment Tests
 
-  func test__nestedEntity_andTypeCaseWithAdditionalMergedNestedEntityFields_givenChildEntityCanConvertToTypeCase_fulfilledFragmentsContainsTypeCase() throws {
+  @MainActor func test__nestedEntity_andTypeCaseWithAdditionalMergedNestedEntityFields_givenChildEntityCanConvertToTypeCase_fulfilledFragmentsContainsTypeCase() throws {
     struct Types {
       static let Character = Interface(name: "Character")
       static let Hero = Interface(name: "Hero")
       static let Human = Object(typename: "Human", implementedInterfaces: [Character.self, Hero.self])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: fail(); return nil
       }
-    }
+    })
 
     class Character: MockSelectionSet {
       typealias Schema = MockSchemaMetadata

--- a/Tests/ApolloTests/Network/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/Network/URLSessionClientTests.swift
@@ -7,6 +7,7 @@ class URLSessionClientTests: XCTestCase {
   var client: URLSessionClient!
   var sessionConfiguration: URLSessionConfiguration!
 
+  @MainActor
   override func setUp() {
     super.setUp()
     Self.testObserver.start()
@@ -339,7 +340,8 @@ class URLSessionClientTests: XCTestCase {
 }
 
 extension URLSessionClientTests: MockRequestProvider {
-  
+
+  @MainActor
   private static let testObserver = TestObserver() { _ in
     requestHandlers = [:]
   }

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -620,6 +620,7 @@ class SelectionSetTests: XCTestCase {
 
   // MARK: - TypeCase Conversion Tests
 
+  @MainActor
   func test__asInlineFragment_givenObjectType_returnsTypeIfCorrectType() {
     // given
     struct Types {
@@ -627,13 +628,13 @@ class SelectionSetTests: XCTestCase {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       case "Droid": return Types.Droid
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -679,6 +680,7 @@ class SelectionSetTests: XCTestCase {
     expect(actual.asDroid).toNot(beNil())
   }
 
+  @MainActor
   func test__asInlineFragment_givenInterfaceType_typeForTypeNameImplementsInterface_returnsType() {
     // given
     struct Types {
@@ -686,12 +688,12 @@ class SelectionSetTests: XCTestCase {
       static let Human = Object(typename: "Human", implementedInterfaces: [Humanoid])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -726,6 +728,7 @@ class SelectionSetTests: XCTestCase {
     expect(actual.asHumanoid).toNot(beNil())
   }
 
+  @MainActor
   func test__asInlineFragment_givenInterfaceType_typeForTypeNameDoesNotImplementInterface_returnsNil() {
     // given
     struct Types {
@@ -733,12 +736,12 @@ class SelectionSetTests: XCTestCase {
       static let Droid = Object(typename: "Droid", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Droid": return Types.Droid
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -773,6 +776,7 @@ class SelectionSetTests: XCTestCase {
     expect(actual.asHumanoid).to(beNil())
   }
 
+  @MainActor
   func test__asInlineFragment_givenUnionType_typeNameIsTypeInUnionPossibleTypes_returnsType() {
     // given
     enum Types {
@@ -780,12 +784,12 @@ class SelectionSetTests: XCTestCase {
       static let Character = Union(name: "Character", possibleTypes: [Types.Human])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -819,6 +823,7 @@ class SelectionSetTests: XCTestCase {
     expect(actual.asCharacter).toNot(beNil())
   }
 
+  @MainActor
   func test__asInlineFragment_givenUnionType_typeNameNotIsTypeInUnionPossibleTypes_returnsNil() {
     // given
     enum Types {
@@ -826,12 +831,12 @@ class SelectionSetTests: XCTestCase {
       static let Character = Union(name: "Character", possibleTypes: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -865,6 +870,7 @@ class SelectionSetTests: XCTestCase {
     expect(actual.asCharacter).to(beNil())
   }
 
+  @MainActor
   func test__asInlineFragment_givenInterfaceTypeOnOperationRoot_typeImplementsInterface_returnsType() {
     // given
     struct Types {
@@ -872,12 +878,12 @@ class SelectionSetTests: XCTestCase {
       static let Query = Object(typename: "Query", implementedInterfaces: [AdminQuery])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Query": return Types.Query
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class RootData: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -977,6 +983,7 @@ class SelectionSetTests: XCTestCase {
 
   // MARK: - Initializer Tests
 
+  @MainActor
   func test__selectionInitializer_givenInitTypeWithTypeCondition__canConvertToConditionalType() {
     // given
     struct Types {
@@ -984,12 +991,12 @@ class SelectionSetTests: XCTestCase {
       static let Human = Object(typename: "Human", implementedInterfaces: [Animal])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1034,6 +1041,7 @@ class SelectionSetTests: XCTestCase {
     expect(actual.asAnimal?.name).to(equal("Artoo"))
   }
 
+  @MainActor
   func test__selectionInitializer_givenInitNestedTypeWithTypeCondition__canConvertToConditionalType() {
     // given
     struct Types {
@@ -1042,12 +1050,12 @@ class SelectionSetTests: XCTestCase {
       static let Human = Object(typename: "Human", implementedInterfaces: [Animal])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Data: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1112,18 +1120,19 @@ class SelectionSetTests: XCTestCase {
     expect(actual.hero.asAnimal?.name).to(equal("Artoo"))
   }
 
+  @MainActor
   func test__selectionInitializer_givenInitTypeWithInclusionCondition__canConvertToConditionalType() {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1167,18 +1176,19 @@ class SelectionSetTests: XCTestCase {
     expect(actual.ifA?.name).to(equal("Han Solo"))
   }
 
+  @MainActor
   func test__selectionInitializer_givenInitTypeWithInclusionCondition__cannotConvertToOtherConditionalType() {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1228,6 +1238,7 @@ class SelectionSetTests: XCTestCase {
     expect(actual.ifB).to(beNil())
   }
 
+  @MainActor
   func test__selectionInitializer_givenInitNestedTypeWithInclusionCondition__cannotConvertToOtherConditionalType() {
     // given
     struct Types {
@@ -1235,12 +1246,12 @@ class SelectionSetTests: XCTestCase {
       static let Query = Object(typename: "Query", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Data: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1361,18 +1372,19 @@ class SelectionSetTests: XCTestCase {
     expect(actual.hero.ifB).to(beNil())
   }
 
+  @MainActor
   func test__selectionInitializer_givenInitMultipleTypesWithConflictingInclusionConditions__canConvertToAllConditionalTypes() {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1416,18 +1428,19 @@ class SelectionSetTests: XCTestCase {
 
   // MARK: Initializer - Optional Field Tests
 
+  @MainActor
   func test__selectionInitializer_givenOptionalScalarField__fieldIsPresentWithOptionalNilValue() {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1477,18 +1490,19 @@ class SelectionSetTests: XCTestCase {
     }
   }
 
+  @MainActor
   func test__selectionInitializer_givenOptionalEntityField__fieldIsPresentWithOptionalNilValue() {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1559,18 +1573,19 @@ class SelectionSetTests: XCTestCase {
     }
   }
 
+  @MainActor
   func test__selectionInitializer_givenOptionalListOfOptionalEntitiesField__setsFieldDataCorrectly() {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -1624,18 +1639,19 @@ class SelectionSetTests: XCTestCase {
     expect(actual.friends?[2]?.name).to(equal("Leia"))
   }
 
+  @MainActor
   func test__selectionInitializer_givenOptionalListOfOptionalScalarsField__setsFieldDataCorrectly() {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata

--- a/Tests/ApolloTests/SelectionSet_JSONInitializerTests.swift
+++ b/Tests/ApolloTests/SelectionSet_JSONInitializerTests.swift
@@ -4,6 +4,7 @@ import ApolloAPI
 import ApolloInternalTestHelpers
 import Nimble
 
+@MainActor
 class SelectionSet_JSONInitializerTests: XCTestCase {
 
   func test__initFromJSON__withFragment_canAccessFragment() throws {
@@ -12,12 +13,12 @@ class SelectionSet_JSONInitializerTests: XCTestCase {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class GivenFragment: MockFragment {
       override class var __parentType: any ParentType { Types.Human }
@@ -62,12 +63,12 @@ class SelectionSet_JSONInitializerTests: XCTestCase {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -97,12 +98,12 @@ class SelectionSet_JSONInitializerTests: XCTestCase {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -134,12 +135,12 @@ class SelectionSet_JSONInitializerTests: XCTestCase {
       static let Human = Object(typename: "Human", implementedInterfaces: [Character.self, Hero.self])
     }
 
-    MockSchemaMetadata.stub_objectTypeForTypeName = {
+    MockSchemaMetadata.stub_objectTypeForTypeName({
       switch $0 {
       case "Human": return Types.Human
       default: XCTFail(); return nil
       }
-    }
+    })
 
     class Character: MockSelectionSet {
       typealias Schema = MockSchemaMetadata


### PR DESCRIPTION
This is a fix for broken tests due to #493 being accidentally merged too early.

In order to properly support Swift Concurrency, tests that alter the MockSchemaMetadata must be marked as `MainActor`.