### PR TITLE
chore: Use Xcode 16.2 on Swift 6 CI jobs

### DIFF
--- a/.github/workflows/ci-tests-xcode-swift-6.yml
+++ b/.github/workflows/ci-tests-xcode-swift-6.yml
@@ -1,11 +1,11 @@
-name: "CI Tests (Xcode 16.1)"
+name: "CI Tests (Xcode 16.2)"
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 env:
-  XCODE_VERSION: "16.1"
+  XCODE_VERSION: "16.2"
 
 jobs:
   changes:


### PR DESCRIPTION
Bumps the Xcode version to 16.2 for our "Swift 6" CI jobs.