### PR TITLE
fix: Changes `URLRequest` cache policy default

### DIFF
--- a/apollo-ios/Sources/Apollo/JSONRequest.swift
+++ b/apollo-ios/Sources/Apollo/JSONRequest.swift
@@ -155,7 +155,7 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
   private var requestCachePolicy: URLRequest.CachePolicy {
     switch cachePolicy {
     case .returnCacheDataElseFetch:
-      return .returnCacheDataElseLoad
+      return .useProtocolCachePolicy
     case .fetchIgnoringCacheData:
       return .reloadIgnoringLocalCacheData
     case .fetchIgnoringCacheCompletely:


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3483.

> Given that if the Apollo iOS cache store had expiration features it would obey them I can support the argument that `useProtocolCachePolicy` is an equivalent default more-so than `returnCacheDataElseLoad`. This shouldn't change the behaviour that was implemented for https://github.com/apollographql/apollo-ios/issues/3432 either

The differing behaviour is in whether the cache policy respects the original Cache-Control header directive re. expiration:
* `useProtocolCachePolicy` is [defined](https://developer.apple.com/documentation/foundation/nsurlrequest/cachepolicy/useprotocolcachepolicy) as "Use the caching logic defined in the protocol implementation, if any, for a particular URL load request."
* `returnCacheDataElseLoad` is [defined](https://developer.apple.com/documentation/foundation/nsurlrequest/cachepolicy/returncachedataelseload) as "Use existing cache data, **regardless or age or expiration date**, loading from originating source only if there is no cached data."