### PR TITLE
Don't add a raw type to Enums with no generated cases

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -491,7 +491,7 @@ class EnumTemplateTests: XCTestCase {
 
   // MARK: - No Enum Cases Tests
 
-  func test_render_givenEmptyEnum_shouldRenderWithoutAssociatedType() {
+  func test_render_givenEmptyEnum_shouldRenderWithoutRawType() {
     // given
     buildSubject(values: [], config: .mock(.other))
 
@@ -506,7 +506,7 @@ class EnumTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  func test_render_givenEnumWithAllDeprectedValues_shouldRenderWithoutAssociatedType() {
+  func test_render_givenEnumWithAllDeprectedValues_shouldRenderWithoutRawType() {
     // given
     buildSubject(
       values: [

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -506,7 +506,7 @@ class EnumTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  func test_render_givenEnumWithAllDeprectedValues_shouldRenderWithoutRawType() {
+  func test_render_givenEnumWithAllDeprecatedValues_shouldRenderWithoutRawType() {
     // given
     buildSubject(
       values: [

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -488,7 +488,48 @@ class EnumTemplateTests: XCTestCase {
       expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
     }
   }
-  
+
+  // MARK: - No Enum Cases Tests
+
+  func test_render_givenEmptyEnum_shouldRenderWithoutAssociatedType() {
+    // given
+    buildSubject(values: [], config: .mock(.other))
+
+    let expected = """
+    public enum TestEnum: EnumType {
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test_render_givenEnumWithAllDeprectedValues_shouldRenderWithoutAssociatedType() {
+    // given
+    buildSubject(
+      values: [
+        ("ONE", "Deprecated for tests", "Doc: One", nil),
+        ("TWO", "Deprecated for tests", "Doc: Two", nil),
+        ("THREE", "Deprecated for tests", nil, nil)
+      ],
+      config: ApolloCodegenConfiguration.mock(options: .init(
+        deprecatedEnumCases: .exclude
+      ))
+    )
+
+    let expected = """
+    enum TestEnum: EnumType {
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
   // MARK: - Schema Customization Tests
   
   func test__render__givenEnumAndValues_withCustomNames_shouldRenderWithCustomNames() throws {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -15,12 +15,15 @@ struct EnumTemplate: TemplateRenderer {
   func renderBodyTemplate(
     nonFatalErrorRecorder: ApolloCodegen.NonFatalError.Recorder
   ) -> TemplateString {
-    TemplateString(
+    let omitAssociatedType = graphqlEnum.values.isEmpty
+    || (config.options.deprecatedEnumCases == .exclude && graphqlEnum.values.allSatisfy(\.isDeprecated))
+
+    return TemplateString(
     """
     \(documentation: graphqlEnum.documentation, config: config)
     \(graphqlEnum.name.typeNameDocumentation)
     \(accessControlModifier(for: .parent))\
-    enum \(graphqlEnum.render(as: .typename)): String, EnumType {
+    enum \(graphqlEnum.render(as: .typename)): \(omitAssociatedType ? "" : "String, ")EnumType {
       \(graphqlEnum.values.compactMap({
         enumCase(for: $0)
       }), separator: "\n")

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -15,7 +15,7 @@ struct EnumTemplate: TemplateRenderer {
   func renderBodyTemplate(
     nonFatalErrorRecorder: ApolloCodegen.NonFatalError.Recorder
   ) -> TemplateString {
-    let omitAssociatedType = graphqlEnum.values.isEmpty
+    let omitRawType = graphqlEnum.values.isEmpty
     || (config.options.deprecatedEnumCases == .exclude && graphqlEnum.values.allSatisfy(\.isDeprecated))
 
     return TemplateString(
@@ -23,7 +23,7 @@ struct EnumTemplate: TemplateRenderer {
     \(documentation: graphqlEnum.documentation, config: config)
     \(graphqlEnum.name.typeNameDocumentation)
     \(accessControlModifier(for: .parent))\
-    enum \(graphqlEnum.render(as: .typename)): \(omitAssociatedType ? "" : "String, ")EnumType {
+    enum \(graphqlEnum.render(as: .typename)): \(omitRawType ? "" : "String, ")EnumType {
       \(graphqlEnum.values.compactMap({
         enumCase(for: $0)
       }), separator: "\n")


### PR DESCRIPTION
When an enum has no cases, or when all of the existing cases have been deprecated, the generated code will not be compilable since Xcode/swift cannot automatically synthesize conformance to RawRepresentable.

This fix simply omits the `String` raw type when the enum has no cases, which allows the build to proceed.