### PR TITLE
Add mutateIfFulfilled functions

### DIFF
--- a/Tests/ApolloTests/MutatingSelectionSetTests.swift
+++ b/Tests/ApolloTests/MutatingSelectionSetTests.swift
@@ -86,4 +86,153 @@ class MutatingSelectionSetTests: XCTestCase {
     expect(data2.hero.name).to(equal("Leia"))
   }
 
+  func test__mutateIfFulfilled_typeCaseProperties__typeCaseIsFulfilled_mutatesProperties() throws {
+    // given
+    var model = TypeCaseSelectionSet.AsHero(__typename: "Hero", name: "A", age: 1).asRootEntityType
+
+    // when
+    let didMutate = model.mutateIfFulfilled(\.asHero) { hero in
+      hero.name = "B"
+      hero.age = 2
+    }
+
+    // then
+    expect(didMutate).to(beTrue())
+    expect(model.asHero?.name).to(equal("B"))
+    expect(model.asHero?.age).to(equal(2))
+  }
+
+  func test__mutateIfFulfilled_typeCaseProperty__typeCaseIsNotFulfilled_returnsFalseAndDoesNotCallMutationBlock() throws {
+    // given
+    var model = TypeCaseSelectionSet(__typename: "Hero")
+
+    // when
+    let didMutate = model.mutateIfFulfilled(\.asHero) { hero in
+      fail("Should not call mutation block")
+    }
+
+    // then
+    expect(didMutate).to(beFalse())
+    expect(model.asHero).to(beNil())
+  }
+
+  func test__mutateIfFulfilled_doubleNestedTypeCaseProperties__typeCaseIsFulfilled_mutatesProperties() throws {
+    // given
+    var model = TypeCaseSelectionSet.AsHero.AsHuman(
+      __typename: "Hero", name: "A", age: 1, birthMonth: "Jan"
+    ).asRootEntityType
+
+    // when
+    let didMutate = model.mutateIfFulfilled(\.asHero?.asHuman) { hero in
+      hero.birthMonth = "Feb"
+    }
+
+    // then
+    expect(didMutate).to(beTrue())
+    expect(model.asHero?.asHuman?.birthMonth).to(equal("Feb"))
+  }
+
+  // MARK: - Shared Models
+
+  struct TypeCaseSelectionSet: MockMutableRootSelectionSet {
+    public var __data: DataDict = .empty()
+    init(_dataDict: DataDict) { __data = _dataDict }
+
+    static var __selections: [Selection] { [
+      .inlineFragment(AsHero.self)
+    ]}
+
+    var asHero: AsHero? { _asInlineFragment() }
+
+    init(
+      __typename: String
+    ) {
+      self.init(_dataDict: DataDict(
+        data: [
+          "__typename": __typename
+        ], fulfilledFragments: [
+          ObjectIdentifier(Self.self),
+        ]))
+    }
+
+    struct AsHero: MockMutableInlineFragment {
+      typealias RootEntityType = TypeCaseSelectionSet
+
+      static var __parentType: any ApolloAPI.ParentType { Object.mock }
+
+      public var __data: DataDict = .empty()
+      init(_dataDict: DataDict) { __data = _dataDict }
+
+      static var __selections: [Selection] { [
+        .field("name", String.self),
+        .inlineFragment(AsHuman.self)
+      ]}
+
+      var asHuman: AsHuman? { _asInlineFragment() }
+
+      var name: String {
+        get { __data["name"] }
+        set { __data["name"] = newValue }
+      }
+
+      var age: Int? {
+        get { __data["age"] }
+        set { __data["age"] = newValue }
+      }
+
+      init(
+        __typename: String,
+        name: String,
+        age: Int
+      ) {
+        self.init(_dataDict: DataDict(
+          data: [
+            "__typename": __typename,
+            "name": name,
+            "age": age,
+          ], fulfilledFragments: [
+            ObjectIdentifier(TypeCaseSelectionSet.self),
+            ObjectIdentifier(Self.self),
+          ]))
+      }
+
+      struct AsHuman: MockMutableInlineFragment {
+        typealias RootEntityType = TypeCaseSelectionSet
+
+        static var __parentType: any ApolloAPI.ParentType { Object.mock }
+
+        public var __data: DataDict = .empty()
+        init(_dataDict: DataDict) { __data = _dataDict }
+
+        static var __selections: [Selection] { [
+          .field("birthMonth", String?.self)
+        ]}
+
+        var birthMonth: String? {
+          get { __data["birthMonth"] }
+          set { __data["birthMonth"] = newValue }
+        }
+
+        init(
+          __typename: String,
+          name: String,
+          age: Int,
+          birthMonth: String?
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": __typename,
+              "name": name,
+              "age": age,
+              "birthMonth": birthMonth
+            ], fulfilledFragments: [
+              ObjectIdentifier(Self.self),
+              ObjectIdentifier(AsHero.self),
+              ObjectIdentifier(TypeCaseSelectionSet.self),
+            ]))
+        }
+      }
+    }
+  }
+
 }

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -1113,7 +1113,7 @@ class SelectionSetTests: XCTestCase {
 
     // when
     let actual = Data(
-      hero: .AsAnimal(__typename: "Droid", name: "Artoo").asRootEntityType
+      hero: Data.Hero.AsAnimal(__typename: "Droid", name: "Artoo").asRootEntityType
     )
 
     // then

--- a/apollo-ios/Sources/ApolloAPI/LocalCacheMutation.swift
+++ b/apollo-ios/Sources/ApolloAPI/LocalCacheMutation.swift
@@ -31,15 +31,64 @@ public extension MutableSelectionSet {
   }
 }
 
