### PR TITLE
feature: Emit Identifiable conformance on SelectionSets

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -125,6 +125,154 @@ class SelectionSetTemplateTests: XCTestCase {
     // then
     expect(String(actual.reversed())).to(equalLineByLine("}", ignoringExtraLines: true))
   }
+  
+  // MARK: Protocol conformance
+  
+  func test__render_selectionSet__givenTypeWithKeyFieldID_rendersIdentifiableConformance() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal @typePolicy(keyFields: "id") {
+      id: ID!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        id
+      }
+    }
+    """
+
+    let expected = """
+    public struct AllAnimal: TestSchema.SelectionSet, Identifiable {
+    """
+
+    // when
+    try await buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 2, ignoringExtraLines: true))
+  }
+  
+  func test__render_selectionSet__givenInterfaceWithKeyFieldID_rendersIdentifiableConformance() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal @typePolicy(keyFields: "id") {
+      id: ID!
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        id
+      }
+    }
+    """
+
+    let expected = """
+    public struct AllAnimal: TestSchema.SelectionSet, Identifiable {
+    """
+
+    // when
+    try await buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 2, ignoringExtraLines: true))
+  }
+  
+  func test__render_selectionSet__givenTypeWithOtherKeyField_doesNotRenderIdentifiableConformance() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal @typePolicy(keyFields: "species") {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        species
+      }
+    }
+    """
+
+    let expected = """
+    public struct AllAnimal: TestSchema.SelectionSet {
+    """
+
+    // when
+    try await buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 2, ignoringExtraLines: true))
+  }
+  
+  func test__render_selectionSet__withoutUsingIDField_doesNotRenderIdentifiableConformance() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal @typePolicy(keyFields: "id") {
+      id: ID!
+      name: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        name
+      }
+    }
+    """
+
+    let expected = """
+    public struct AllAnimal: TestSchema.SelectionSet {
+    """
+
+    // when
+    try await buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 2, ignoringExtraLines: true))
+  }
 
   // MARK: Parent Type
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -102,7 +102,9 @@ struct SelectionSetTemplate {
       """
       \(SelectionSetNameDocumentation(selectionSet))
       \(renderAccessControl())\
-      struct \(fieldSelectionSetName): \(SelectionSetType()) {
+      struct \(fieldSelectionSetName): \(SelectionSetType())\
+      \(if: selectionSet.isIdentifiable, ", Identifiable")\
+       {
         \(BodyTemplate(context))
       }
       """
@@ -118,6 +120,7 @@ struct SelectionSetTemplate {
       \(renderAccessControl())\
       struct \(inlineFragment.renderedTypeName): \(SelectionSetType(asInlineFragment: true))\
       \(if: inlineFragment.isCompositeInlineFragment, ", \(config.ApolloAPITargetName).CompositeInlineFragment")\
+      \(if: inlineFragment.isIdentifiable, ", Identifiable")\
        {
         \(BodyTemplate(context))
       }

--- a/apollo-ios-codegen/Sources/IR/IR+ComputedSelectionSet.swift
+++ b/apollo-ios-codegen/Sources/IR/IR+ComputedSelectionSet.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GraphQLCompiler
 import OrderedCollections
 import Utilities
 
@@ -18,6 +19,24 @@ public struct ComputedSelectionSet {
 
   /// The `TypeInfo` for the selection set of the computed selections
   public let typeInfo: IR.SelectionSet.TypeInfo
+  
+  /// Indicates if the parent type has a single keyField named `id`.
+  public var isIdentifiable: Bool {
+    guard direct?.fields["id"] != nil || merged.fields["id"] != nil else {
+      return false
+    }
+    if let type = typeInfo.parentType as? GraphQLObjectType,
+       type.keyFields == ["id"] {
+      return true
+    }
+    
+    if let type = typeInfo.parentType as? GraphQLInterfaceType,
+       type.keyFields == ["id"] {
+      return true
+    }
+    
+    return false
+  }
 
   // MARK: Dynamic Member Subscript
 


### PR DESCRIPTION
This is a rework of #548, except this time it will only emit a conformance if the `keyFields` is set to exactly `["id"]` (instead of assuming the presence of an `id` field is enough).

If a type has a field named `id` it is actually impossible to override the behavior of `Identifiable`, so I believe there is no situation in which an automatic conformance to Identifiable isn't desirable.

This PR will not generate a getter named `id` (as was proposed earlier), so there won't be an unexpected field named `id` in any case.