### PR TITLE
fix: Assign websocket callback queue before connecting

### DIFF
--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -167,10 +167,11 @@ public class WebSocketTransport {
     self.addApolloClientHeaders(to: &self.websocket.request)
 
     self.websocket.delegate = self
+    self.websocket.callbackQueue = processingQueue
+
     if config.connectOnInit {
       self.websocket.connect()
     }
-    self.websocket.callbackQueue = processingQueue
   }
 
   public func isConnected() -> Bool {

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -167,6 +167,9 @@ public class WebSocketTransport {
     self.addApolloClientHeaders(to: &self.websocket.request)
 
     self.websocket.delegate = self
+    // Keep the assignment of the callback queue before attempting to connect. There is the
+    // potential of a data race if the connection fails early and the disconnect logic reads
+    // the callback queue while it's being set.
     self.websocket.callbackQueue = processingQueue
 
     if config.connectOnInit {


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-ios/issues/3466.

Assign the callback queue before connecting to prevent potential data race.