### PR TITLE
fix: Multipart delimiter boundary parsing

### DIFF
--- a/Tests/ApolloInternalTestHelpers/String+Data.swift
+++ b/Tests/ApolloInternalTestHelpers/String+Data.swift
@@ -2,6 +2,6 @@ import Foundation
 
 public extension String {
   func crlfFormattedData() -> Data {
-    return replacingOccurrences(of: "\n\n", with: "\r\n\r\n").data(using: .utf8)!
+    return replacingOccurrences(of: "\n", with: "\r\n").data(using: .utf8)!
   }
 }

--- a/Tests/ApolloTests/DeferTests.swift
+++ b/Tests/ApolloTests/DeferTests.swift
@@ -103,6 +103,7 @@ final class DeferTests: XCTestCase {
 
   func test__parsing__givenPartialResponse_shouldReturnSingleSuccess() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -193,6 +194,7 @@ final class DeferTests: XCTestCase {
 
   func test__parsing__givenPartialAndIncrementalResponses_withRootMerge_shouldReturnMultipleSuccesses() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -240,7 +242,7 @@ final class DeferTests: XCTestCase {
           }
         ]
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 
@@ -292,6 +294,7 @@ final class DeferTests: XCTestCase {
 
   func test__parsing__givenPartialAndIncrementalResponses_withNestedMerge_shouldReturnMultipleSuccesses() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -353,7 +356,7 @@ final class DeferTests: XCTestCase {
           }
         ]
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 

--- a/Tests/ApolloTests/DeferTests.swift
+++ b/Tests/ApolloTests/DeferTests.swift
@@ -82,10 +82,11 @@ final class DeferTests: XCTestCase {
   // MARK: Parsing tests
 
   private func buildNetworkTransport(
-    responseData: Data
+    responseData: Data,
+    multipartBoundary boundary: String = "graphql"
   ) -> RequestChainNetworkTransport {
     let client = MockURLSessionClient(
-      response: .mock(headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;deferSpec=20220824"]),
+      response: .mock(headerFields: ["Content-Type": "multipart/mixed;boundary=\(boundary);deferSpec=20220824"]),
       data: responseData
     )
 
@@ -225,7 +226,7 @@ final class DeferTests: XCTestCase {
       content-type: application/json
 
       {
-        "hasNext": true,
+        "hasNext": false,
         "incremental": [
           {
             "label": "deferredGenres",
@@ -439,6 +440,97 @@ final class DeferTests: XCTestCase {
           ObjectIdentifier(TVShowQuery.Data.Show.Character.DeferredFriend.self),
         ]))
         expect(scoobyDoo?.__data._deferredFragments).to(beEmpty())
+      }
+    }
+
+    wait(for: [expectation], timeout: defaultTimeout)
+  }
+
+  func test__parsing__givenPartialAndIncrementalResponses_withDashBoundaryInMessageBody_shouldNotSplitChunk() throws {
+    let multipartBoundary = "-"
+    let mysteryCharacterName = "lots\(multipartBoundary)of-\(multipartBoundary)similar--\(multipartBoundary)boundaries---\(multipartBoundary)in----\(multipartBoundary)this-----\(multipartBoundary)string"
+
+    let network = buildNetworkTransport(
+      responseData: """
+        
+        --\(multipartBoundary)
+        content-type: application/json
+
+        {
+          "hasNext": true,
+          "data": {
+            "show" : {
+              "__typename": "show",
+              "name": "The Scooby-Doo Show",
+              "characters": [
+                {
+                  "__typename": "Character",
+                  "name": "Scooby-Doo"
+                },
+                {
+                  "__typename": "Character",
+                  "name": "Shaggy Rogers"
+                },
+                {
+                  "__typename": "Character",
+                  "name": "Velma Dinkley"
+                },
+                {
+                  "__typename": "Character",
+                  "name": "\(mysteryCharacterName)"
+                }
+              ]
+            }
+          }
+        }
+        --\(multipartBoundary)
+        content-type: application/json
+
+        {
+          "hasNext": false,
+          "incremental": [
+            {
+              "label": "deferredGenres",
+              "path": [
+                "show"
+              ],
+              "data": {
+                "genres": [
+                  "Comedy",
+                  "Mystery",
+                  "Adventure"
+                ]
+              }
+            }
+          ]
+        }
+        --\(multipartBoundary)--
+        """.crlfFormattedData(),
+      multipartBoundary: multipartBoundary
+    )
+
+    let expectation = expectation(description: "Result received")
+    expectation.expectedFulfillmentCount = 2
+
+    _ = network.send(operation: TVShowQuery()) { result in
+      defer {
+        expectation.fulfill()
+      }
+
+      expect(result).to(beSuccess())
+
+      let data = try? result.get().data
+      expect(data?.__data._fulfilledFragments).to(equal([
+        ObjectIdentifier(TVShowQuery.Data.self),
+      ]))
+      expect(data?.__data._deferredFragments).to(beEmpty())
+
+      let show = data?.show
+      if expectation.numberOfFulfillments == 0 { // Partial data
+        expect(show?.characters).to(haveCount(4))
+
+        let mysteryCharacter = show?.characters[3]
+        expect(mysteryCharacter?.name).to(equal(mysteryCharacterName))
       }
     }
 

--- a/Tests/ApolloTests/Interceptors/MultipartResponseDeferParserTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseDeferParserTests.swift
@@ -20,6 +20,7 @@ final class MultipartResponseDeferParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;deferSpec=20220824"],
         data: """
+          
           --graphql
           content-type: test/custom
 
@@ -29,7 +30,7 @@ final class MultipartResponseDeferParserTests: XCTestCase {
             },
             "hasNext": true
           }
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -57,11 +58,12 @@ final class MultipartResponseDeferParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;deferSpec=20220824"],
         data: """
+          
           --graphql
           content-type: application/json
 
           not_a_valid_json_object
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -89,13 +91,14 @@ final class MultipartResponseDeferParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;deferSpec=20220824"],
         data: """
+          
           --graphql
           content-type: application/json
 
           {
             "key": "value"
           }
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -132,6 +135,7 @@ final class MultipartResponseDeferParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;deferSpec=20220824"],
         data: """
+          
           --graphql
           content-type: application/json
 
@@ -141,7 +145,7 @@ final class MultipartResponseDeferParserTests: XCTestCase {
             },
             "hasNext": true
           }
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -202,6 +206,7 @@ final class MultipartResponseDeferParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;deferSpec=20220824"],
         data: """
+          
           --graphql
           content-type: application/json
 
@@ -232,7 +237,7 @@ final class MultipartResponseDeferParserTests: XCTestCase {
             ],
             "hasNext": false
           }
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in

--- a/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
@@ -20,6 +20,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0"],
         data: """
+          
           --graphql
           content-type: test/custom
 
@@ -28,7 +29,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
               "key" : "value"
             }
           }
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -56,6 +57,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0"],
         data: """
+          
           --graphql
           content-type: application/json
 
@@ -66,7 +68,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
               }
             ]
           }
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -94,6 +96,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0"],
         data: """
+          
           --graphql
           content-type: application/json
 
@@ -105,7 +108,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
               }
             ]
           }
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -133,6 +136,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0"],
         data: """
+          
           --graphql
           content-type: application/json
 
@@ -149,7 +153,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
               }
             ]
           }
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -177,6 +181,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0"],
         data: """
