### PR TITLE
feature: Adds support for GraphQL over HTTP media type

### DIFF
--- a/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
@@ -516,6 +516,47 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
     wait(for: [expectation], timeout: defaultTimeout)
   }
 
+  func test__parsing__givenSingleChunk_withGraphQLOverHTTPContentType_shouldReturnSuccess() throws {
+    let network = buildNetworkTransport(responseData: """
+      
+      --graphql
+      content-type: application/graphql-response+json
+
+      {
+        "payload": {
+          "data": {
+            "__typename": "Time",
+            "ticker": 1
+          }
+        }
+      }
+      --graphql--
+      """.crlfFormattedData()
+    )
+
+    let expectedData = try Time(data: [
+      "__typename": "Time",
+      "ticker": 1
+    ], variables: nil)
+
+    let expectation = expectation(description: "Multipart data received")
+
+    _ = network.send(operation: MockSubscription<Time>()) { result in
+      defer {
+        expectation.fulfill()
+      }
+
+      switch (result) {
+      case let .success(data):
+        expect(data.data).to(equal(expectedData))
+      case let .failure(error):
+        fail("Unexpected failure result - \(error)")
+      }
+    }
+
+    wait(for: [expectation], timeout: defaultTimeout)
+  }
+
   func test__parsing__givenSingleChunk_withDashBoundaryInMessageBody_shouldReturnSuccess() throws {
     let multipartBoundary = "-"
     let network = buildNetworkTransport(

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -375,7 +375,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseSubscriptionParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseSubscriptionParser.protocolSpec),application/graphql-response+json,application/json")
       expectation.fulfill()
     }
 
@@ -400,7 +400,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseSubscriptionParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseSubscriptionParser.protocolSpec),application/graphql-response+json,application/json")
       XCTAssertNotNil(request.allHTTPHeaderFields?["Random"])
       expectation.fulfill()
     }
@@ -430,7 +430,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/graphql-response+json,application/json")
       expectation.fulfill()
     }
 
@@ -455,7 +455,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/graphql-response+json,application/json")
       expectation.fulfill()
     }
 
@@ -480,7 +480,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/graphql-response+json,application/json")
       XCTAssertNotNil(request.allHTTPHeaderFields?["Random"])
       expectation.fulfill()
     }
@@ -510,7 +510,7 @@ class RequestChainTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json")
+      XCTAssertEqual(header, "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/graphql-response+json,application/json")
       XCTAssertNotNil(request.allHTTPHeaderFields?["Random"])
       expectation.fulfill()
     }

