### PR TITLE
ci: Update to use upload-artifact@v4 action

### DIFF
--- a/.github/workflows/ci-tests-xcode-swift-6.yml
+++ b/.github/workflows/ci-tests-xcode-swift-6.yml
@@ -152,14 +152,14 @@ jobs:
         npm install && npm test
     - name: Save xcodebuild logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-logs
         path: |
           DerivedData/Logs/Build
     - name: Save crash logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-crashes
         path: |
@@ -172,7 +172,7 @@ jobs:
         zip -r ResultBundle.zip ResultBundle.xcresult
     - name: Save test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-results
         path: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -162,14 +162,14 @@ jobs:
         npm install && npm test
     - name: Save xcodebuild logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-logs
         path: |
           DerivedData/Logs/Build
     - name: Save crash logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-crashes
         path: |
@@ -182,7 +182,7 @@ jobs:
         zip -r ResultBundle.zip ResultBundle.xcresult
     - name: Save test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-results
         path: |

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -126,14 +126,14 @@ jobs:
         npm install && npm test
     - name: Save xcodebuild logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-logs
         path: |
           DerivedData/Logs/Build
     - name: Save crash logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-crashes
         path: |
@@ -146,7 +146,7 @@ jobs:
         zip -r ResultBundle.zip ResultBundle.xcresult
     - name: Save test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}-results
         path: |


### PR DESCRIPTION
PRs are currently failing multiple workflows with this error:
> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

It seems relatively straight-forward considering our simple use of the action, but the thing that jumped out to me was:
> In v4, users lose the ability to upload to the same named artifact multiple times. Once an artifact is uploaded cannot be altered, **and there cannot be multiple v4 artifacts with the same name, in the same workflow run.**

I think we're fine here because we use the `upload-artifact` action in three workflows but they're separate workflows not jobs within the same workflow. The jobs we do have within the same workflow all use different names for the upload artifacts too; `${{ matrix.name }}-logs`, `${{ matrix.name }}-crashes`, and `${{ matrix.name }}-results`.