+          
           --graphql
           content-type: application/json
 
@@ -191,7 +196,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
               }
             ]
           }
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -219,11 +224,12 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
       response: .mock(
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0"],
         data: """
+          
           --graphql
           content-type: application/json
 
           not_a_valid_json_object
-          --graphql
+          --graphql--
           """.crlfFormattedData()
       )
     ) { result in
@@ -276,6 +282,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   func test__parsing__givenHeartbeat_shouldIgnore() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -302,7 +309,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
           }
         }
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 
@@ -334,6 +341,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   func test__parsing__givenNullPayload_shouldIgnore() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       Content-Type: application/json
 
@@ -351,7 +359,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
           }
         }
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 
@@ -380,6 +388,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   func test__parsing__givenNullErrors_shouldIgnore() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -397,7 +406,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
           }
         }
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 
@@ -426,6 +435,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   func test__parsing__givenSingleChunk_shouldReturnSuccess() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -437,7 +447,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
           }
         }
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 
@@ -466,6 +476,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   func test__parsing__givenMultipleChunks_shouldReturnMultipleSuccesses() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -488,7 +499,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
           }
         }
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 
@@ -519,6 +530,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   func test__parsing__givenPayloadAndUnknownKeys_shouldReturnSuccessAndIgnoreUnknownKeys() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -531,7 +543,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
           }
         }
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 
@@ -560,6 +572,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   func test__parsing__givenPayloadWithDataAndGraphQLError_shouldReturnSuccessWithDataAndGraphQLError() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -576,7 +589,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
           ]
         }
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 
@@ -606,6 +619,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   func test__parsing__givenPayloadWithNullDataAndGraphQLError_shouldReturnSuccessWithOnlyGraphQLError() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 
@@ -619,7 +633,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
           ]
         }
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 
@@ -642,6 +656,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
 
   func test__parsing__givenEndOfStream_shouldReturnSuccess() throws {
     let network = buildNetworkTransport(responseData: """
+      
       --graphql
       content-type: application/json
 

--- a/Tests/ApolloTests/Network/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/Network/URLSessionClientTests.swift
@@ -301,10 +301,10 @@ class URLSessionClientTests: XCTestCase {
     let client2 = URLSessionClient(sessionConfiguration: sessionConfiguration,
                                    sessionDescription: expected)
     XCTAssertEqual(expected, client2.session.sessionDescription)
-      
+    
     client2.invalidate()
   }
-    
+
   func testTaskDescription() {
     let url = URL(string: "http://www.test.com/taskDesciption")!
     
@@ -337,6 +337,217 @@ class URLSessionClientTests: XCTestCase {
 
     self.wait(for: [expectation], timeout: 5)
   }
+
+  // MARK: Multipart Tests
+
+  func test__multipart__givenSingleChunk_shouldReturnSingleChunk() throws {
+    let url = URL(string: "http://www.test.com/multipart-single-chunk")!
+    let boundary = "-"
+    let multipartString = "--\(boundary)\r\nContent-Type: application/json\r\n\r\n{\"data\": {\"field1\": \"value1\"}}\r\n--\(boundary)--"
+
+    let request = self.request(
+      for: url,
+      responseData: multipartString.data(using: .utf8),
+      statusCode: 200,
+      headerFields: ["Content-Type": "multipart/mixed; boundary=\(boundary)"]
+    )
+
+    let expectation = self.expectation(description: "Multipart chunk received")
+
+    // Results are sent twice for multipart responses with both received here because this test infrastructure uses
+    // URLSessionClient direclty whereas in a request chain it is wrapped by an interceptor (NetworkFetchInterceptor)
+    // and that may handle the callbacks differently.
+    //
+    // 1. When multipart chunks are received, to be processed immediately - from urlSession(_:dataTask:didReceive:)
+    // 2. When the operation completes, with any remaining task data - from urlSession(_:task:didCompleteWithError:)
+    expectation.expectedFulfillmentCount = 2
+
+    self.client.sendRequest(request) { result in
+      switch result {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+
+      case .success(let (data, httpResponse)):
+        XCTAssertTrue(httpResponse.isSuccessful)
+        XCTAssertTrue(httpResponse.isMultipart)
+
+        switch String(data: data, encoding: .utf8) {
+        case multipartString, "": // "" is the second result and is expected to be empty
+          expectation.fulfill()
+
+        default:
+          XCTFail("Unexpected data received: \(data)")
+        }
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1)
+  }
+
+  func test__multipart__givenMultipleChunks_shouldReturnAllChunks() throws {
+    let url = URL(string: "http://www.test.com/multipart-many-chunks")!
+    let boundary = "-"
+    let multipartString = "--\(boundary)\r\nContent-Type: application/json\r\n\r\n{\"data\": {\"field1\": \"value1\"}}\r\n--\(boundary)\r\nContent-Type: application/json\r\n\r\n{\"data\": {\"field2\": \"value2\"}}\r\n--\(boundary)--"
+
+    let request = self.request(
+      for: url,
+      responseData: multipartString.data(using: .utf8),
+      statusCode: 200,
+      headerFields: ["Content-Type": "multipart/mixed; boundary=\(boundary)"]
+    )
+
+    let expectation = self.expectation(description: "Multipart chunk received")
+
+    // Results are sent twice for multipart responses with both received here because this test infrastructure uses
+    // URLSessionClient direclty whereas in a request chain it is wrapped by an interceptor (NetworkFetchInterceptor)
+    // and that may handle the callbacks differently.
+    //
+    // 1. When multipart chunks are received, to be processed immediately - from urlSession(_:dataTask:didReceive:)
+    // 2. When the operation completes, with any remaining task data - from urlSession(_:task:didCompleteWithError:)
+    expectation.expectedFulfillmentCount = 2
+
+    self.client.sendRequest(request) { result in
+      switch result {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+
+      case .success(let (data, httpResponse)):
+        XCTAssertTrue(httpResponse.isSuccessful)
+        XCTAssertTrue(httpResponse.isMultipart)
+
+        switch String(data: data, encoding: .utf8) {
+        case multipartString, "": // "" is the second result and is expected to be empty
+          expectation.fulfill()
+
+        default:
+          XCTFail("Unexpected data received: \(data)")
+        }
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1)
+  }
+
+  func test__multipart__givenCompleteAndPartialChunks_shouldReturnCompleteChunkSeparateFromPartialChunk() throws {
+    let url = URL(string: "http://www.test.com/multipart-complete-and-partial-chunk")!
+    let boundary = "-"
+    let completeChunk = "--\(boundary)\r\nContent-Type: application/json\r\n\r\n{\"data\": {\"field1\": \"value1\"}}"
+    let partialChunk = "\r\n--\(boundary)\r\nConte"
+    let multipartString = completeChunk + partialChunk
+
+    let request = self.request(
+      for: url,
+      responseData: multipartString.data(using: .utf8),
+      statusCode: 200,
+      headerFields: ["Content-Type": "multipart/mixed; boundary=\(boundary)"]
+    )
+
+    let expectation = self.expectation(description: "Multipart chunk received")
+
+    // Results are sent twice for multipart responses with both received here because this test infrastructure uses
+    // URLSessionClient direclty whereas in a request chain it is wrapped by an interceptor (NetworkFetchInterceptor)
+    // and that may handle the callbacks differently.
+    //
+    // 1. When multipart chunks are received, to be processed immediately - from urlSession(_:dataTask:didReceive:)
+    // 2. When the operation completes, with any remaining task data - from urlSession(_:task:didCompleteWithError:)
+    expectation.expectedFulfillmentCount = 2
+
+    self.client.sendRequest(request) { result in
+      switch result {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+
+      case .success(let (data, httpResponse)):
+        XCTAssertTrue(httpResponse.isSuccessful)
+        XCTAssertTrue(httpResponse.isMultipart)
+
+        switch String(data: data, encoding: .utf8) {
+        case completeChunk, partialChunk:
+          expectation.fulfill()
+
+        default:
+          XCTFail("Unexpected data received: \(data)")
+        }
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1)
+  }
+
+  func test__multipart__givenChunkContainingBoundaryString_shouldNotSplitChunk() throws {
+    let url = URL(string: "http://www.test.com/multipart-containing-boundary-string")!
+    let boundary = "-"
+    let multipartString = "--\(boundary)\r\nContent-Type: application/json\r\n\r\n{\"data\": {\"field1\": \"value1--\(boundary)\"}}\r\n--\(boundary)--"
+
+    let request = self.request(
+      for: url,
+      responseData: multipartString.data(using: .utf8),
+      statusCode: 200,
+      headerFields: ["Content-Type": "multipart/mixed; boundary=\(boundary)"]
+    )
+
+    let expectation = self.expectation(description: "Multipart chunk received")
+
+    // Results are sent twice for multipart responses with both received here because this test infrastructure uses
+    // URLSessionClient direclty whereas in a request chain it is wrapped by an interceptor (NetworkFetchInterceptor)
+    // and that may handle the callbacks differently.
+    //
+    // 1. When multipart chunks are received, to be processed immediately - from urlSession(_:dataTask:didReceive:)
+    // 2. When the operation completes, with any remaining task data - from urlSession(_:task:didCompleteWithError:)
+    expectation.expectedFulfillmentCount = 2
+
+    self.client.sendRequest(request) { result in
+      switch result {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+
+      case .success(let (data, httpResponse)):
+        XCTAssertTrue(httpResponse.isSuccessful)
+        XCTAssertTrue(httpResponse.isMultipart)
+
+        switch String(data: data, encoding: .utf8) {
+        case multipartString, "": // "" is the second result and is expected to be empty
+          expectation.fulfill()
+
+        default:
+          XCTFail("Unexpected data received: \(data)")
+        }
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1)
+  }
+
+  func test__multipart__givenChunkContainingBoundaryStringWithoutClosingBoundary_shouldNotSplitChunk() throws {
+    let url = URL(string: "http://www.test.com/multipart-without-closing-boundary")!
+    let boundary = "-"
+    let multipartString = "--\(boundary)\r\nContent-Type: application/json\r\n\r\n{\"data\": {\"field1\": \"value1--\(boundary)\"}}"
+
+    let request = self.request(
+      for: url,
+      responseData: multipartString.data(using: .utf8),
+      statusCode: 200,
+      headerFields: ["Content-Type": "multipart/mixed; boundary=\(boundary)"]
+    )
+
+    let expectation = self.expectation(description: "Multipart chunk received")
+
+    self.client.sendRequest(request) { result in
+      switch result {
+      case .failure(let error):
+        return XCTFail("Unexpected error: \(error)")
+
+      case .success(let (data, httpResponse)):
+        XCTAssertTrue(httpResponse.isSuccessful)
+        XCTAssertTrue(httpResponse.isMultipart)
+
+        XCTAssertEqual(String(data: data, encoding: .utf8), multipartString)
+        expectation.fulfill()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1)
+  }
 }
 
 extension URLSessionClientTests: MockRequestProvider {
@@ -347,5 +558,4 @@ extension URLSessionClientTests: MockRequestProvider {
   }
   
   public static var requestHandlers = [URL: MockRequestHandler]()
-  
 }

--- a/Tests/ApolloTests/Network/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/Network/URLSessionClientTests.swift
@@ -10,7 +10,9 @@ class URLSessionClientTests: XCTestCase {
   @MainActor
   override func setUp() {
     super.setUp()
+
     Self.testObserver.start()
+
     sessionConfiguration = URLSessionConfiguration.default
     sessionConfiguration.protocolClasses = [MockURLProtocol<Self>.self]
     client = URLSessionClient(sessionConfiguration: sessionConfiguration)
@@ -19,6 +21,7 @@ class URLSessionClientTests: XCTestCase {
   override func tearDown() {
     client = nil
     sessionConfiguration = nil
+
     super.tearDown()
   }
   
@@ -29,32 +32,41 @@ class URLSessionClientTests: XCTestCase {
     httpVersion: String? = nil,
     headerFields: [String: String]? = nil
   ) -> URLRequest {
-    let request = URLRequest(url: url,
-                             cachePolicy: .reloadIgnoringCacheData,
-                             timeoutInterval: 10)
-    
+    let request = URLRequest(
+      url: url,
+      cachePolicy: .reloadIgnoringCacheData,
+      timeoutInterval: 10
+    )
+
     Self.requestHandlers[url] = { request in
       guard let requestURL = request.url else {
         throw URLError(.badURL)
       }
       
-      let response = HTTPURLResponse(url: requestURL,
-                                     statusCode: statusCode,
-                                     httpVersion: httpVersion,
-                                     headerFields: headerFields)
+      let response = HTTPURLResponse(
+        url: requestURL,
+        statusCode: statusCode,
+        httpVersion: httpVersion,
+        headerFields: headerFields
+      )
+
       return .success((response!, responseData))
     }
     
     return request
   }
   
-  func testBasicGet() {
+  func test__request__basicGet() {
     let url = URL(string: "http://www.test.com/basicget")!
     let stringResponse = "Basic GET Response Data"
-    let request = self.request(for: url,
-                               responseData: stringResponse.data(using: .utf8),
-                               statusCode: 200)
+    let request = self.request(
+      for: url,
+      responseData: stringResponse.data(using: .utf8),
+      statusCode: 200
+    )
+
     let expectation = self.expectation(description: "Basic GET request completed")
+
     self.client.sendRequest(request) { result in
       defer {
         expectation.fulfill()
@@ -63,6 +75,7 @@ class URLSessionClientTests: XCTestCase {
       switch result {
       case .failure(let error):
         XCTFail("Unexpected error: \(error)")
+
       case .success(let (data, httpResponse)):
         XCTAssertFalse(data.isEmpty)
         XCTAssertEqual(String(data: data, encoding: .utf8), stringResponse)
@@ -74,7 +87,7 @@ class URLSessionClientTests: XCTestCase {
     self.wait(for: [expectation], timeout: 5)
   }
   
-  func testGettingImage() {
+  func test__request__gettingImage() {
     let url = URL(string: "http://www.test.com/gettingImage")!
     #if os(macOS)
     let responseImg = NSImage(systemSymbolName: "pencil", accessibilityDescription: nil)
@@ -87,12 +100,15 @@ class URLSessionClientTests: XCTestCase {
     let responseData = responseImg.pngData()
     #endif
     let headerFields = ["Content-Type": "image/jpeg"]
-    let request = self.request(for: url,
-                               responseData: responseData,
-                               statusCode: 200,
-                               headerFields: headerFields)
-    
+    let request = self.request(
+      for: url,
+      responseData: responseData,
+      statusCode: 200,
+      headerFields: headerFields
+    )
+
     let expectation = self.expectation(description: "GET request for image completed")
+
     self.client.sendRequest(request) { result in
       defer {
         expectation.fulfill()
@@ -101,6 +117,7 @@ class URLSessionClientTests: XCTestCase {
       switch result {
       case .failure(let error):
         XCTFail("Unexpected error: \(error)")
+
       case .success(let (data, httpResponse)):
         XCTAssertFalse(data.isEmpty)
         XCTAssertEqual(httpResponse.allHeaderFields["Content-Type"] as! String, "image/jpeg")
@@ -118,20 +135,23 @@ class URLSessionClientTests: XCTestCase {
     self.wait(for: [expectation], timeout: 5)
   }
   
-  func testPostingJSON() throws {
+  func test__request__postingJSON() throws {
     let testJSON = ["key": "value"]
     let data = try JSONSerialization.data(withJSONObject: testJSON, options: .prettyPrinted)
     let url = URL(string: "http://www.test.com/postingJSON")!
     let headerFields = ["Content-Type": "application/json"]
-    
-    var request = self.request(for: url,
-                               responseData: data,
-                               statusCode: 200,
-                               headerFields: headerFields)
+
+    var request = self.request(
+      for: url,
+      responseData: data,
+      statusCode: 200,
+      headerFields: headerFields
+    )
     request.httpBody = data
     request.httpMethod = GraphQLHTTPMethod.POST.rawValue
 
     let expectation = self.expectation(description: "POST request with JSON completed")
+
     self.client.sendRequest(request) { result in
       defer {
         expectation.fulfill()
@@ -140,6 +160,7 @@ class URLSessionClientTests: XCTestCase {
       switch result {
       case .failure(let error):
         XCTFail("Unexpected error: \(error)")
+
       case .success(let (data, httpResponse)):
         XCTAssertEqual(request.url, httpResponse.url)
 
@@ -155,13 +176,16 @@ class URLSessionClientTests: XCTestCase {
     self.wait(for: [expectation], timeout: 5)
   }
   
-  func testCancellingTaskDirectlyCallsCompletionWithError() throws {
+  func test__request__cancellingTaskDirectly_shouldCallCompletionWithError() throws {
     let url = URL(string: "http://www.test.com/cancelTaskDirectly")!
-    let request = request(for: url,
-                          responseData: nil,
-                          statusCode: -1)
+    let request = request(
+      for: url,
+      responseData: nil,
+      statusCode: -1
+    )
 
     let expectation = self.expectation(description: "Cancelled task completed")
+
     let task = self.client.sendRequest(request) { result in
       defer {
         expectation.fulfill()
@@ -176,9 +200,11 @@ class URLSessionClientTests: XCTestCase {
           let nsError = underlying as NSError
           XCTAssertEqual(nsError.domain, NSURLErrorDomain)
           XCTAssertEqual(nsError.code, NSURLErrorCancelled)
+
         default:
           XCTFail("Unexpected error: \(error)")
         }
+
       case .success:
         XCTFail("Task succeeded when it should have been cancelled!")
       }
@@ -189,14 +215,17 @@ class URLSessionClientTests: XCTestCase {
     self.wait(for: [expectation], timeout: 5)
   }
   
-  func testCancellingTaskThroughClientDoesNotCallCompletion() throws {
+  func test__request__cancellingTaskThroughClient_shouldNotCallCompletion() throws {
     let url = URL(string: "http://www.test.com/cancelThroughClient")!
-    let request = request(for: url,
-                          responseData: nil,
-                          statusCode: -1)
+    let request = request(
+      for: url,
+      responseData: nil,
+      statusCode: -1
+    )
 
     let expectation = self.expectation(description: "Cancelled task completed")
     expectation.isInverted = true
+
     let task = self.client.sendRequest(request) { result in
       // This shouldn't get hit since we cancel the task immediately
       expectation.fulfill()
@@ -208,7 +237,7 @@ class URLSessionClientTests: XCTestCase {
 
   }
   
-  func testMultipleSimultaneousRequests() {
+  func test__request__multipleSimultaneousRequests() {
     let expectation = self.expectation(description: "request sent, response received")
     let iterations = 20
     expectation.expectedFulfillmentCount = iterations
@@ -219,9 +248,12 @@ class URLSessionClientTests: XCTestCase {
     for i in 0..<iterations {
       let url = URL(string: "http://www.test.com/multipleSimultaneousRequests\(i)")!
       let responseStr = "Simultaneous Request \(i)"
-      let request = self.request(for: url,
-                                 responseData: responseStr.data(using: .utf8),
-                                 statusCode: 200)
+      let request = self.request(
+        for: url,
+        responseData: responseStr.data(using: .utf8),
+        statusCode: 200
+      )
+
       responseStrings[i] = responseStr
       requests[i] = request
     }
@@ -231,6 +263,7 @@ class URLSessionClientTests: XCTestCase {
         XCTFail("Unable to find URLRequest")
         return
       }
+
       let task = self.client.sendRequest(request) { result in
         let responseStr = responseStrings[index]
         switch result {
@@ -239,6 +272,7 @@ class URLSessionClientTests: XCTestCase {
           XCTAssertFalse(data.isEmpty)
           let httpResponseStr = String(data: data, encoding: .utf8)
           XCTAssertEqual(responseStr, httpResponseStr)
+
         case .failure(let error):
           XCTFail("Unexpected error: \(error)")
         }
@@ -261,7 +295,7 @@ class URLSessionClientTests: XCTestCase {
     XCTAssertEqual(set.count, iterations)
   }
   
-  func testInvalidatingClientAndThenTryingToSendARequestReturnsAppropriateError() {
+  func test__request__invalidatingClientAndThenTryingToSendARequestReturnsAppropriateError() {
     let client = URLSessionClient(sessionConfiguration: sessionConfiguration)
     client.invalidate()
 
@@ -292,25 +326,29 @@ class URLSessionClientTests: XCTestCase {
     self.wait(for: [expectation], timeout: 5)
   }
   
-  func testSessionDescription() {
+  func test__request__sessionDescription() {
     // Should be nil by default.
     XCTAssertNil(client.session.sessionDescription)
             
     // Should set the sessionDescription of the URLSession.
     let expected = "test description"
-    let client2 = URLSessionClient(sessionConfiguration: sessionConfiguration,
-                                   sessionDescription: expected)
+    let client2 = URLSessionClient(
+      sessionConfiguration: sessionConfiguration,
+      sessionDescription: expected
+    )
+
     XCTAssertEqual(expected, client2.session.sessionDescription)
     
     client2.invalidate()
   }
 
-  func testTaskDescription() {
+  func test__request__taskDescription() {
     let url = URL(string: "http://www.test.com/taskDesciption")!
-    
-    let request = request(for: url,
-                          responseData: nil,
-                          statusCode: -1)
+    let request = request(
+      for: url,
+      responseData: nil,
+      statusCode: -1
+    )
 
     let expectation = self.expectation(description: "Described task completed")
     expectation.isInverted = true
@@ -325,8 +363,10 @@ class URLSessionClientTests: XCTestCase {
     XCTAssertNil(task.taskDescription)
     
     let expected = "test task description"
-    let describedTask = self.client.sendRequest(request,
-                                                taskDescription: expected) { result in
+    let describedTask = self.client.sendRequest(
+      request,
+      taskDescription: expected
+    ) { result in
       // This shouldn't get hit since we cancel the task immediately
       expectation.fulfill()
     }
@@ -549,6 +589,8 @@ class URLSessionClientTests: XCTestCase {
     self.wait(for: [expectation], timeout: 1)
   }
 }
+
+// MARK: - MockRequestProvider Conformance
 
 extension URLSessionClientTests: MockRequestProvider {
 

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -641,6 +641,7 @@ class RequestChainTests: XCTestCase {
         headerFields: ["Content-Type": "multipart/mixed;boundary=graphql;subscriptionSpec=1.0"]
       ),
       data: """
+      
       --graphql
       content-type: application/json
 
@@ -663,7 +664,7 @@ class RequestChainTests: XCTestCase {
           }
         }
       }
