### PR TITLE
fix: `DataDict` initialization of `deferredFragments` for named fragments

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -2749,7 +2749,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
               ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self)
             ],
             deferredFragments: [
-              ObjectIdentifier(TestOperationQuery.Data.AllAnimal.SlowSpecies.self)
+              ObjectIdentifier(AnimalFragment.self)
             ]
           ))
         }
@@ -2814,7 +2814,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
               ObjectIdentifier(TestOperationQuery.Data.AllAnimal.AsDog.self)
             ],
             deferredFragments: [
-              ObjectIdentifier(TestOperationQuery.Data.AllAnimal.AsDog.SlowSpecies.self)
+              ObjectIdentifier(DogFragment.self)
             ]
           ))
         }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -732,25 +732,20 @@ struct SelectionSetTemplate {
 
     var deferredFragments: OrderedSet<String> = []
 
-    let nameGenerator: (_ typeInfo: SelectionSet.TypeInfo) -> String = { typeInfo in
-      SelectionSetNameGenerator.generatedSelectionSetName(
-        for: typeInfo,
-        format: .fullyQualified,
-        pluralizer: config.pluralizer
-      )
-    }
-
     for inlineFragmentSpread in directSelections.inlineFragments.values.elements {
       if inlineFragmentSpread.typeInfo.isDeferred {
-        let selectionSetName = nameGenerator(inlineFragmentSpread.typeInfo)
+        let selectionSetName = SelectionSetNameGenerator.generatedSelectionSetName(
+          for: inlineFragmentSpread.typeInfo,
+          format: .fullyQualified,
+          pluralizer: config.pluralizer
+        )
         deferredFragments.append(selectionSetName)
       }
     }
 
     for namedFragment in directSelections.namedFragments.values.elements {
       if namedFragment.typeInfo.isDeferred {
-        let selectionSetName = nameGenerator(namedFragment.typeInfo)
-        deferredFragments.append(selectionSetName)
+        deferredFragments.append(namedFragment.fragment.generatedDefinitionName)
       }
     }
 


### PR DESCRIPTION
_Discovered this bug when working on the selection set initializers for defer._

When deferred fragments are named fragments the deferred type is the fragments generated definition name.