### PR TITLE
Call the completions in the given callback queue when `CompletionManager` is getting deinitialized

### DIFF
--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPagerCoordinator.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPagerCoordinator.swift
@@ -244,6 +244,6 @@ private actor CompletionManager {
   }
 
   deinit {
-    completions.forEach { $0.completion?(PaginationError.cancellation) }
+    completions.forEach { $0.execute(error: PaginationError.cancellation) }
   }
 }


### PR DESCRIPTION
In `CompletionManager.deinit` we directly call each of the completions but instead we should use `.execute` to ensure that the completion closures are being called in the given queue.