### PR TITLE
Replace Discord with Discourse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Excited about the Apollo iOS ecosystem and want to make it better? We’re excit
 
 Apollo is a community of developers just like you, striving to create the best tools and libraries around GraphQL. We welcome anyone who wants to contribute or provide constructive feedback, no matter your age or level of experience. If you want to help but don't know where to start, let us know, and we'll find something for you.
 
-Oh, and if you haven't already, stop by our [community forums](https://community.apollographql.com)!
+Oh, and if you haven't already, stop by our [Community Forum](https://community.apollographql.com)!
 
 ## Overview
 
@@ -106,7 +106,7 @@ At Apollo, we consider the security of our projects a top priority. No matter ho
 
 ### Responding to issues
 
-In addition to reporting issues, a great way to contribute to Apollo iOS is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. Don't forget to say "Hi" on our [community forums](https://community.apollographql.com/tag/mobile)!
+In addition to reporting issues, a great way to contribute to Apollo iOS is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. Don't forget to say "Hi" on our [Community Forum](https://community.apollographql.com/tag/mobile)!
 
 ### Suggesting features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Excited about the Apollo iOS ecosystem and want to make it better? We’re excit
 
 Apollo is a community of developers just like you, striving to create the best tools and libraries around GraphQL. We welcome anyone who wants to contribute or provide constructive feedback, no matter your age or level of experience. If you want to help but don't know where to start, let us know, and we'll find something for you.
 
-Oh, and if you haven't already, stop by our [Discord server](https://discord.gg/graphos) and [community forums](https://community.apollographql.com)!
+Oh, and if you haven't already, stop by our [community forums](https://community.apollographql.com)!
 
 ## Overview
 
@@ -106,7 +106,7 @@ At Apollo, we consider the security of our projects a top priority. No matter ho
 
 ### Responding to issues
 
-In addition to reporting issues, a great way to contribute to Apollo iOS is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. Don't forget to say "Hi" on our [community forums](https://community.apollographql.com/tag/mobile) and [Discord server](https://discord.com/invite/graphos)!
+In addition to reporting issues, a great way to contribute to Apollo iOS is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. Don't forget to say "Hi" on our [community forums](https://community.apollographql.com/tag/mobile)!
 
 ### Suggesting features
 

--- a/apollo-ios/.github/ISSUE_TEMPLATE/question.yaml
+++ b/apollo-ios/.github/ISSUE_TEMPLATE/question.yaml
@@ -10,7 +10,6 @@ body:
         - [Documentation](https://www.apollographql.com/docs/ios)
         - [GitHub issues](https://github.com/apollographql/apollo-ios/issues)
         - [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-ios)
-        - [GraphOS Discord](https://discord.com/invite/graphos)
         - [Community forums](https://community.apollographql.com/tag/mobile)
 
         Please avoid duplicating issues and discussions. If you'd like a GitHub issue to be reopened, leave a message on the issue.

--- a/docs/source/tutorial/tutorial-subscriptions.mdx
+++ b/docs/source/tutorial/tutorial-subscriptions.mdx
@@ -172,4 +172,4 @@ There are way more things you can do with the Apollo iOS SDK, and the rest of th
 - Working with [custom scalars](/ios/custom-scalars)
 - [Caching](/ios/caching/introduction)
 
-Feel free to ask questions by [joining the Apollo GraphQL Forum](http://community.apollographql.com/new-topic?category=Help&tags=mobile,client).
+Feel free to ask questions by [Apollo's Community Forum](http://community.apollographql.com/new-topic?category=Help&tags=mobile,client).

--- a/docs/source/tutorial/tutorial-subscriptions.mdx
+++ b/docs/source/tutorial/tutorial-subscriptions.mdx
@@ -172,4 +172,4 @@ There are way more things you can do with the Apollo iOS SDK, and the rest of th
 - Working with [custom scalars](/ios/custom-scalars)
 - [Caching](/ios/caching/introduction)
 
-Feel free to ask questions by [Apollo's Community Forum](http://community.apollographql.com/new-topic?category=Help&tags=mobile,client).
+Feel free to ask questions in [Apollo's Community Forum](http://community.apollographql.com/new-topic?category=Help&tags=mobile,client).

--- a/docs/source/tutorial/tutorial-subscriptions.mdx
+++ b/docs/source/tutorial/tutorial-subscriptions.mdx
@@ -172,4 +172,4 @@ There are way more things you can do with the Apollo iOS SDK, and the rest of th
 - Working with [custom scalars](/ios/custom-scalars)
 - [Caching](/ios/caching/introduction)
 
-Feel free to ask questions by either [joining our Discord server](https://discord.gg/GraphOS) or [joining the Apollo GraphQL Forum](http://community.apollographql.com/new-topic?category=Help&tags=mobile,client).
+Feel free to ask questions by [joining the Apollo GraphQL Forum](http://community.apollographql.com/new-topic?category=Help&tags=mobile,client).


### PR DESCRIPTION
Replace Discord with Discourse links since the Discourse Community Forum there is becoming our focus.