### PR TITLE
fix: Defer metadata extensions

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/DeferredFragmentsMetadataTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/DeferredFragmentsMetadataTemplateTests.swift
@@ -87,17 +87,15 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.root: Data.AllAnimal.Root.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.root: Data.AllAnimal.Root.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)
@@ -136,17 +134,15 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.root: Data.AllAnimal.Root.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.root: Data.AllAnimal.Root.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)
@@ -190,17 +186,15 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.root: Data.AllAnimal.AsDog.Root.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.root: Data.AllAnimal.AsDog.Root.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)
@@ -249,19 +243,17 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let one = DeferredFragmentIdentifier(label: "one", fieldPath: ["allAnimals"])
-          static let two = DeferredFragmentIdentifier(label: "two", fieldPath: ["allAnimals"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.one: Data.AllAnimal.AsDog.One.self,
-          DeferredFragmentIdentifiers.two: Data.AllAnimal.AsDog.Two.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let one = DeferredFragmentIdentifier(label: "one", fieldPath: ["allAnimals"])
+        static let two = DeferredFragmentIdentifier(label: "two", fieldPath: ["allAnimals"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.one: Data.AllAnimal.AsDog.One.self,
+        DeferredFragmentIdentifiers.two: Data.AllAnimal.AsDog.Two.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)
@@ -316,19 +308,17 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let one = DeferredFragmentIdentifier(label: "one", fieldPath: ["allAnimals"])
-          static let two = DeferredFragmentIdentifier(label: "two", fieldPath: ["allAnimals"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.one: Data.AllAnimal.AsDog.One.self,
-          DeferredFragmentIdentifiers.two: Data.AllAnimal.AsCat.Two.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let one = DeferredFragmentIdentifier(label: "one", fieldPath: ["allAnimals"])
+        static let two = DeferredFragmentIdentifier(label: "two", fieldPath: ["allAnimals"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.one: Data.AllAnimal.AsDog.One.self,
+        DeferredFragmentIdentifiers.two: Data.AllAnimal.AsCat.Two.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)
@@ -386,19 +376,17 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let outer = DeferredFragmentIdentifier(label: "outer", fieldPath: ["allAnimals"])
-          static let inner = DeferredFragmentIdentifier(label: "inner", fieldPath: ["allAnimals", "friend"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.outer: Data.AllAnimal.AsDog.Outer.self,
-          DeferredFragmentIdentifiers.inner: Data.AllAnimal.AsDog.Outer.Friend.AsCat.Inner.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let outer = DeferredFragmentIdentifier(label: "outer", fieldPath: ["allAnimals"])
+        static let inner = DeferredFragmentIdentifier(label: "inner", fieldPath: ["allAnimals", "friend"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.outer: Data.AllAnimal.AsDog.Outer.self,
+        DeferredFragmentIdentifiers.inner: Data.AllAnimal.AsDog.Outer.Friend.AsCat.Inner.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)
@@ -441,17 +429,15 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.root: AnimalFragment.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.root: AnimalFragment.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)
@@ -496,17 +482,15 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.root: DogFragment.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.root: DogFragment.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)
@@ -554,17 +538,15 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.root: Data.Root.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.root: Data.Root.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)
@@ -612,17 +594,15 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     let rendered = renderSubject()
     
     expect(rendered).to(equalLineByLine("""
-      // MARK: Deferred Fragment Metadata
+      // MARK: - Deferred Fragment Metadata
 
-      extension TestOperationQuery {
-        enum DeferredFragmentIdentifiers {
-          static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
-        }
-
-        static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
-          DeferredFragmentIdentifiers.root: Data.AsDog.Root.self,
-        ]}
+      enum DeferredFragmentIdentifiers {
+        static let root = DeferredFragmentIdentifier(label: "root", fieldPath: ["allAnimals"])
       }
+
+      public static var deferredFragments: [DeferredFragmentIdentifier: any ApolloAPI.SelectionSet.Type]? {[
+        DeferredFragmentIdentifiers.root: Data.AsDog.Root.self,
+      ]}
       """,
       atLine: 2,
       ignoringExtraLines: false)

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/DeferredFragmentsMetadataTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/DeferredFragmentsMetadataTemplate.swift
@@ -31,13 +31,11 @@ struct DeferredFragmentsMetadataTemplate {
 
     return """
 
-    // MARK: Deferred Fragment Metadata
+    // MARK: - Deferred Fragment Metadata
 
-    \(renderAccessControl())extension \(operation.generatedDefinitionName) {
-      \(DeferredFragmentIdentifiersTemplate(deferredFragmentPathTypeInfo))
+    \(DeferredFragmentIdentifiersTemplate(deferredFragmentPathTypeInfo))
 
-      \(DeferredFragmentsPropertyTemplate(deferredFragmentPathTypeInfo))
-    }
+    \(DeferredFragmentsPropertyTemplate(deferredFragmentPathTypeInfo))
     """
   }
 
@@ -61,7 +59,7 @@ struct DeferredFragmentsMetadataTemplate {
     _ deferredFragmentPathTypeInfo: [DeferredPathTypeInfo]
   ) -> TemplateString {
     """
-    static var deferredFragments: [DeferredFragmentIdentifier: any \(config.ApolloAPITargetName).SelectionSet.Type]? {[
+    public static var deferredFragments: [DeferredFragmentIdentifier: any \(config.ApolloAPITargetName).SelectionSet.Type]? {[
     \(deferredFragmentPathTypeInfo.map {
       return """
         DeferredFragmentIdentifiers.\($0.deferCondition.label): \($0.typeName).self,

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -41,12 +41,12 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
             renderAccessControl: { accessControlModifier(for: .member) }()
         ).renderBody())
       }
+      \(DeferredFragmentsMetadataTemplate(
+        operation: operation,
+        config: config,
+        renderAccessControl: { accessControlModifier(for: .parent) }()
+      ).render())
     }
-    \(DeferredFragmentsMetadataTemplate(
-      operation: operation,
-      config: config,
-      renderAccessControl: { accessControlModifier(for: .parent) }()
-    ).render())
 
     """)
   }


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3503

This implements solution 2 in the issue description for the following reasons:
* This diff is minimal and resolves the issue for all module types. We could keep the extension but we're going to end up with multiple templates that need to handle the metadata insertion = IMO less optimal.
* I don't see any benefit to having the defer metadata within the same file but in an extension. The metadata is partitioned with a `MARK` comment line.
* Operation files also do not support custom edits so there is no need to preserve anything about previously generated operation files.