### PR TITLE
Batch writing of records to SQLite store

### DIFF
--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -16,13 +16,24 @@ public protocol SQLiteDatabase {
   
   func selectRawRows(forKeys keys: Set<CacheKey>) throws -> [DatabaseRow]
 
-  func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws
-  
+  func addOrUpdate(records: [(cacheKey: CacheKey, recordString: String)]) throws
+
   func deleteRecord(for cacheKey: CacheKey) throws
 
   func deleteRecords(matching pattern: CacheKey) throws
   
   func clearDatabase(shouldVacuumOnClear: Bool) throws
+
+  @available(*, deprecated, renamed: "addOrUpdate(records:)")
+  func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws
+
+}
+
+extension SQLiteDatabase {
+
+  public func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws {
+    try addOrUpdate(records: [(cacheKey, recordString)])
+  }
 
 }
 

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
@@ -43,11 +43,17 @@ public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
       return DatabaseRow(cacheKey: key, storedInfo: record)
     }
   }
-  
-  public func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws {
-    try self.db.run(self.records.insert(or: .replace, self.keyColumn <- cacheKey, self.recordColumn <- recordString))
+
+  public func addOrUpdate(records: [(cacheKey: CacheKey, recordString: String)]) throws {
+    guard !records.isEmpty else { return }
+    
+    let setters = records.map {
+      [self.keyColumn <- $0.cacheKey, self.recordColumn <- $0.recordString]
+    }
+
+    try self.db.run(self.records.insertMany(or: .replace, setters))
   }
-  
+
   public func deleteRecord(for cacheKey: CacheKey) throws {
     let query = self.records.filter(keyColumn == cacheKey)
     try self.db.run(query.delete())


### PR DESCRIPTION
This uses `insertMany` to batch the writing of records to the SQLite cache. Previously we were running separate DB transaction/query for each individual record written. This should significantly improve performance of File I/O for cache writes.

We are investigating utilizing the [Benchmarks](https://github.com/ordo-one/package-benchmark/tree/main) package at some point in the future to measure the performance improvement, but that project is blocked for now and we should still release this performance improvement in the mean time.
