### PR TITLE
Updating package config for test apis

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Package.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     .library(name: "AnimalKingdomAPITestMocks", targets: ["AnimalKingdomAPITestMocks"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apollographql/apollo-ios", exact: "1.16.1"),
+    .package(name: "apollo-ios", path: "../../../apollo-ios"),
   ],
   targets: [
     .target(

--- a/Sources/GitHubAPI/GitHubAPI/Package.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     .library(name: "GitHubAPI", targets: ["GitHubAPI"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apollographql/apollo-ios", exact: "1.16.1"),
+    .package(name: "apollo-ios", path: "../../../apollo-ios"),
   ],
   targets: [
     .target(

--- a/Sources/StarWarsAPI/StarWarsAPI/Package.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     .library(name: "StarWarsAPI", targets: ["StarWarsAPI"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apollographql/apollo-ios", exact: "1.16.1"),
+    .package(name: "apollo-ios", path: "../../../apollo-ios"),
   ],
   targets: [
     .target(

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Package.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     .library(name: "SubscriptionAPI", targets: ["SubscriptionAPI"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apollographql/apollo-ios", exact: "1.16.1"),
+    .package(name: "apollo-ios", path: "../../../apollo-ios"),
   ],
   targets: [
     .target(

--- a/Sources/UploadAPI/UploadAPI/Package.swift
+++ b/Sources/UploadAPI/UploadAPI/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     .library(name: "UploadAPI", targets: ["UploadAPI"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apollographql/apollo-ios", exact: "1.16.1"),
+    .package(name: "apollo-ios", path: "../../../apollo-ios"),
   ],
   targets: [
     .target(

--- a/SwiftScripts/Sources/TargetConfig/Module.swift
+++ b/SwiftScripts/Sources/TargetConfig/Module.swift
@@ -7,7 +7,9 @@ public struct Module {
   public init?(module: String) {
     switch module.lowercased() {
     case "none": self.moduleType = .embeddedInTarget(name: "")
-    case "swiftpackagemanager", "spm": self.moduleType = .swiftPackageManager
+    case "swiftpackagemanager", "spm": self.moduleType = .swiftPackage(apolloSDKDependency: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType.ApolloSDKDependency(
+      sdkVersion: .local(path: "../../../apollo-ios")
+    ))
     case "other": self.moduleType = .other
     default: return nil
     }


### PR DESCRIPTION
Updating the spm config for testing apis to use local `apollo-ios` pathing