-public extension MutableSelectionSet where Fragments: FragmentContainer {
-  @inlinable var fragments: Fragments {
-    get { Self.Fragments(_dataDict: __data) }
-    _modify {
-      var f = Self.Fragments(_dataDict: __data)
-      yield &f
-      self.__data._data = f.__data._data
+public extension MutableSelectionSet where Self: InlineFragment {
+
+  /// Function for mutating a conditional inline fragment on a mutable selection set.
+  ///
+  /// This function is the only supported way to mutate an inline fragment. Because setting the
+  /// value for an inline fragment that was not already present would result in fatal data
+  /// inconsistencies, inline fragments properties are get-only. However, mutating the properties of
+  /// an inline fragment that has been fulfilled is allowed. This function enables the described
+  /// functionality by checking if the fragment is fulfilled and, if so, calling the mutation body.
+  ///
+  /// - Parameters:
+  ///   - keyPath: The `KeyPath` to the inline fragment to mutate the properties of
+  ///   - transform: A closure used to apply mutations to the inline fragment's properties.
+  /// - Returns: A `Bool` indicating if the fragment was fulfilled.
+  ///   If this returns `false`, the `transform` block will not be called.
+  @discardableResult
+  mutating func mutateIfFulfilled<T: ApolloAPI.InlineFragment>(
+    _ keyPath: KeyPath<Self, T?>,
+    _ transform: (inout T) -> Void
+  ) -> Bool where T.RootEntityType == Self.RootEntityType {
+    guard var fragment = self[keyPath: keyPath] else {
+      return false
     }
+
+    transform(&fragment)
+    self.__data = fragment.__data
+    return true
   }
 }
 
 public protocol MutableRootSelectionSet: RootSelectionSet, MutableSelectionSet {}
+
+public extension MutableRootSelectionSet {
+  
+  /// Function for mutating a conditional inline fragment on a mutable selection set.
+  ///
+  /// This function is the only supported way to mutate an inline fragment. Because setting the
+  /// value for an inline fragment that was not already present would result in fatal data
+  /// inconsistencies, inline fragments properties are get-only. However, mutating the properties of
+  /// an inline fragment that has been fulfilled is allowed. This function enables the described
+  /// functionality by checking if the fragment is fulfilled and, if so, calling the mutation body.
+  ///
+  /// - Parameters:
+  ///   - keyPath: The `KeyPath` to the inline fragment to mutate the properties of
+  ///   - transform: A closure used to apply mutations to the inline fragment's properties.
+  /// - Returns: A `Bool` indicating if the fragment was fulfilled.
+  ///   If this returns `false`, the `transform` block will not be called.
+  @discardableResult
+  mutating func mutateIfFulfilled<T: ApolloAPI.InlineFragment>(
+    _ keyPath: KeyPath<Self, T?>,
+    _ transform: (inout T) -> Void
+  ) -> Bool where T.RootEntityType == Self {
+    guard var fragment = self[keyPath: keyPath] else {
+      return false
+    }
+
+    transform(&fragment)
+    self.__data = fragment.__data
+    return true
+  }
+}

--- a/apollo-ios/Sources/ApolloAPI/LocalCacheMutation.swift
+++ b/apollo-ios/Sources/ApolloAPI/LocalCacheMutation.swift
@@ -58,7 +58,7 @@ public extension MutableSelectionSet where Self: InlineFragment {
   /// - Returns: A `Bool` indicating if the fragment was fulfilled.
   ///   If this returns `false`, the `transform` block will not be called.
   @discardableResult
-  mutating func mutateIfFulfilled<T: ApolloAPI.InlineFragment>(
+  mutating func mutateIfFulfilled<T: InlineFragment>(
     _ keyPath: KeyPath<Self, T?>,
     _ transform: (inout T) -> Void
   ) -> Bool where T.RootEntityType == Self.RootEntityType {
@@ -90,7 +90,7 @@ public extension MutableRootSelectionSet {
   /// - Returns: A `Bool` indicating if the fragment was fulfilled.
   ///   If this returns `false`, the `transform` block will not be called.
   @discardableResult
-  mutating func mutateIfFulfilled<T: ApolloAPI.InlineFragment>(
+  mutating func mutateIfFulfilled<T: InlineFragment>(
     _ keyPath: KeyPath<Self, T?>,
     _ transform: (inout T) -> Void
   ) -> Bool where T.RootEntityType == Self {

--- a/apollo-ios/Sources/ApolloAPI/LocalCacheMutation.swift
+++ b/apollo-ios/Sources/ApolloAPI/LocalCacheMutation.swift
@@ -31,6 +31,17 @@ public extension MutableSelectionSet {
   }
 }
 
+public extension MutableSelectionSet where Fragments: FragmentContainer {
+  @inlinable var fragments: Fragments {
+    get { Self.Fragments(_dataDict: __data) }
+    _modify {
+      var f = Self.Fragments(_dataDict: __data)
+      yield &f
+      self.__data._data = f.__data._data
+    }
+  }
+}
+
 public extension MutableSelectionSet where Self: InlineFragment {
 
   /// Function for mutating a conditional inline fragment on a mutable selection set.


### PR DESCRIPTION
This addresses the limitations described in https://github.com/apollographql/apollo-ios/issues/3443. This is solved by adding a new `mutateIfFulfilled` function that only allows for the properties of an inline fragment to be mutated if the fragment already is fulfilled, while still preventing a fragment from being added/removed from an existing model.