-      --graphql
+      --graphql--
       """.crlfFormattedData()
     )
 

--- a/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -85,8 +85,9 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
       return
     }
 
-    for chunk in dataString.components(separatedBy: "--\(boundary)") {
-      if chunk.isEmpty || chunk.isBoundaryMarker { continue }
+    let boundaryMarker = Self.boundaryMarker(delimitedBy: boundary)
+    for chunk in dataString.components(separatedBy: boundaryMarker) {
+      if chunk.isEmpty || chunk.isBoundaryMarker || chunk.isMultipartNewLine { continue }
 
       switch parser.parse(chunk) {
       case let .success(data):

--- a/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -85,6 +85,11 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
       return
     }
 
+    // Parsing Notes:
+    //
+    // Multipart messages arriving here may consist of more than one chunk, but they are always
+    // expected to be complete chunks. Downstream protocol specification parsers are only built
+    // to handle the protocol specific message formats, i.e.: data between the multipart delimiter.
     let boundaryDelimiter = Self.boundaryDelimiter(with: boundary)
     for chunk in dataString.components(separatedBy: boundaryDelimiter) {
       if chunk.isEmpty || chunk.isDashBoundaryPrefix || chunk.isMultipartNewLine { continue }

--- a/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -140,6 +140,26 @@ extension MultipartResponseSpecificationParser {
   static var dataLineSeparator: StaticString { "\r\n\r\n" }
 }
 
-fileprivate extension String {
-  var isBoundaryMarker: Bool { self == "--" }
+extension String {
+  fileprivate var isBoundaryMarker: Bool { self == "--" }
+
+  /// Returns the range of a complete multipart chunk.
+  func multipartRange(delimitedBy boundary: String) -> String.Index? {
+    let boundaryMarker = "\r\n--\(boundary)"
+    let endBoundaryMarker = "\r\n--\(boundary)--"
+
+    // The end boundary marker indicates that no further chunks will follow so if this delimiter
+    // if found then include the delimiter in the index. Search for this first.
+    if let endIndex = range(of: endBoundaryMarker, options: .backwards)?.upperBound {
+      return endIndex
+    }
+
+    // A chunk boundary indicates there may still be more chunks to follow so the index need not
+    // include the chunk boundary in the index.
+    if let chunkIndex = range(of: boundaryMarker, options: .backwards)?.lowerBound {
+      return chunkIndex
+    }
+
+    return nil
+  }
 }

--- a/apollo-ios/Sources/Apollo/URLSessionClient.swift
+++ b/apollo-ios/Sources/Apollo/URLSessionClient.swift
@@ -292,19 +292,19 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     taskData.append(additionalData: data)
 
     if let httpResponse = dataTask.response as? HTTPURLResponse, httpResponse.isMultipart {
-      let multipartHeaderComponents = httpResponse.multipartHeaderComponents
-      guard let boundaryString = multipartHeaderComponents.boundary else {
+      guard let boundaryString = httpResponse.multipartHeaderComponents.boundary else {
         taskData.completionBlock(.failure(URLSessionClientError.missingMultipartBoundary))
         return
       }
 
-      let boundaryMarker = "--\(boundaryString)"
       guard
-        let dataString = String(data: taskData.data, encoding: .utf8)?.trimmingCharacters(in: .newlines),
-        let lastBoundaryIndex = dataString.range(of: boundaryMarker, options: .backwards)?.upperBound,
+        let dataString = String(data: taskData.data, encoding: .utf8),
+        let lastBoundaryIndex = dataString.multipartRange(delimitedBy: boundaryString),
         let boundaryData = dataString.prefix(upTo: lastBoundaryIndex).data(using: .utf8)
       else {
-        taskData.completionBlock(.failure(URLSessionClientError.cannotParseBoundaryData))
+        // Do not return .failure here simply because there was no boundary delimiter found; the data
+        // may still be arriving. If the request ends without more data arriving it will get handled
+        // in urlSession(_:task:didCompleteWithError:).
         return
       }
 

--- a/apollo-ios/Sources/Apollo/URLSessionClient.swift
+++ b/apollo-ios/Sources/Apollo/URLSessionClient.swift
@@ -297,14 +297,19 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
         return
       }
 
+      // Parsing Notes:
+      //
+      // Multipart messages are parsed here only to look for complete chunks to pass on to the downstream
+      // parsers. Any leftover data beyond a delimited chunk is held back for more data to arrive.
+      //
+      // Do not return `.failure` here simply because there was no boundary delimiter found; the
+      // data may still be arriving. If the request ends without more data arriving it will get handled
+      // in urlSession(_:task:didCompleteWithError:).
       guard
         let dataString = String(data: taskData.data, encoding: .utf8),
         let lastBoundaryDelimiterIndex = dataString.multipartRange(using: boundary),
         let boundaryData = dataString.prefix(upTo: lastBoundaryDelimiterIndex).data(using: .utf8)
       else {
-        // Do not return .failure here simply because there was no boundary delimiter found; the data
-        // may still be arriving. If the request ends without more data arriving it will get handled
-        // in urlSession(_:task:didCompleteWithError:).
         return
       }
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3453.

The multipart message parsing code was not splitting message chunks at the correct boundary. It would only look for the [dash boundary (`--graphql`)](https://github.com/apollographql/team-clients/blob/9e5914a2eb9e55e1a0882edeab45188acbf76c0e/rfcs/MultipartSubscriptionsTests.md#conventions) instead of the [full delimiter (`\r\n--graphql`)](https://github.com/apollographql/team-clients/blob/9e5914a2eb9e55e1a0882edeab45188acbf76c0e/rfcs/MultipartSubscriptionsTests.md#conventions). This meant that if the dash boundary was present in the message body the chunk would be split causing a parsing error.

* Multipart delimiter changed to match the RFC specifications.
* Refactored property and function names to match multipart RFC terminology.
* Test data updated to represent RFC specification-matching message data.
* `URLSessionClientTests` restyled and new tests added to ensure correct delimiter parsing.
* Tests added to defer and subscription protocol parsers to ensure correct delimiter parsing.
* I've also done manual integration testing with the [`client-router-e2e-tests`](https://github.com/apollographql/client-router-e2e-tests) repo test services and everything works as expected.