### PR TITLE
fix: Websocket error broadcast for unsubscribed ID

### DIFF
--- a/Tests/ApolloTests/WebSocket/WebSocketTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTests.swift
@@ -110,8 +110,8 @@ class WebSocketTests: XCTestCase {
     subject.cancel()
   }
   
-  func testLocalErrorUnknownId() throws {
-    let expectation = self.expectation(description: "Unknown id for subscription")
+  func testLocalErrorMissingId() throws {
+    let expectation = self.expectation(description: "Missing id for subscription")
     
     let subject = client.subscribe(subscription: MockSubscription<ReviewAddedData>()) { result in
       defer { expectation.fulfill() }
@@ -133,10 +133,10 @@ class WebSocketTests: XCTestCase {
         }
       }
     }
-    
+
+    // Message data below has missing 'id' and should notify all subscribers of the error
     let message : JSONEncodableDictionary = [
       "type": "data",
-      "id": "2",            // subscribing on id = 1, i.e. expecting error when receiving id = 2
       "payload": [
         "data": [
           "reviewAdded": [


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-ios/issues/2274
Closes https://github.com/apollographql/apollo-ios/issues/2447

There is a sequence of events where the caller unsubscribes which removes their ID from `subscribers` but an incoming message is then received for that subscriber. It doesn't seem correct to broadcast that as an error to all remaining subscribers for unrelated messages.

Changes:
* Only broadcast an error to all subscribers if there was no `id` field in the message
* Do not send any error if the `id` was not found in `subscribers`.