### PR TITLE
Propagate likely unrecoverable watch errors to result handler

### DIFF
--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -139,6 +139,9 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
           if self.refetchOnFailedUpdates && self.fetching.cachePolicy != .returnCacheDataDontFetch {
             // If the cache fetch is not successful, for instance if the data is missing, refresh from the server.
             self.fetch(cachePolicy: .fetchIgnoringCacheData)
+          } else {
+            // Propagate the error so the watcher knows something is wrong.
+            self.resultHandler(result)
           }
         }
       }


### PR DESCRIPTION
Addresses [#3507](https://github.com/apollographql/apollo-ios/issues/3507)

I know creating a PR on a repo before maintainers have had a chance to review or comment on the linked issue is not a great practice. Please review this PR in the spirit in which it is given: as a starting discussion point and an attempt to further elucidate the points made in [#3507](https://github.com/apollographql/apollo-ios/issues/3507).

Getting this change to pass CI is going to take some doing – it looks like `AsyncResultObserver` expects that _any_ call to `resultHandler` triggers a refetch, which doesn't seem to true to me. I'd love some guidance before I try to shave that yak.