### PR TITLE
Make ApolloStore an open extensible class, and its previously-internal dependencies public

### DIFF
--- a/apollo-ios/Sources/Apollo/DataLoader.swift
+++ b/apollo-ios/Sources/Apollo/DataLoader.swift
@@ -1,4 +1,5 @@
-final class DataLoader<Key: Hashable, Value> {
+@_spi(Execution)
+public final class DataLoader<Key: Hashable, Value> {
   public typealias BatchLoad = (Set<Key>) throws -> [Key: Value]
   private var batchLoad: BatchLoad
 

--- a/apollo-ios/Sources/Apollo/ExecutionSources/CacheDataExecutionSource.swift
+++ b/apollo-ios/Sources/Apollo/ExecutionSources/CacheDataExecutionSource.swift
@@ -5,9 +5,10 @@ import ApolloAPI
 /// A `GraphQLExecutionSource` configured to execute upon the data stored in a ``NormalizedCache``.
 ///
 /// Each object exposed by the cache is represented as a `Record`.
-struct CacheDataExecutionSource: GraphQLExecutionSource {
-  typealias RawObjectData = Record
-  typealias FieldCollector = CacheDataFieldSelectionCollector
+@_spi(Execution)
+public struct CacheDataExecutionSource: GraphQLExecutionSource {
+  public typealias RawObjectData = Record
+  public typealias FieldCollector = CacheDataFieldSelectionCollector
 
   /// A `weak` reference to the transaction the cache data is being read from during execution.
   /// This transaction is used to resolve references to other objects in the cache during field
@@ -24,13 +25,13 @@ struct CacheDataExecutionSource: GraphQLExecutionSource {
   /// When executing on cache data all selections, including deferred, must be executed together because
   /// there is only a single response from the cache data. Any deferred selection that was cached will
   /// be returned in the response.
-  var shouldAttemptDeferredFragmentExecution: Bool { true }
+  public var shouldAttemptDeferredFragmentExecution: Bool { true }
 
   init(transaction: ApolloStore.ReadTransaction) {
     self.transaction = transaction
   }
 
-  func resolveField(
+  public func resolveField(
     with info: FieldExecutionInfo,
     on object: Record
   ) -> PossiblyDeferred<AnyHashable?> {
@@ -72,14 +73,14 @@ struct CacheDataExecutionSource: GraphQLExecutionSource {
     return transaction.loadObject(forKey: reference.key)
   }
 
-  func computeCacheKey(for object: Record, in schema: any SchemaMetadata.Type) -> CacheKey? {
+  public func computeCacheKey(for object: Record, in schema: any SchemaMetadata.Type) -> CacheKey? {
     return object.key
   }
 
   /// A wrapper around the `DefaultFieldSelectionCollector` that maps the `Record` object to it's
   /// `fields` representing the object's data.
-  struct CacheDataFieldSelectionCollector: FieldSelectionCollector {
-    static func collectFields(
+  public struct CacheDataFieldSelectionCollector: FieldSelectionCollector {
+    public static func collectFields(
       from selections: [Selection],
       into groupedFields: inout FieldSelectionGrouping,
       for object: Record,

--- a/apollo-ios/Sources/Apollo/GraphQLDependencyTracker.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLDependencyTracker.swift
@@ -2,44 +2,47 @@
 import ApolloAPI
 #endif
 
-final class GraphQLDependencyTracker: GraphQLResultAccumulator {
+@_spi(Execution)
+public final class GraphQLDependencyTracker: GraphQLResultAccumulator {
 
-  let requiresCacheKeyComputation: Bool = true
+  public let requiresCacheKeyComputation: Bool = true
 
   private var dependentKeys: Set<CacheKey> = Set()
+  
+  public init() {}
 
-  func accept(scalar: JSONValue, info: FieldExecutionInfo) {
+  public func accept(scalar: JSONValue, info: FieldExecutionInfo) {
     dependentKeys.insert(info.cachePath.joined)
   }
 
-  func accept(customScalar: JSONValue, info: FieldExecutionInfo) {
+  public func accept(customScalar: JSONValue, info: FieldExecutionInfo) {
     dependentKeys.insert(info.cachePath.joined)
   }
 
-  func acceptNullValue(info: FieldExecutionInfo) {
+  public func acceptNullValue(info: FieldExecutionInfo) {
     dependentKeys.insert(info.cachePath.joined)
   }
 
-  func acceptMissingValue(info: FieldExecutionInfo) throws -> () {
+  public func acceptMissingValue(info: FieldExecutionInfo) throws -> () {
     dependentKeys.insert(info.cachePath.joined)
   }
 
-  func accept(list: [Void], info: FieldExecutionInfo) {
+  public func accept(list: [Void], info: FieldExecutionInfo) {
     dependentKeys.insert(info.cachePath.joined)
   }
 
-  func accept(childObject: Void, info: FieldExecutionInfo) {
+  public func accept(childObject: Void, info: FieldExecutionInfo) {
   }
 
-  func accept(fieldEntry: Void, info: FieldExecutionInfo) -> Void? {
+  public func accept(fieldEntry: Void, info: FieldExecutionInfo) -> Void? {
     dependentKeys.insert(info.cachePath.joined)
     return ()
   }
 
-  func accept(fieldEntries: [Void], info: ObjectExecutionInfo) {
+  public func accept(fieldEntries: [Void], info: ObjectExecutionInfo) {
   }
 
-  func finish(rootValue: Void, info: ObjectExecutionInfo) -> Set<CacheKey> {
+  public func finish(rootValue: Void, info: ObjectExecutionInfo) -> Set<CacheKey> {
     return dependentKeys
   }
 }

--- a/apollo-ios/Sources/Apollo/GraphQLResultAccumulator.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLResultAccumulator.swift
@@ -24,23 +24,26 @@ public protocol GraphQLResultAccumulator: AnyObject {
   func finish(rootValue: ObjectResult, info: ObjectExecutionInfo) throws -> FinalResult
 }
 
-func zip<Accumulator1: GraphQLResultAccumulator, Accumulator2: GraphQLResultAccumulator>(_ accumulator1: Accumulator1, _ accumulator2: Accumulator2) -> Zip2Accumulator<Accumulator1, Accumulator2> {
+@_spi(Execution)
+public func zip<Accumulator1: GraphQLResultAccumulator, Accumulator2: GraphQLResultAccumulator>(_ accumulator1: Accumulator1, _ accumulator2: Accumulator2) -> Zip2Accumulator<Accumulator1, Accumulator2> {
   return Zip2Accumulator(accumulator1, accumulator2)
 }
 
-func zip<Accumulator1: GraphQLResultAccumulator, Accumulator2: GraphQLResultAccumulator, Accumulator3: GraphQLResultAccumulator>(_ accumulator1: Accumulator1, _ accumulator2: Accumulator2, _ accumulator3: Accumulator3) -> Zip3Accumulator<Accumulator1, Accumulator2, Accumulator3> {
+@_spi(Execution)
+public func zip<Accumulator1: GraphQLResultAccumulator, Accumulator2: GraphQLResultAccumulator, Accumulator3: GraphQLResultAccumulator>(_ accumulator1: Accumulator1, _ accumulator2: Accumulator2, _ accumulator3: Accumulator3) -> Zip3Accumulator<Accumulator1, Accumulator2, Accumulator3> {
   return Zip3Accumulator(accumulator1, accumulator2, accumulator3)
 }
 
-final class Zip2Accumulator<Accumulator1: GraphQLResultAccumulator, Accumulator2: GraphQLResultAccumulator>: GraphQLResultAccumulator {
-  typealias PartialResult = (Accumulator1.PartialResult, Accumulator2.PartialResult)
-  typealias FieldEntry = (Accumulator1.FieldEntry?, Accumulator2.FieldEntry?)
-  typealias ObjectResult = (Accumulator1.ObjectResult, Accumulator2.ObjectResult)
-  typealias FinalResult = (Accumulator1.FinalResult, Accumulator2.FinalResult)
+@_spi(Execution)
+public final class Zip2Accumulator<Accumulator1: GraphQLResultAccumulator, Accumulator2: GraphQLResultAccumulator>: GraphQLResultAccumulator {
+  public typealias PartialResult = (Accumulator1.PartialResult, Accumulator2.PartialResult)
+  public typealias FieldEntry = (Accumulator1.FieldEntry?, Accumulator2.FieldEntry?)
+  public typealias ObjectResult = (Accumulator1.ObjectResult, Accumulator2.ObjectResult)
+  public typealias FinalResult = (Accumulator1.FinalResult, Accumulator2.FinalResult)
 
   private let accumulator1: Accumulator1
   private let accumulator2: Accumulator2
-  let requiresCacheKeyComputation: Bool
+  public let requiresCacheKeyComputation: Bool
 
   fileprivate init(_ accumulator1: Accumulator1, _ accumulator2: Accumulator2) {
     self.accumulator1 = accumulator1
@@ -51,64 +54,65 @@ final class Zip2Accumulator<Accumulator1: GraphQLResultAccumulator, Accumulator2
     accumulator2.requiresCacheKeyComputation
   }
 
-  func accept(scalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
+  public func accept(scalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.accept(scalar: scalar, info: info),
             try accumulator2.accept(scalar: scalar, info: info))
   }
 
-  func accept(customScalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
+  public func accept(customScalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.accept(customScalar: customScalar, info: info),
             try accumulator2.accept(customScalar: customScalar, info: info))
   }
 
-  func acceptNullValue(info: FieldExecutionInfo) throws -> PartialResult {
+  public func acceptNullValue(info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.acceptNullValue(info: info),
             try accumulator2.acceptNullValue(info: info))
   }
 
-  func acceptMissingValue(info: FieldExecutionInfo) throws -> PartialResult {
+  public func acceptMissingValue(info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.acceptMissingValue(info: info),
             try accumulator2.acceptMissingValue(info: info))
   }
 
-  func accept(list: [PartialResult], info: FieldExecutionInfo) throws -> PartialResult {
+  public func accept(list: [PartialResult], info: FieldExecutionInfo) throws -> PartialResult {
     let (list1, list2) = unzip(list)
     return (try accumulator1.accept(list: list1, info: info),
             try accumulator2.accept(list: list2, info: info))
   }
 
-  func accept(childObject: ObjectResult, info: FieldExecutionInfo) throws -> PartialResult {
+  public func accept(childObject: ObjectResult, info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.accept(childObject: childObject.0, info: info),
             try accumulator2.accept(childObject: childObject.1, info: info))
   }
 
-  func accept(fieldEntry: PartialResult, info: FieldExecutionInfo) throws -> FieldEntry? {
+  public func accept(fieldEntry: PartialResult, info: FieldExecutionInfo) throws -> FieldEntry? {
     return (try accumulator1.accept(fieldEntry: fieldEntry.0, info: info),
             try accumulator2.accept(fieldEntry: fieldEntry.1, info: info))
   }
 
-  func accept(fieldEntries: [FieldEntry], info: ObjectExecutionInfo) throws -> ObjectResult {
+  public func accept(fieldEntries: [FieldEntry], info: ObjectExecutionInfo) throws -> ObjectResult {
     let (fieldEntries1, fieldEntries2) = unzip(fieldEntries)
     return (try accumulator1.accept(fieldEntries: fieldEntries1, info: info),
             try accumulator2.accept(fieldEntries: fieldEntries2, info: info))
   }
 
-  func finish(rootValue: ObjectResult, info: ObjectExecutionInfo) throws -> FinalResult {
+  public func finish(rootValue: ObjectResult, info: ObjectExecutionInfo) throws -> FinalResult {
     return (try accumulator1.finish(rootValue: rootValue.0, info: info),
             try accumulator2.finish(rootValue: rootValue.1, info: info))
   }
 }
 
-final class Zip3Accumulator<Accumulator1: GraphQLResultAccumulator, Accumulator2: GraphQLResultAccumulator, Accumulator3: GraphQLResultAccumulator>: GraphQLResultAccumulator {
-  typealias PartialResult = (Accumulator1.PartialResult, Accumulator2.PartialResult, Accumulator3.PartialResult)
-  typealias FieldEntry = (Accumulator1.FieldEntry?, Accumulator2.FieldEntry?, Accumulator3.FieldEntry?)
-  typealias ObjectResult = (Accumulator1.ObjectResult, Accumulator2.ObjectResult, Accumulator3.ObjectResult)
-  typealias FinalResult = (Accumulator1.FinalResult, Accumulator2.FinalResult, Accumulator3.FinalResult)
+@_spi(Execution)
+public final class Zip3Accumulator<Accumulator1: GraphQLResultAccumulator, Accumulator2: GraphQLResultAccumulator, Accumulator3: GraphQLResultAccumulator>: GraphQLResultAccumulator {
+  public typealias PartialResult = (Accumulator1.PartialResult, Accumulator2.PartialResult, Accumulator3.PartialResult)
+  public typealias FieldEntry = (Accumulator1.FieldEntry?, Accumulator2.FieldEntry?, Accumulator3.FieldEntry?)
+  public typealias ObjectResult = (Accumulator1.ObjectResult, Accumulator2.ObjectResult, Accumulator3.ObjectResult)
+  public typealias FinalResult = (Accumulator1.FinalResult, Accumulator2.FinalResult, Accumulator3.FinalResult)
 
   private let accumulator1: Accumulator1
   private let accumulator2: Accumulator2
   private let accumulator3: Accumulator3
-  let requiresCacheKeyComputation: Bool
+  public let requiresCacheKeyComputation: Bool
 
   fileprivate init(_ accumulator1: Accumulator1,
                    _ accumulator2: Accumulator2,
@@ -122,57 +126,57 @@ final class Zip3Accumulator<Accumulator1: GraphQLResultAccumulator, Accumulator2
     accumulator3.requiresCacheKeyComputation
   }
 
-  func accept(scalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
+  public func accept(scalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.accept(scalar: scalar, info: info),
             try accumulator2.accept(scalar: scalar, info: info),
             try accumulator3.accept(scalar: scalar, info: info))
   }
 
-  func accept(customScalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
+  public func accept(customScalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.accept(customScalar: customScalar, info: info),
             try accumulator2.accept(customScalar: customScalar, info: info),
             try accumulator3.accept(customScalar: customScalar, info: info))
   }
 
-  func acceptNullValue(info: FieldExecutionInfo) throws -> PartialResult {
+  public func acceptNullValue(info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.acceptNullValue(info: info),
             try accumulator2.acceptNullValue(info: info),
             try accumulator3.acceptNullValue(info: info))
   }
 
-  func acceptMissingValue(info: FieldExecutionInfo) throws -> PartialResult {
+  public func acceptMissingValue(info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.acceptMissingValue(info: info),
             try accumulator2.acceptMissingValue(info: info),
             try accumulator3.acceptMissingValue(info: info))
   }
 
-  func accept(list: [PartialResult], info: FieldExecutionInfo) throws -> PartialResult {
+  public func accept(list: [PartialResult], info: FieldExecutionInfo) throws -> PartialResult {
     let (list1, list2, list3) = unzip(list)
     return (try accumulator1.accept(list: list1, info: info),
             try accumulator2.accept(list: list2, info: info),
             try accumulator3.accept(list: list3, info: info))
   }
 
-  func accept(childObject: ObjectResult, info: FieldExecutionInfo) throws -> PartialResult {
+  public func accept(childObject: ObjectResult, info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.accept(childObject: childObject.0, info: info),
             try accumulator2.accept(childObject: childObject.1, info: info),
             try accumulator3.accept(childObject: childObject.2, info: info))
   }
 
-  func accept(fieldEntry: PartialResult, info: FieldExecutionInfo) throws -> FieldEntry? {
+  public func accept(fieldEntry: PartialResult, info: FieldExecutionInfo) throws -> FieldEntry? {
     return (try accumulator1.accept(fieldEntry: fieldEntry.0, info: info),
             try accumulator2.accept(fieldEntry: fieldEntry.1, info: info),
             try accumulator3.accept(fieldEntry: fieldEntry.2, info: info))
   }
 
-  func accept(fieldEntries: [FieldEntry], info: ObjectExecutionInfo) throws -> ObjectResult {
+  public func accept(fieldEntries: [FieldEntry], info: ObjectExecutionInfo) throws -> ObjectResult {
     let (fieldEntries1, fieldEntries2, fieldEntries3) = unzip(fieldEntries)
     return (try accumulator1.accept(fieldEntries: fieldEntries1, info: info),
             try accumulator2.accept(fieldEntries: fieldEntries2, info: info),
             try accumulator3.accept(fieldEntries: fieldEntries3, info: info))
   }
 
-  func finish(rootValue: ObjectResult, info: ObjectExecutionInfo) throws -> FinalResult {
+  public func finish(rootValue: ObjectResult, info: ObjectExecutionInfo) throws -> FinalResult {
     return (try accumulator1.finish(rootValue: rootValue.0, info: info),
             try accumulator2.finish(rootValue: rootValue.1, info: info),
             try accumulator3.finish(rootValue: rootValue.2, info: info))

--- a/apollo-ios/Sources/Apollo/GraphQLResultNormalizer.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLResultNormalizer.swift
@@ -3,55 +3,57 @@ import Foundation
 import ApolloAPI
 #endif
 
-enum ResultNormalizerFactory {
+@_spi(Execution)
+public enum ResultNormalizerFactory {
 
-  static func selectionSetDataNormalizer() -> SelectionSetDataResultNormalizer {
+  public static func selectionSetDataNormalizer() -> SelectionSetDataResultNormalizer {
     SelectionSetDataResultNormalizer()
   }
 
-  static func networkResponseDataNormalizer() -> RawJSONResultNormalizer {
+  public static func networkResponseDataNormalizer() -> RawJSONResultNormalizer {
     RawJSONResultNormalizer()
   }
 }
 
-class BaseGraphQLResultNormalizer: GraphQLResultAccumulator {
+@_spi(Execution)
+public class BaseGraphQLResultNormalizer: GraphQLResultAccumulator {
   
-  let requiresCacheKeyComputation: Bool = true
+  public let requiresCacheKeyComputation: Bool = true
 
   private var records: RecordSet = [:]
 
   fileprivate init() {}
 
-  final func accept(scalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
+  public final func accept(scalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
     return scalar
   }
 
-  func accept(customScalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
+  public func accept(customScalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
     return customScalar
   }
 
-  final func acceptNullValue(info: FieldExecutionInfo) -> JSONValue? {
+  public final func acceptNullValue(info: FieldExecutionInfo) -> JSONValue? {
     return NSNull()
   }
 
-  final func acceptMissingValue(info: FieldExecutionInfo) -> JSONValue? {
+  public final func acceptMissingValue(info: FieldExecutionInfo) -> JSONValue? {
     return nil
   }
 
-  final func accept(list: [JSONValue?], info: FieldExecutionInfo) -> JSONValue? {
+  public final func accept(list: [JSONValue?], info: FieldExecutionInfo) -> JSONValue? {
     return list
   }
 
-  final func accept(childObject: CacheReference, info: FieldExecutionInfo) -> JSONValue? {
+  public final func accept(childObject: CacheReference, info: FieldExecutionInfo) -> JSONValue? {
     return childObject
   }
 
-  final func accept(fieldEntry: JSONValue?, info: FieldExecutionInfo) throws -> (key: String, value: JSONValue)? {
+  public final func accept(fieldEntry: JSONValue?, info: FieldExecutionInfo) throws -> (key: String, value: JSONValue)? {
     guard let fieldEntry else { return nil }
     return (try info.cacheKeyForField(), fieldEntry)
   }
 
-  final func accept(
+  public final func accept(
     fieldEntries: [(key: String, value: JSONValue)],
     info: ObjectExecutionInfo
   ) throws -> CacheReference {
@@ -63,15 +65,17 @@ class BaseGraphQLResultNormalizer: GraphQLResultAccumulator {
     return CacheReference(cachePath)
   }
 
-  final func finish(rootValue: CacheReference, info: ObjectExecutionInfo) throws -> RecordSet {
+  public final func finish(rootValue: CacheReference, info: ObjectExecutionInfo) throws -> RecordSet {
     return records
   }
 }
 
-final class RawJSONResultNormalizer: BaseGraphQLResultNormalizer {}
+@_spi(Execution)
+public final class RawJSONResultNormalizer: BaseGraphQLResultNormalizer {}
 
-final class SelectionSetDataResultNormalizer: BaseGraphQLResultNormalizer {
-  override final func accept(customScalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
+@_spi(Execution)
+public final class SelectionSetDataResultNormalizer: BaseGraphQLResultNormalizer {
+  override public final func accept(customScalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
     if let customScalar = customScalar as? (any JSONEncodable) {
       return customScalar._jsonValue
     }


### PR DESCRIPTION
(This is in reference to https://github.com/apollographql/apollo-ios/issues/3461, which I filed earlier today.)

The goal of this PR is: Make it easier to customize behavior of the Apollo normalized cache.

Currently, ApolloStore is a concrete class depended-on by lots of Apollo internals. It's not marked open, nor is it a protocol, so in practice there is no way without modifying Apollo code for applications to customize the store behavior.

With this PR, it is still necessary to use `@_spi(Execution)` for overriding particularly fiddly bits of ApolloStore behavior. I think this is probably a good thing to help users understand that they're digging deep into the internals, while still allowing us to customize the behavior we want.

Feedback is welcome. In particular I'm not sure whether to do what Android does and make ApolloStore a protocol and rename the current `ApolloStore` to `DefaultApolloStore`. I can make that change too if desired.

---

Feel free to skip the below, but here's some more context about the why:

My specific use-case is one that has been touched-on/requested a number of places (https://github.com/apollographql/apollo-ios/issues/3319, https://github.com/apollographql/apollo-ios/issues/892, https://github.com/apollographql/apollo-ios/issues/3216: make the Apollo cache accept missing values for nullable fields as null, rather than failing to parse them.) While Apollo team has resisted adding a flag, if ApolloStore were extensible I could implement the behavior I want myself without forking all of apollo-ios.

This example is what I was trying to write, impossible (as far as I can tell) without making ApolloStore extensible. It's just an ApolloStore that passes `.allowForOptionalFields` to the `GraphQLSelectionSetMapper` during load:

```swift
import Foundation
import ApolloAPI
@_spi(Execution) import Apollo

public class MyApolloStore: ApolloStore {
    override open func load<Operation: GraphQLOperation>(
        _ operation: Operation,
        callbackQueue: DispatchQueue? = nil,
        resultHandler: @escaping GraphQLResultHandler<Operation.Data>
    ) {
        withinReadTransaction({ transaction in
            let (data, dependentKeys) = try transaction.readObject(
                ofType: Operation.Data.self,
                withKey: CacheReference.rootCacheReference(for: Operation.operationType).key,
                variables: operation.__variables,
                accumulator: zip(GraphQLSelectionSetMapper<Operation.Data>(handleMissingValues: .allowForOptionalFields),
                                 GraphQLDependencyTracker())
            )

            return GraphQLResult(
                data: data,
                extensions: nil,
                errors: nil,
                source: .cache,
                dependentKeys: dependentKeys
            )
        }, callbackQueue: nil, completion: resultHandler)
    }
}

```