### PR TITLE
ci: Use trigger event with base branch context

### DIFF
--- a/.github/workflows/check-pr-metadata.yml
+++ b/.github/workflows/check-pr-metadata.yml
@@ -1,8 +1,8 @@
 name: Check PR Metadata
 
 on:
-  pull_request:
-    types: [ready_for_review, opened]
+  pull_request_target:
+    types: [ready_for_review, opened, reopened]
 
 jobs:
   check-pr-metadata:


### PR DESCRIPTION
I noticed that the 'Check PR Metadata' CI check was not always running or failing with the following error:
> GraphQL: Resource not accessible by integration (addComment)

I did some reading and from [this issue](https://github.com/cli/cli/issues/8374#issuecomment-1840846179) it seems as if the correct event to base the action on is `pull_request_target` rather than `pull_request` because of the need to elevate permissions for the action. The following in the [GitHub documentation for `pull_request_target`](https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) is the relevant section:
> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the `pull_request` event does.

* _I added the `reopened` event to the types that would trigger this check too._