### PR TITLE
docs: add meta descriptions and subtitles

### DIFF
--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Apollo iOS
 subtitle: Integrate Apollo iOS into your app
-description: Learn how to add Apollo iOS to your app with step-by-step instructions for installation, schema integration, code generation, and setting up ApolloClient for type-safe GraphQL operations.
+description: Learn how to add Apollo iOS to your app with step-by-step instructions for installation, schema integration, code generation, and setting up a client instance for type-safe GraphQL operations.
 sidebar_title: Get Started
 ---
 

--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -1,5 +1,7 @@
 ---
 title: Getting Started with Apollo iOS
+subtitle: Integrate Apollo iOS into your app
+description: Learn how to add Apollo iOS to your app with step-by-step instructions for installation, schema integration, code generation, and setting up ApolloClient for type-safe GraphQL operations.
 sidebar_title: Get Started
 ---
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Introduction to Apollo iOS
-description: A strongly typed, Swift-first GraphQL client
+subtitle: Learn how Apollo iOS, a Swift-first GraphQL client simplifies GraphQL operations with strongly-typed models, caching, and more
+description: Discover how Apollo iOS, a Swift-first, open-source GraphQL client offers type-safe code generation, caching, and robust networking.
 ---
 
 **Apollo iOS** is an [open-source](https://github.com/apollographql/apollo-ios) GraphQL client for native client applications, written in Swift.

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction to Apollo iOS
-subtitle: Learn how Apollo iOS, a Swift-first GraphQL client simplifies GraphQL operations with strongly-typed models, caching, and more
+subtitle: Learn how Apollo iOS, a Swift-first GraphQL client, simplifies GraphQL data management
 description: Discover how Apollo iOS, a Swift-first, open-source GraphQL client offers type-safe code generation, caching, and robust networking.
 ---
 


### PR DESCRIPTION
Add meta descriptions and subtitles to help with discoverability of top-level pages