--- a/apollo-ios/Sources/Apollo/MultipartResponseDeferParser.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseDeferParser.swift
@@ -13,7 +13,7 @@ struct MultipartResponseDeferParser: MultipartResponseSpecificationParser {
       switch self {
 
       case let .unsupportedContentType(type):
-        return "Unsupported content type: application/json is required but got \(type)."
+        return "Unsupported content type: 'application/graphql-response+json' or 'application/json' are supported, received '\(type)'."
       case .cannotParseChunkData:
         return "The chunk data could not be parsed."
       case .cannotParsePayloadData:
@@ -53,7 +53,9 @@ struct MultipartResponseDeferParser: MultipartResponseSpecificationParser {
     for dataLine in chunk.components(separatedBy: Self.dataLineSeparator.description) {
       switch DataLine(dataLine.trimmingCharacters(in: .newlines)) {
       case let .contentHeader(directives):
-        guard directives.contains("application/json") else {
+        guard directives.contains(where: { directive in
+          directive == "application/json" || directive == "application/graphql-response+json"
+        }) else {
           return .failure(ParsingError.unsupportedContentType(type: directives.joined(separator: ";")))
         }
 

--- a/apollo-ios/Sources/Apollo/MultipartResponseDeferParser.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseDeferParser.swift
@@ -53,9 +53,7 @@ struct MultipartResponseDeferParser: MultipartResponseSpecificationParser {
     for dataLine in chunk.components(separatedBy: Self.dataLineSeparator.description) {
       switch DataLine(dataLine.trimmingCharacters(in: .newlines)) {
       case let .contentHeader(directives):
-        guard directives.contains(where: { directive in
-          directive == "application/json" || directive == "application/graphql-response+json"
-        }) else {
+        guard directives.contains(where: { $0.isValidGraphQLContentType }) else {
           return .failure(ParsingError.unsupportedContentType(type: directives.joined(separator: ";")))
         }
 

--- a/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -194,4 +194,8 @@ extension String {
       .components(separatedBy: ";")
       .map({ $0.trimmingCharacters(in: .whitespaces) })
   }
+
+  var isValidGraphQLContentType: Bool {
+    self == "application/json" || self == "application/graphql-response+json"
+  }
 }

--- a/apollo-ios/Sources/Apollo/MultipartResponseSubscriptionParser.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseSubscriptionParser.swift
@@ -15,7 +15,7 @@ struct MultipartResponseSubscriptionParser: MultipartResponseSpecificationParser
       switch self {
 
       case let .unsupportedContentType(type):
-        return "Unsupported content type: application/json is required but got \(type)."
+        return "Unsupported content type: 'application/graphql-response+json' or 'application/json' are supported, received '\(type)'."
       case .cannotParseChunkData:
         return "The chunk data could not be parsed."
       case let .irrecoverableError(message):
@@ -71,7 +71,9 @@ struct MultipartResponseSubscriptionParser: MultipartResponseSpecificationParser
         break
 
       case let .contentHeader(directives):
-        guard directives.contains("application/json") else {
+        guard directives.contains(where: { directive in
+          directive == "application/json" || directive == "application/graphql-response+json"
+        }) else {
           return .failure(ParsingError.unsupportedContentType(type: directives.joined(separator: ";")))
         }
 

--- a/apollo-ios/Sources/Apollo/MultipartResponseSubscriptionParser.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseSubscriptionParser.swift
@@ -71,9 +71,7 @@ struct MultipartResponseSubscriptionParser: MultipartResponseSpecificationParser
         break
 
       case let .contentHeader(directives):
-        guard directives.contains(where: { directive in
-          directive == "application/json" || directive == "application/graphql-response+json"
-        }) else {
+        guard directives.contains(where: { $0.isValidGraphQLContentType }) else {
           return .failure(ParsingError.unsupportedContentType(type: directives.joined(separator: ";")))
         }
 

--- a/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -103,13 +103,13 @@ open class RequestChainNetworkTransport: NetworkTransport {
     if Operation.operationType == .subscription {
       request.addHeader(
         name: "Accept",
-        value: "multipart/mixed;\(MultipartResponseSubscriptionParser.protocolSpec),application/json"
+        value: "multipart/mixed;\(MultipartResponseSubscriptionParser.protocolSpec),application/graphql-response+json,application/json"
       )
 
     } else {
       request.addHeader(
         name: "Accept",
-        value: "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json"
+        value: "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/graphql-response+json,application/json"
       )
     }
 


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-ios/issues/3485.

1. Make sure we include the new type in the 'accept' request header.
2. Update tests for new content type.
3. There were no changes needed for error handling because [we do not throw when the response status code falls outside the 200..<300 range](https://github.com/apollographql/apollo-ios-dev/blob/main/apollo-ios/Sources/Apollo/ResponseCodeInterceptor.swift#L60).
4. Our non-multipart response parser does not require that the content type actually be `application/json`. Instead it simply attempts to [deserialize anything as if it is JSON](https://github.com/apollographql/apollo-ios-dev/blob/main/apollo-ios/Sources/Apollo/JSONResponseParsingInterceptor.swift#L54). It's only in the multipart parsers that we do a content type check for the chunks. @AnthonyMDev - this hasn't been an issue for now but do you think we should add this check? I'm inclined to leave the standard parser as it is.