### PR TITLE
docs: Fix broken link

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -16,7 +16,7 @@ Apollo iOS executes queries and mutations using a GraphQL server and returns res
 Apollo iOS also includes caching mechanisms specifically for GraphQL data, enabling you to execute GraphQL queries against your locally cached data directly.
 
 <div>
-  <ButtonLink href="./get-started/" size="lg">
+  <ButtonLink href="./get-started" size="lg">
     Installation
   </ButtonLink>
 </div>
@@ -74,7 +74,7 @@ Apollo iOS handles all the heavy lifting of networking with GraphQL, including:
 Apollo Client's integration for [React](/react) also works with [React Native](https://facebook.github.io/react-native/) on both iOS and Android.
 
 <div align="center">
-  <ButtonLink href="./get-started/" size="lg">
+  <ButtonLink href="./get-started" size="lg">
     Get Started!
   </ButtonLink>
 </div>


### PR DESCRIPTION
Broken "Getting started" links on [this](https://www.apollographql.com/docs/ios) page. I _think_ removing the trailing slash should do it?