### PR TITLE
ci: Fix `URLSessionClientTest` tests

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockURLProtocol.swift
+++ b/Tests/ApolloInternalTestHelpers/MockURLProtocol.swift
@@ -11,10 +11,10 @@ public class MockURLProtocol<RequestProvider: MockRequestProvider>: URLProtocol 
   }
   
   override public func startLoading() {
-    guard let url = self.request.url,
-          let handler = RequestProvider.requestHandlers[url] else {
-      fatalError("No MockRequestHandler available for URL.")
-    }
+    guard
+      let url = self.request.url,
+      let handler = RequestProvider.requestHandlers[url]
+    else { return }
 
     DispatchQueue.main.asyncAfter(deadline: .now() + Double.random(in: 0.0...0.25)) {
       defer {

--- a/Tests/ApolloTests/Network/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/Network/URLSessionClientTests.swift
@@ -355,33 +355,19 @@ class URLSessionClientTests: XCTestCase {
       responseData: nil,
       statusCode: -1
     )
-
-    let expectation = self.expectation(description: "Described task completed")
-    expectation.isInverted = true
     
-    let task = self.client.sendRequest(request) { result in
-      // This shouldn't get hit since we cancel the task immediately
-      expectation.fulfill()
-    }
+    let task = self.client.sendRequest(request) { result in }
     self.client.cancel(task: task)
-    
+
     // Should be nil by default.
     XCTAssertNil(task.taskDescription)
     
     let expected = "test task description"
-    let describedTask = self.client.sendRequest(
-      request,
-      taskDescription: expected
-    ) { result in
-      // This shouldn't get hit since we cancel the task immediately
-      expectation.fulfill()
-    }
+    let describedTask = self.client.sendRequest(request, taskDescription: expected) { result in }
     self.client.cancel(task: describedTask)
-    
+
     // The returned task should have the provided taskDescription.
     XCTAssertEqual(expected, describedTask.taskDescription)
-
-    self.wait(for: [expectation], timeout: 5)
   }
 
   // MARK: Multipart Tests

--- a/Tests/ApolloTests/Network/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/Network/URLSessionClientTests.swift
@@ -233,7 +233,13 @@ class URLSessionClientTests: XCTestCase {
 
     self.client.cancel(task: task)
 
-    self.wait(for: [expectation], timeout: 5)
+    // Instead of waiting an arbitrary amount of time for the completion to maybe be called
+    // the following mimics what Apple's documentation for URLSessionTask.cancel() states
+    // happens when a task is cancelled, i.e.: manually calling the delegate method
+    // urlSession(_:task:didCompleteWithError:)
+    self.client.urlSession(self.client.session, task: task, didCompleteWithError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled))
+
+    self.wait(for: [expectation], timeout: 0.5)
 
   }
   


### PR DESCRIPTION
We've been getting frequent failures of the `test__request__cancellingTaskThroughClient_shouldNotCallCompletion` test in the [Main Branch Health](https://github.com/apollographql/apollo-ios-dev/actions/workflows/release-check.yml) nightly build. I [fixed the build logs](https://github.com/apollographql/apollo-ios-dev/pull/523) not being archived which lead to the following:
- We shouldn't be using `fatalError` for a missing request handler. I think it's a bad practice and the behaviour obscures the actual test failure by crashing instead.
- Improves the `test__request__cancellingTaskThroughClient_shouldNotCallCompletion` test by invoking the same delegate callback that happens when a task is cancelled. This means we don't need to wait an arbitrary amount of time for the request callback to be called and can know for certain that the test succeeded.
- Improves the `test__request__taskDescription` test by not having to wait an arbitrary amount of time for the test to exit. The test has nothing to do with the completion handler and the task description can be checked and the test satisfied immediately.