### PR TITLE
Prevent merging of fragment fields into selection tree if fragment field merging is disabled

### DIFF
--- a/Tests/ApolloCodegenInternalTestHelpers/IRBuilderTestWrapper.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/IRBuilderTestWrapper.swift
@@ -24,7 +24,10 @@ public class IRBuilderTestWrapper {
     operation operationDefinition: CompilationResult.OperationDefinition,
     mergingStrategy: MergedSelections.MergingStrategy = .all
   ) async -> IRTestWrapper<IR.Operation> {
-    let operation = await irBuilder.build(operation: operationDefinition)
+    let operation = await irBuilder.build(
+      operation: operationDefinition,
+      mergingNamedFragmentFields: mergingStrategy.contains(.namedFragments)
+    )
     return IRTestWrapper(
       irObject: operation,
       computedSelectionSetCache: .init(
@@ -38,7 +41,10 @@ public class IRBuilderTestWrapper {
     fragment fragmentDefinition: CompilationResult.FragmentDefinition,
     mergingStrategy: MergedSelections.MergingStrategy = .all
   ) async -> IRTestWrapper<IR.NamedFragment> {
-    let fragment = await irBuilder.build(fragment: fragmentDefinition)
+    let fragment = await irBuilder.build(
+      fragment: fragmentDefinition,
+      mergingNamedFragmentFields: mergingStrategy.contains(.namedFragments)
+    )
     return IRTestWrapper(
       irObject: fragment,
       computedSelectionSetCache: .init(

--- a/apollo-ios-codegen/Sources/IR/IRBuilder.swift
+++ b/apollo-ios-codegen/Sources/IR/IRBuilder.swift
@@ -23,7 +23,8 @@ public class IRBuilder {
   }
 
   public func build(
-    operation operationDefinition: CompilationResult.OperationDefinition
+    operation operationDefinition: CompilationResult.OperationDefinition,
+    mergingNamedFragmentFields: Bool = true
   ) async -> Operation {
     let rootField = CompilationResult.Field(
       name: operationDefinition.operationType.rawValue,
@@ -38,7 +39,8 @@ public class IRBuilder {
     let result = await RootFieldBuilder.buildRootEntityField(
       forRootField: rootField,
       onRootEntity: rootEntity,
-      inIR: self
+      inIR: self,
+      mergingNamedFragmentFields: mergingNamedFragmentFields
     )
 
     return Operation(
@@ -86,7 +88,8 @@ public class IRBuilder {
   }
 
   public func build(
-    fragment fragmentDefinition: CompilationResult.FragmentDefinition
+    fragment fragmentDefinition: CompilationResult.FragmentDefinition,
+    mergingNamedFragmentFields: Bool = true
   ) async -> NamedFragment {
     await builtFragmentStorage.getFragment(named: fragmentDefinition.name) {
       let rootField = CompilationResult.Field(
@@ -102,7 +105,8 @@ public class IRBuilder {
       let result = await RootFieldBuilder.buildRootEntityField(
         forRootField: rootField,
         onRootEntity: rootEntity,
-        inIR: self
+        inIR: self,
+        mergingNamedFragmentFields: mergingNamedFragmentFields
       )
 
       return NamedFragment(


### PR DESCRIPTION
Currently, when fragment field merging is disabled we are preventing the fields from being merged into the `MergedSelections` while traversing the built `EntitySelectionTree`. However, the performance issues described in https://github.com/apollographql/apollo-ios/issues/3434 are actually caused during the merging of the fragment fields _into_ the `EntitySelectionTree`s during the building of the operations.

This PR prevents the fragment selection trees from being merged into the `EntitySelectionTree` while building the operations **if fragment field merging is disabled**.

This means that the entity trees are actually incomplete, but they still work for the purposes of Codegen in this scenario. Incomplete `EntitySelectionTree`s would cause selection set initializers to be invalid. But this is not a problem because disabling fragment field merging is already incompatible with selection set initializers (and we have a validation step to ensure those options are not used together).