### PR TITLE
fix: InputObject GraphQLNullable subscript

### DIFF
--- a/.github/workflows/ci-tests-xcode-swift-6.yml
+++ b/.github/workflows/ci-tests-xcode-swift-6.yml
@@ -152,14 +152,14 @@ jobs:
         npm install && npm test
     - name: Save xcodebuild logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-logs
         path: |
           DerivedData/Logs/Build
     - name: Save crash logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-crashes
         path: |
@@ -172,7 +172,7 @@ jobs:
         zip -r ResultBundle.zip ResultBundle.xcresult
     - name: Save test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-results
         path: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -162,14 +162,14 @@ jobs:
         npm install && npm test
     - name: Save xcodebuild logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-logs
         path: |
           DerivedData/Logs/Build
     - name: Save crash logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-crashes
         path: |
@@ -182,7 +182,7 @@ jobs:
         zip -r ResultBundle.zip ResultBundle.xcresult
     - name: Save test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-results
         path: |

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -126,14 +126,14 @@ jobs:
         npm install && npm test
     - name: Save xcodebuild logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-logs
         path: |
           DerivedData/Logs/Build
     - name: Save crash logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-crashes
         path: |
@@ -146,7 +146,7 @@ jobs:
         zip -r ResultBundle.zip ResultBundle.xcresult
     - name: Save test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-results
         path: |

--- a/Tests/ApolloTests/InputDictTests.swift
+++ b/Tests/ApolloTests/InputDictTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import Nimble
+import ApolloAPI
+
+final class InputDictTests: XCTestCase {
+
+  private struct OperationInput: InputObject {
+    public private(set) var __data: InputDict
+
+    public init(_ data: InputDict) {
+      __data = data
+    }
+
+    public init(
+      stringField: String,
+      nullableField: GraphQLNullable<String> = nil
+    ) {
+      __data = InputDict([
+        "stringField": stringField,
+        "nullableField": nullableField
+      ])
+    }
+
+    public var stringField: String {
+      get { __data["stringField"] }
+      set { __data["stringField"] = newValue }
+    }
+
+    public var nullableField: GraphQLNullable<String> {
+      get { __data["nullableField"] }
+      set { __data["nullableField"] = newValue }
+    }
+  }
+
+  func test__accessor__givenInputObjectNullableFieldInitializedWithDefaultValue_whenAccessingField_shouldEqualNilOrGraphQLNullableNone() throws {
+    // given
+    let input = OperationInput(stringField: "Something")
+
+    // when
+    let stringValue = input.stringField
+    let nullableValue = input.nullableField
+
+    // then
+    expect(stringValue).to(equal("Something"))
+
+    expect(nullableValue).to(equal(GraphQLNullable<String>.none))
+    expect(nullableValue.unwrapped).to(beNil())
+    XCTAssertEqual(nullableValue, nil)
+  }
+
+  func test__accessor__givenInputObjectNullableFieldInitializedWithValue_whenAccessingField_shouldEqualnitializedValue() throws {
+    // given
+    let input = OperationInput(stringField: "Something", nullableField: "AnotherThing")
+
+    // when
+    let stringValue = input.stringField
+    let nullableValue = input.nullableField
+
+    // then
+    expect(stringValue).to(equal("Something"))
+
+    expect(nullableValue).to(equal(GraphQLNullable.some("AnotherThing")))
+    expect(nullableValue).to(equal("AnotherThing"))
+    expect(nullableValue.unwrapped).to(equal("AnotherThing"))
+  }
+
+  func test__accessor__givenInputObjectNullableFieldInitializedWithNullValue_whenAccessingField_shouldEqualGraphQLNullableNull() throws {
+    // given
+    let input = OperationInput(stringField: "Something", nullableField: .null)
+
+    // when
+    let stringValue = input.stringField
+    let nullableValue = input.nullableField
+
+    // then
+    expect(stringValue).to(equal("Something"))
+
+    expect(nullableValue).to(equal(GraphQLNullable<String>.null))
+  }
+
+}

--- a/apollo-ios/Sources/ApolloAPI/SchemaTypes/InputObject.swift
+++ b/apollo-ios/Sources/ApolloAPI/SchemaTypes/InputObject.swift
@@ -30,8 +30,20 @@ public struct InputDict: GraphQLOperationVariableValue, Hashable {
 
   public var _jsonEncodableValue: (any JSONEncodable)? { data._jsonEncodableObject }
 
+  @_disfavoredOverload
   public subscript<T: GraphQLOperationVariableValue>(key: String) -> T {
     get { data[key] as! T }
+    set { data[key] = newValue }
+  }
+
+  public subscript<T: GraphQLOperationVariableValue>(key: String) -> GraphQLNullable<T> {
+    get {
+      if let value = data[key] {
+        return value as! GraphQLNullable<T>
+      }
+
+      return .none
+    }
     set { data[key] = newValue }
   }
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3506.

`InputObject` needed a `GraphQLNullable`-specific subscript to prevent `nil` value keys being forcefully unwrapped.