### PR TITLE
fix: Multipart chunk content type

### DIFF
--- a/Tests/ApolloTests/Interceptors/MultipartResponseDeferParserTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseDeferParserTests.swift
@@ -137,7 +137,7 @@ final class MultipartResponseDeferParserTests: XCTestCase {
         data: """
           
           --graphql
-          content-type: application/json
+          Content-Type: application/json; charset=utf-8
 
           {
             "data" : {

--- a/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
@@ -438,6 +438,47 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
     let network = buildNetworkTransport(responseData: """
       
       --graphql
+      content-type: application/json
+
+      {
+        "payload": {
+          "data": {
+            "__typename": "Time",
+            "ticker": 1
+          }
+        }
+      }
+      --graphql--
+      """.crlfFormattedData()
+    )
+
+    let expectedData = try Time(data: [
+      "__typename": "Time",
+      "ticker": 1
+    ], variables: nil)
+
+    let expectation = expectation(description: "Multipart data received")
+
+    _ = network.send(operation: MockSubscription<Time>()) { result in
+      defer {
+        expectation.fulfill()
+      }
+
+      switch (result) {
+      case let .success(data):
+        expect(data.data).to(equal(expectedData))
+      case let .failure(error):
+        fail("Unexpected failure result - \(error)")
+      }
+    }
+
+    wait(for: [expectation], timeout: defaultTimeout)
+  }
+
+  func test__parsing__givenSingleChunk_withMultipleContentTypeDirectives_shouldReturnSuccess() throws {
+    let network = buildNetworkTransport(responseData: """
+      
+      --graphql
       Content-Type: application/json; charset=utf-8
 
       {

--- a/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseSubscriptionParserTests.swift
@@ -438,7 +438,7 @@ final class MultipartResponseSubscriptionParserTests: XCTestCase {
     let network = buildNetworkTransport(responseData: """
       
       --graphql
-      content-type: application/json
+      Content-Type: application/json; charset=utf-8
 
       {
         "payload": {

--- a/apollo-ios/Sources/Apollo/MultipartResponseDeferParser.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseDeferParser.swift
@@ -23,7 +23,7 @@ struct MultipartResponseDeferParser: MultipartResponseSpecificationParser {
   }
 
   private enum DataLine {
-    case contentHeader(type: String)
+    case contentHeader(directives: [String])
     case json(object: JSONObject)
     case unknown
 
@@ -32,14 +32,8 @@ struct MultipartResponseDeferParser: MultipartResponseSpecificationParser {
     }
 
     private static func parse(_ dataLine: String) -> DataLine {
-      var contentTypeHeader: StaticString { "content-type:" }
-
-      if dataLine.starts(with: contentTypeHeader.description) {
-        let contentType = (dataLine
-          .components(separatedBy: ":").last ?? dataLine
-        ).trimmingCharacters(in: .whitespaces)
-
-        return .contentHeader(type: contentType)
+      if let directives = dataLine.parseContentTypeDirectives() {
+        return .contentHeader(directives: directives)
       }
 
       if
@@ -58,9 +52,9 @@ struct MultipartResponseDeferParser: MultipartResponseSpecificationParser {
   static func parse(_ chunk: String) -> Result<Data?, any Error> {
     for dataLine in chunk.components(separatedBy: Self.dataLineSeparator.description) {
       switch DataLine(dataLine.trimmingCharacters(in: .newlines)) {
-      case let .contentHeader(type):
-        guard type == "application/json" else {
-          return .failure(ParsingError.unsupportedContentType(type: type))
+      case let .contentHeader(directives):
+        guard directives.contains("application/json") else {
+          return .failure(ParsingError.unsupportedContentType(type: directives.joined(separator: ";")))
         }
 
       case let .json(object):

--- a/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -182,4 +182,16 @@ extension String {
 
     return nil
   }
+
+  func parseContentTypeDirectives() -> [String]? {
+    var lowercasedContentTypeHeader: StaticString { "content-type:" }
+
+    guard lowercased().starts(with: lowercasedContentTypeHeader.description) else {
+      return nil
+    }
+
+    return dropFirst(lowercasedContentTypeHeader.description.count)
+      .components(separatedBy: ";")
+      .map({ $0.trimmingCharacters(in: .whitespaces) })
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3495.

Refactored the parsing of `content-type` to handle multiple directives, which resolved the bug but also removed duplicated code. and allows for all directives to be used.