### PR TITLE
Fix getting started button link

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -10,7 +10,7 @@ Apollo iOS executes queries and mutations using a GraphQL server and returns res
 Apollo iOS also includes caching mechanisms specifically for GraphQL data, enabling you to execute GraphQL queries against your locally cached data directly.
 
 <div>
-  <ButtonLink href="./get-started" size="lg">
+  <ButtonLink href="/ios/get-started" size="lg">
     Installation
   </ButtonLink>
 </div>
@@ -68,7 +68,7 @@ Apollo iOS handles all the heavy lifting of networking with GraphQL, including:
 Apollo Client's integration for [React](/react) also works with [React Native](https://facebook.github.io/react-native/) on both iOS and Android.
 
 <div align="center">
-  <ButtonLink href="./get-started" size="lg">
+  <ButtonLink href="/ios/get-started" size="lg">
     Get Started!
   </ButtonLink>
 </div>


### PR DESCRIPTION
Just noticed these lead to 404s. I believe an absolute link needs to be used for ButtonLinks (didn't notice any others in the ios docs)