### PR TITLE
ci: Main branch health failure logs

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -103,11 +103,6 @@ jobs:
         xcode-version: ${{ env.XCODE_VERSION }}
     - name: Checkout Repo
       uses: actions/checkout@v3
-    # Caching for apollo-ios and apollo-ios-codegen SPM dependencies
-    # - uses: actions/cache@v3
-    #   with:
-    #     path: ./DerivedData/SourcePackages
-    #     key: ${{ runner.os }}-spm-${{ hashFiles('./apollo-ios/Package.resolved') }}-${{ hashFiles('./apollo-ios-codegen/Package.resolved') }}
     - name: Retrieve Build Cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -124,23 +124,27 @@ jobs:
       run: |
         npm install && npm test
     - name: Save xcodebuild logs
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.name }}-logs
         path: |
           DerivedData/Logs/Build
     - name: Save crash logs
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.name }}-crashes
         path: |
           ~/Library/Logs/DiagnosticReports
     - name: Zip Result Bundle
+      if: ${{ failure() }}
       shell: bash
       working-directory: TestResults
       run: |
         zip -r ResultBundle.zip ResultBundle.xcresult
     - name: Save test results
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.name }}-results

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -90,6 +90,12 @@ jobs:
             test-plan: Apollo-Codegen-CITestPlan
             name: Codegen Lib Unit Tests - macOS
             run-js-tests: true
+          # ApolloPagination Tests
+          - destination: platform=macOS,arch=x86_64
+            scheme: ApolloPaginationTests
+            test-plan: Apollo-PaginationTestPlan
+            name: ApolloPagination Unit Tests - macOS
+            run-js-tests: false
     name: ${{ matrix.name }}
     steps:
     - uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
I noticed that we've been having some failures on the Main Branch Health job but the test logs aren't being saved.
- Adds the `failure()` condition so that the save steps are still run when the job fails
- Adds pagination tests (not sure why these weren't in here, maybe just forgot when the pagination lib was added)
- Some clean up