### PR TITLE
ci: Minor job improvements

### DIFF
--- a/.github/workflows/ci-tests-xcode-swift-6.yml
+++ b/.github/workflows/ci-tests-xcode-swift-6.yml
@@ -136,16 +136,6 @@ jobs:
           ./Derived/*
         key: ${{ github.run_id }}-dependencies
         fail-on-cache-miss: true
-    # Caching for apollo-ios and apollo-ios-codegen SPM dependencies
-    # - uses: actions/cache@v3
-    #   with:
-    #     path: ./DerivedData/SourcePackages
-    #     key: ${{ runner.os }}-spm-${{ hashFiles('./apollo-ios/Package.resolved') }}-${{ hashFiles('./apollo-ios-codegen/Package.resolved') }}
-    # - name: Run Tuist Generation
-    #   uses: tuist/tuist-action@0.13.0
-    #   with:
-    #       command: 'generate'
-    #       arguments: ''
     - name: Build and Test
       if: ${{ matrix.should-run == true || matrix.should-run == 'true' }}
       id: build-and-test
@@ -189,59 +179,3 @@ jobs:
           TestResults/ResultBundle.zip
 
   # CodegenTestConfigurations removed because source is not compatible with Sendable yet.
-  
-  verify-frontend-bundle-latest:
-    runs-on: macos-15
-    needs: [changes]
-    if: ${{ needs.changes.outputs.codegen  == 'true' }}
-    timeout-minutes: 5
-    name: Verify Frontend Bundle Latest - macOS
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Build JS Bundle
-      shell: bash
-      working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript
-      run: ./auto_rollup.sh
-    - name: Verify Latest
-      shell: bash
-      run: |
-        git diff --exit-code
-
-  verify-cli-binary-archive:
-    runs-on: macos-15
-    needs: [changes]
-    if: ${{ needs.changes.outputs.codegen  == 'true' }}
-    timeout-minutes: 5
-    name: Verify CLI Binary Archive - macOS
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Extract CLI Binary
-      shell: bash
-      working-directory: apollo-ios/CLI
-      run: tar -xf apollo-ios-cli.tar.gz apollo-ios-cli
-    - name: Verify Version
-      shell: bash
-      working-directory: apollo-ios/scripts
-      run: ./cli-version-check.sh
-
-  run-cocoapods-integration-tests:
-    runs-on: macos-15
-    timeout-minutes: 20
-    name: Cocoapods Integration Tests - macOS
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: ${{ env.XCODE_VERSION }}
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Export ENV Variables
-      shell: bash
-      working-directory: apollo-ios
-      run: |
-        apollo_ios_sha=$(git rev-parse HEAD)
-        echo "APOLLO_IOS_SHA=$apollo_ios_sha" >> ${GITHUB_ENV}
-    - name: Run CocoaPods Integration Tests
-      id: run-cocoapods-integration-tests
-      uses: ./.github/actions/run-cocoapods-integration-tests

--- a/.github/workflows/ci-tests-xcode-swift-6.yml
+++ b/.github/workflows/ci-tests-xcode-swift-6.yml
@@ -202,7 +202,7 @@ jobs:
     - name: Build JS Bundle
       shell: bash
       working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript
-      run: npm install && ./auto_rollup.sh
+      run: ./auto_rollup.sh
     - name: Verify Latest
       shell: bash
       run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -215,7 +215,7 @@ jobs:
     - name: Build JS Bundle
       shell: bash
       working-directory: apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript
-      run: npm install && ./auto_rollup.sh
+      run: ./auto_rollup.sh
     - name: Verify Latest
       shell: bash
       run: |

--- a/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/auto_rollup.sh
+++ b/apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/auto_rollup.sh
@@ -3,7 +3,7 @@ set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 output_file="$SCRIPT_DIR/../ApolloCodegenFrontendBundle.swift"
-cd "$SCRIPT_DIR" && npm run build
+cd "$SCRIPT_DIR" && npm install && npm run build
 minJS=$(cat "$SCRIPT_DIR/dist/ApolloCodegenFrontend.bundle.js")
 printf "%s%s%s" "let ApolloCodegenFrontendBundle: String = #\"" "$minJS" "\"#" > "$output_file"
 exit 0


### PR DESCRIPTION
Here's a couple changes to our CI jobs to hopefully speed up total CI time and reduce mistakes:
* I'm moving `npm install` to the common script so that we don't need to do it separately as part of the JS frontend bundle update. This should mean less mistakes by missing a step that is needed to install the latest package updates. _Stems from the secops PR that failed CI due to the bundle needing to be updated. Couldn't understand why I wasn't getting any changes, then realized I needed to install the package updates before regenerating the bundle. This makes it a common step now so that should all be handled for us._
* The jobs we perform using Xcode 16.1 (Swift 6) should only be the ones that actually use that runtime. So I've removed the jobs from that CI script that aren't affected by the Xcode/Swift version.