### PR TITLE
Make `fetch(cachePolicy:)` `public` in `GraphQLQueryWatcher` so `ApolloClientProtocol.watch` can be mocked.

### DIFF
--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -73,7 +73,7 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
     fetch(cachePolicy: cachePolicy)
   }
 
-  func fetch(cachePolicy: CachePolicy) {
+  public func fetch(cachePolicy: CachePolicy) {
     $fetching.mutate {
       // Cancel anything already in flight before starting a new fetch
       $0.cancellable?.cancel()


### PR DESCRIPTION
I am implementing a `MockApolloClient`. It implements `ApolloClientProtocol`. I got to the point of implementing `watch(query:cachePolicy:context:callbackQueue:resultHandler:)`.

Looking at `ApolloClient`'s implementation, it's very simple:

```swift
    let watcher = GraphQLQueryWatcher(client: self,
                                      query: query,
                                      context: context,
                                      callbackQueue: callbackQueue,
                                      resultHandler: resultHandler)
    watcher.fetch(cachePolicy: cachePolicy)
    return watcher
```

It is basically implemented by passing `self` to `GraphQLQueryWatcher`, which interacts with that `ApolloClientProtocol` instance.

As far as I can see, the best way to implement `watch` in my `MockApolloClient` is by having basically the exact same code. I would pass in `self` (being the `MockApolloClient: ApolloClientProtocol`) into the `GraphQLQueryWatcher` initializer, call `fetch(cachePolicy:)` on it, and then return it.

However, `fetch(cachePolicy:)` is not `public` on `GraphQLQueryWatcher`, it's `internal`, so I can't do that.

I suspect this is a simple oversight.

I don't think it makes sense to re-implement `GraphQLQueryWatcher`, it'd be better to have the same logic powering watching in the `MockApolloClient` because it can operate in terms of the mock implementation of `ApolloClientProtocol.fetch` and `ApolloClientProtocol.store`. And frankly, it'd be impossible to do anything else because the `ApolloClientProtocol.watch` method is declared as returning `GraphQLQueryWatcher`, and `GraphQLQueryWatcher` itself is `public`, not `open` (just like `ApolloClient` itself), so the only thing I can possibly do is use `GraphQLQueryWatcher`, and that means needing to use its implementation as-is.

As such, this PR makes `fetch(cachePolicy:)` `public`. That's all it does.

Thank you for your consideration.