### PR TITLE
ci: Update Xcode versions

### DIFF
--- a/.github/workflows/ci-tests-xcode-swift-6.yml
+++ b/.github/workflows/ci-tests-xcode-swift-6.yml
@@ -1,11 +1,11 @@
-name: "CI Tests (Xcode 16.1 Beta)"
+name: "CI Tests (Xcode 16.1)"
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 env:
-  XCODE_VERSION: "16.1-beta"
+  XCODE_VERSION: "16.1"
 
 jobs:
   changes:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,4 +1,4 @@
-name: "CI Tests"
+name: "CI Tests (Xcode 15.4)"
 
 on:
   pull_request:


### PR DESCRIPTION
There is no more Xcode 16.x beta on the GitHub images so this PR updates the version we use for Swift 6 compatibility to Xcode 16.1 which is the latest stable.

Even though a beta of 16.2 is available from Apple now and will probably be available on GitHub in the future I don't think we need to target beta versions specifically any more; Swift 6 is the important piece and that looks to have settled in 16.1.