### PR TITLE
feature: Configure `URLRequest` timeout interval

### DIFF
--- a/Tests/ApolloTests/RequestContextTests.swift
+++ b/Tests/ApolloTests/RequestContextTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import Nimble
+@testable import Apollo
+import ApolloAPI
+import ApolloInternalTestHelpers
+
+class RequestContextTests: XCTestCase {
+  private class Hero: MockSelectionSet {
+    typealias Schema = MockSchemaMetadata
+
+    override class var __selections: [Selection] {[
+      .field("__typename", String.self),
+      .field("name", String.self)
+    ]}
+
+    var name: String { __data["name"] }
+  }
+
+  private struct TwoMinuteTimeoutContext: RequestConfigurationContext {
+    let requestTimeout: TimeInterval
+
+    init(requestTimeout: TimeInterval) {
+      self.requestTimeout = requestTimeout
+    }
+  }
+
+  private let twoMinuteTimeout = TwoMinuteTimeoutContext(requestTimeout: 120)
+
+  // MARK: JSONRequest tests
+
+  func test__jsonRequest__withoutRequestConfigurationContext_doesNotConfigureRequestTimeout() throws {
+    let jsonRequest = JSONRequest(
+      operation: MockQuery<Hero>(),
+      graphQLEndpoint: TestURL.mockServer.url,
+      clientName: "test-client",
+      clientVersion: "test-client-version"
+    )
+
+    let urlRequest = try jsonRequest.toURLRequest()
+
+    expect(urlRequest.timeoutInterval).to(equal(60))
+  }
+
+  func test__jsonRequest__givenRequestConfigurationContext_shouldConfigureRequestTimeout() throws {
+    let jsonRequest = JSONRequest(
+      operation: MockQuery<Hero>(),
+      graphQLEndpoint: TestURL.mockServer.url,
+      clientName: "test-client",
+      clientVersion: "test-client-version",
+      context: twoMinuteTimeout
+    )
+
+    let urlRequest = try jsonRequest.toURLRequest()
+
+    expect(urlRequest.timeoutInterval).to(equal(120))
+  }
+
+  // MARK: UploadRequest tests
+
+  func test__uploadRequest__withoutRequestConfigurationContext_doesNotConfigureRequestTimeout() throws {
+    let uploadRequest = UploadRequest(
+      graphQLEndpoint: TestURL.mockServer.url,
+      operation: MockQuery<Hero>(),
+      clientName: "test-client",
+      clientVersion: "test-client-version",
+      files: [GraphQLFile(fieldName: "x", originalName: "y", data: "z".data(using: .utf8)!)]
+    )
+
+    let urlRequest = try uploadRequest.toURLRequest()
+
+    expect(urlRequest.timeoutInterval).to(equal(60))
+  }
+
+  func test__uploadRequest__givenRequestConfigurationContext_shouldConfigureRequestTimeout() throws {
+    let uploadRequest = UploadRequest(
+      graphQLEndpoint: TestURL.mockServer.url,
+      operation: MockQuery<Hero>(),
+      clientName: "test-client",
+      clientVersion: "test-client-version",
+      files: [GraphQLFile(fieldName: "x", originalName: "y", data: "z".data(using: .utf8)!)],
+      context: twoMinuteTimeout
+    )
+
+    let urlRequest = try uploadRequest.toURLRequest()
+
+    expect(urlRequest.timeoutInterval).to(equal(120))
+  }
+}

--- a/Tests/ApolloTests/RequestContextTests.swift
+++ b/Tests/ApolloTests/RequestContextTests.swift
@@ -16,7 +16,7 @@ class RequestContextTests: XCTestCase {
     var name: String { __data["name"] }
   }
 
