### PR TITLE
feat(apollo-ios-codegen): Stable sort schema types for SchemaMetadata

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGenIR/IRInputObjectTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRInputObjectTests.swift
@@ -25,7 +25,7 @@ class IRInputObjectTests: XCTestCase {
 
   func buildSubject() async throws {
     let ir: IRBuilder = try await .mock(schema: schemaSDL, document: document)
-    subject = ir.schema.referencedTypes.inputObjects.first!
+    subject = ir.schema.referencedTypes.inputObjects[1]
   }
 
   // MARK: - Tests

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/GraphQLSchema.swift
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/GraphQLSchema.swift
@@ -19,7 +19,8 @@ protocol GraphQLSchemaType: JavaScriptReferencedObject {
 
 }
 
-public class GraphQLNamedType: JavaScriptReferencedObject, @unchecked Sendable, Hashable, CustomDebugStringConvertible, GraphQLNamedItem {
+public class GraphQLNamedType: 
+  JavaScriptReferencedObject, @unchecked Sendable, Hashable, CustomDebugStringConvertible, GraphQLNamedItem {
   public let name: GraphQLName
 
   public let documentation: String?

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/GraphQLSchema.swift
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/GraphQLSchema.swift
@@ -19,8 +19,8 @@ protocol GraphQLSchemaType: JavaScriptReferencedObject {
 
 }
 
-public class GraphQLNamedType: 
-  JavaScriptReferencedObject, @unchecked Sendable, Hashable, CustomDebugStringConvertible, GraphQLNamedItem {
+public class GraphQLNamedType:
+  JavaScriptReferencedObject, @unchecked Sendable, Comparable, Hashable, CustomDebugStringConvertible, GraphQLNamedItem {
   public let name: GraphQLName
 
   public let documentation: String?
@@ -57,6 +57,10 @@ public class GraphQLNamedType:
 
   public static func ==(lhs: GraphQLNamedType, rhs: GraphQLNamedType) -> Bool {
     return lhs.name == rhs.name
+  }
+
+  public static func < (lhs: GraphQLNamedType, rhs: GraphQLNamedType) -> Bool {
+    lhs.name.schemaName < rhs.name.schemaName
   }
 
   public var debugDescription: String {

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/GraphQLSchema.swift
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/GraphQLSchema.swift
@@ -19,8 +19,7 @@ protocol GraphQLSchemaType: JavaScriptReferencedObject {
 
 }
 
-public class GraphQLNamedType:
-  JavaScriptReferencedObject, @unchecked Sendable, Comparable, Hashable, CustomDebugStringConvertible, GraphQLNamedItem {
+public class GraphQLNamedType: JavaScriptReferencedObject, @unchecked Sendable, Hashable, CustomDebugStringConvertible, GraphQLNamedItem {
   public let name: GraphQLName
 
   public let documentation: String?
@@ -57,10 +56,6 @@ public class GraphQLNamedType:
 
   public static func ==(lhs: GraphQLNamedType, rhs: GraphQLNamedType) -> Bool {
     return lhs.name == rhs.name
-  }
-
-  public static func < (lhs: GraphQLNamedType, rhs: GraphQLNamedType) -> Bool {
-    lhs.name.schemaName < rhs.name.schemaName
   }
 
   public var debugDescription: String {

--- a/apollo-ios-codegen/Sources/IR/IR+Schema.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+Schema.swift
@@ -34,7 +34,7 @@ public final class Schema {
       schemaRootTypes: CompilationResult.RootTypeDefinition
     ) {
       // Ensure allTypes is stable
-      self.allTypes = OrderedSet(types.sorted())
+      self.allTypes = OrderedSet(types.sorted(by: { $0.name.schemaName < $1.name.schemaName }))
       self.schemaRootTypes = schemaRootTypes
 
       var objects = OrderedSet<GraphQLObjectType>()

--- a/apollo-ios-codegen/Sources/IR/IR+Schema.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+Schema.swift
@@ -33,7 +33,8 @@ public final class Schema {
       _ types: [GraphQLNamedType],
       schemaRootTypes: CompilationResult.RootTypeDefinition
     ) {
-      self.allTypes = OrderedSet(types)
+      // Ensure allTypes is stable
+      self.allTypes = OrderedSet(types.sorted())
       self.schemaRootTypes = schemaRootTypes
 
       var objects = OrderedSet<GraphQLObjectType>()


### PR DESCRIPTION
In some cases, the order of parsed types come out differently on different systems (unclear why). This creates problems in some situations where we're checking in the generated SchemaMetadata files, as we continuously flip back and forth between two orderings, generating git diffs.

By sorting the parsed types, we guarantee that their order is stable and no unnecessary diffs are introduced.