### PR TITLE
fix: Bug with AnyHashable coercion for non-iOS platforms

### DIFF
--- a/apollo-ios/Sources/ApolloAPI/DataDict.swift
+++ b/apollo-ios/Sources/ApolloAPI/DataDict.swift
@@ -174,7 +174,7 @@ extension DataDict {
   /// we need to do some additional unwrapping and casting of the values to avoid crashes and other
   /// run time bugs.
   public static let _AnyHashableCanBeCoerced: Bool = {
-    if #available(iOS 14.5, *) {
+    if #available(iOS 14.5, macOS 11.3, tvOS 14.5, watchOS 7.4, *) {
       return true
     } else {
       return false


### PR DESCRIPTION
We encountered a similar [issue](https://github.com/apollographql/apollo-ios/issues/3247) on the macOS 11..<11.3 versions, which has been [fixed](https://github.com/apollographql/apollo-ios-dev/pull/61) for iOS. 

Although the issue was observed on macOS, I suggest including all platforms that could potentially face the same problem.

---

This PR extends the `_AnyHashableCanBeCoerced` check to include macOS, watchOS, and tvOS with their respective minimum versions. 