-  private struct TwoMinuteTimeoutContext: RequestConfigurationContext {
+  private struct TwoMinuteTimeoutContext: RequestContextTimeoutConfigurable {
     let requestTimeout: TimeInterval
 
     init(requestTimeout: TimeInterval) {

--- a/Tests/ApolloTests/RequestContextTimeoutTests.swift
+++ b/Tests/ApolloTests/RequestContextTimeoutTests.swift
@@ -4,7 +4,7 @@ import Nimble
 import ApolloAPI
 import ApolloInternalTestHelpers
 
-class RequestContextTests: XCTestCase {
+class RequestContextTimeoutTests: XCTestCase {
   private class Hero: MockSelectionSet {
     typealias Schema = MockSchemaMetadata
 

--- a/apollo-ios/Sources/Apollo/HTTPRequest.swift
+++ b/apollo-ios/Sources/Apollo/HTTPRequest.swift
@@ -87,7 +87,7 @@ open class HTTPRequest<Operation: GraphQLOperation>: Hashable {
   open func toURLRequest() throws -> URLRequest {
     var request: URLRequest
 
-    if let configContext = context as? any RequestConfigurationContext {
+    if let configContext = context as? any RequestContextTimeoutConfigurable {
       request = URLRequest(url: self.graphQLEndpoint, timeoutInterval: configContext.requestTimeout)
     } else {
       request = URLRequest(url: self.graphQLEndpoint)

--- a/apollo-ios/Sources/Apollo/HTTPRequest.swift
+++ b/apollo-ios/Sources/Apollo/HTTPRequest.swift
@@ -85,8 +85,14 @@ open class HTTPRequest<Operation: GraphQLOperation>: Hashable {
   /// - Throws: Any error in creating the request
   /// - Returns: The URL request, ready to send to your server.
   open func toURLRequest() throws -> URLRequest {
-    var request = URLRequest(url: self.graphQLEndpoint)
-    
+    var request: URLRequest
+
+    if let configContext = context as? any RequestConfigurationContext {
+      request = URLRequest(url: self.graphQLEndpoint, timeoutInterval: configContext.requestTimeout)
+    } else {
+      request = URLRequest(url: self.graphQLEndpoint)
+    }
+
     for (fieldName, value) in additionalHeaders {
       request.addValue(value, forHTTPHeaderField: fieldName)
     }

--- a/apollo-ios/Sources/Apollo/RequestContext.swift
+++ b/apollo-ios/Sources/Apollo/RequestContext.swift
@@ -11,8 +11,8 @@ import ApolloAPI
 /// that they cannot get just from the existing operation. It can be anything that conforms to this protocol.
 public protocol RequestContext {}
 
-/// A specialized request context that specifies configuration details for the URLRequest.
-public protocol RequestConfigurationContext: RequestContext {
+/// A specialized request context that specifies configuration details for the URLRequest timing.
+public protocol RequestContextTimeoutConfigurable: RequestContext {
   /// The timeout interval specifies the limit on the idle interval allotted to a request in the process of
   /// loading. This timeout interval is measured in seconds.
   var requestTimeout: TimeInterval { get }

--- a/apollo-ios/Sources/Apollo/RequestContext.swift
+++ b/apollo-ios/Sources/Apollo/RequestContext.swift
@@ -11,7 +11,10 @@ import ApolloAPI
 /// that they cannot get just from the existing operation. It can be anything that conforms to this protocol.
 public protocol RequestContext {}
 
-/// A specialized request context that specifies configuration details for the URLRequest timing.
+/// A request context specialization protocol that specifies options for configuring the timeout of a `URLRequest`.
+///
+/// A `RequestContext` object can conform to this protocol to provide a custom `requestTimeout` for an individual request.
+/// If the `RequestContext` for a request does not conform to this protocol, the default request timeout of `URLRequest` will be used.
 public protocol RequestContextTimeoutConfigurable: RequestContext {
   /// The timeout interval specifies the limit on the idle interval allotted to a request in the process of
   /// loading. This timeout interval is measured in seconds.

--- a/apollo-ios/Sources/Apollo/RequestContext.swift
+++ b/apollo-ios/Sources/Apollo/RequestContext.swift
@@ -18,5 +18,7 @@ public protocol RequestContext {}
 public protocol RequestContextTimeoutConfigurable: RequestContext {
   /// The timeout interval specifies the limit on the idle interval allotted to a request in the process of
   /// loading. This timeout interval is measured in seconds.
+  ///
+  /// The value of this property will be set as the `timeoutInterval` on the `URLRequest` created for this GraphQL request.
   var requestTimeout: TimeInterval { get }
 }

--- a/apollo-ios/Sources/Apollo/RequestContext.swift
+++ b/apollo-ios/Sources/Apollo/RequestContext.swift
@@ -10,3 +10,10 @@ import ApolloAPI
 /// This allows the various interceptors to make modifications, or perform actions, with information
 /// that they cannot get just from the existing operation. It can be anything that conforms to this protocol.
 public protocol RequestContext {}
+
+/// A specialized request context that specifies configuration details for the URLRequest.
+public protocol RequestConfigurationContext: RequestContext {
+  /// The timeout interval specifies the limit on the idle interval allotted to a request in the process of
+  /// loading. This timeout interval is measured in seconds.
+  var requestTimeout: TimeInterval { get }
+}


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-ios/issues/3522.

The _desired_ solution mentioned in the issue was to introduce an additional parameter on the `fetch` and `send` functions. That solution would have introduced a breaking change due to those functions being part of the protocols `ApolloClientProtocol` and `NetworkTransport` respectively.

The solution implemented in this PR is to leverage the `RequestContext` marker protocol and introduce a configuration specific sub-protocol. The idea is that this can be extended in the future to introduce more request configuration parameters as needed. It also is not a breaking change.