### PR TITLE
[Codegen]: Partial fragments

### DIFF
--- a/apollo-ios-codegen/Sources/IR/IR+NamedFragment.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+NamedFragment.swift
@@ -51,3 +51,15 @@ public class NamedFragment: Definition, Hashable, CustomDebugStringConvertible {
     definition.debugDescription
   }
 }
+
+public extension NamedFragment {
+  func partialFragment() -> NamedFragment {
+    NamedFragment(
+      definition: definition,
+      rootField: rootField,
+      referencedFragments: referencedFragments,
+      entityStorage: entityStorage.partial(),
+      containsDeferredFragment: containsDeferredFragment
+    )
+  }
+}

--- a/apollo-ios-codegen/Sources/IR/IR+RootFieldBuilder.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+RootFieldBuilder.swift
@@ -398,7 +398,7 @@ class RootFieldBuilder {
     spreadIntoParentWithTypePath parentTypeInfo: SelectionSet.TypeInfo,
     deferCondition: CompilationResult.DeferCondition? = nil
   ) async -> NamedFragmentSpread {
-    let fragment = await ir.build(fragment: fragmentSpread.fragment)
+    let fragment = await ir.build(fragment: fragmentSpread.fragment, shouldGeneratePartialFragment: true)
     referencedFragments.append(fragment)
     referencedFragments.append(contentsOf: fragment.referencedFragments)
 
@@ -410,7 +410,7 @@ class RootFieldBuilder {
 
     self.containsDeferredFragment = fragment.containsDeferredFragment || scope.deferCondition != nil
 
-    let scopePath = scope.isEmpty 
+    let scopePath = scope.isEmpty
       ? parentTypeInfo.scopePath
       : parentTypeInfo.scopePath.mutatingLast { $0.appending(scope) }
 

--- a/apollo-ios-codegen/Sources/IR/IRBuilder.swift
+++ b/apollo-ios-codegen/Sources/IR/IRBuilder.swift
@@ -23,7 +23,8 @@ public class IRBuilder {
   }
 
   public func build(
-    operation operationDefinition: CompilationResult.OperationDefinition
+    operation operationDefinition: CompilationResult.OperationDefinition,
+    usePartialEntities: Bool = false
   ) async -> Operation {
     let rootField = CompilationResult.Field(
       name: operationDefinition.operationType.rawValue,
@@ -86,9 +87,11 @@ public class IRBuilder {
   }
 
   public func build(
-    fragment fragmentDefinition: CompilationResult.FragmentDefinition
+    fragment fragmentDefinition: CompilationResult.FragmentDefinition,
+    shouldGeneratePartialFragment: Bool = false
   ) async -> NamedFragment {
-    await builtFragmentStorage.getFragment(named: fragmentDefinition.name) {
+
+    let namedFragment = await builtFragmentStorage.getFragment(named: fragmentDefinition.name) {
       let rootField = CompilationResult.Field(
         name: fragmentDefinition.name,
         type: .nonNull(.entity(fragmentDefinition.type)),
@@ -113,6 +116,10 @@ public class IRBuilder {
         containsDeferredFragment: result.containsDeferredFragment
       )
     }
-  }
 
+    if shouldGeneratePartialFragment {
+      return namedFragment.partialFragment()
+    }
+    return namedFragment
+  }
 }


### PR DESCRIPTION
We are currently migrating to the new Apollo codegen.

The new codegen tool runs for over 30 minutes and uses a lot of memory to generate the latest Swift types, and our CI is failing to complete. I suspect this thread might be related to https://github.com/apollographql/apollo-ios/issues/3434.

I am opening this pull request to propose changes and gather feedback from the repo authors.

**The current flow:**
Whenever the [RootFieldBuilder](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IR%2BRootFieldBuilder.swift#L6) builds named fragments via [buildNamedFragmentSpread](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IR%2BRootFieldBuilder.swift#L401). The codegen flow will eventually reuse/create a previously built fragment from [BuiltFragmentStorage](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IRBuilder.swift#L53). Once resolved, a [NamedFragment](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IR%2BNamedFragment.swift#L4) type would be returned by the codegen flow and will merge the [Entity](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IR%2BEntity.swift#L8) fields to build up the [EntitySelectionTree](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IR%2BEntitySelectionTree.swift#L15) in the Selection Set which references the named fragment.

![Blank diagram (7)](https://github.com/user-attachments/assets/a09e50ad-94cf-4bbd-9844-6685fd24bbae)

The fragments resolved from [BuiltFragmentStorage](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IRBuilder.swift#L53) are eventually referenced to it's previously created swift file.

Some fragments can contain very large amounts of [Entity](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IR%2BEntity.swift#L8) fields which might not be relevant for referencing intents.

With this pull request, I suggest adding support for partial [NamedFragment](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IR%2BNamedFragment.swift#L4) to **reduce the amount of data merged into the containing EntitySelectionTree**.

The intention of partial fragments is to return a [NamedFragment](https://github.com/apollographql/apollo-ios-codegen/blob/6db35551c7bc0879b61539c08338253a7b4a146b/Sources/IR/IR%2BNamedFragment.swift#L4) which contain entities necessary for **referencing** intents. (ex: field for inlineFragments, references for **referencedFragments** etc.)

![Copy of Blank diagram](https://github.com/user-attachments/assets/d1fdc251-0304-4acd-a47a-f8d2324d80e5)

In this example, I am naively reducing the number of entities that have FieldPaths deeper than 3 (?)
I was also considering an experimental flag along to the config, however I've limited the amount of changes to gather initial feedback.

**Why 3**? Assumption: entities containing the fields to be spread into the containing inline fragment + underlying fragments and their fields. (maybe rather than naively filtering a depth of 3 a better approach would be to filter by definition/GraphQLType)

![Blank diagram (8) (1)](https://github.com/user-attachments/assets/caf6d800-30d6-430a-a231-cb08cf3bd558)
I'm not however familiar with all edge cases and would appreciate any suggestions and reviews.

With this change, the same output is generated against our schema, but the duration is reduced from 30 minutes to 3 minutes, and memory usage has decreased to 400 MB.