### PR TITLE
fix: Xcode 16.3 CLI installation

### DIFF
--- a/apollo-ios/Plugins/InstallCLI/InstallCLIPluginCommand.swift
+++ b/apollo-ios/Plugins/InstallCLI/InstallCLIPluginCommand.swift
@@ -1,8 +1,13 @@
 import Foundation
 import PackagePlugin
+import os
 
 @main
 struct InstallCLIPluginCommand: CommandPlugin {
+
+  enum Error: Swift.Error {
+    case CannotDetermineXcodeVersion
+  }
 
   func performCommand(context: PackagePlugin.PluginContext, arguments: [String]) async throws {
     let dependencies = context.package.dependencies
@@ -27,14 +32,73 @@ extension InstallCLIPluginCommand: XcodeCommandPlugin {
 
   /// 👇 This entry point is called when operating on an Xcode project.
   func performCommand(context: XcodePluginContext, arguments: [String]) throws {
-    print("Installing Apollo CLI Plugin to Xcode project \(context.xcodeProject.displayName)")
-    let apolloPath = "\(context.pluginWorkDirectory)/../../checkouts/apollo-ios"
     let process = Process()
-    let path = try context.tool(named: "sh").path
-    process.executableURL = URL(fileURLWithPath: path.string)
-    process.arguments = ["\(apolloPath)/scripts/download-cli.sh", context.xcodeProject.directory.string]
+    let toolPath = try context.tool(named: "sh").path
+    process.executableURL = URL(fileURLWithPath: toolPath.string)
+
+    let downloadScriptPath = try downloadScriptPath(context: context)
+    process.arguments = [downloadScriptPath, context.xcodeProject.directory.string]
+
+    Logger().info("Using download script path: \(downloadScriptPath)")
+
     try process.run()
     process.waitUntilExit()
+  }
+
+  /// Used to get the location of the CLI download script.
+  ///
+  /// - Parameter context: Contextual information based on the plugin's stated intent and requirements.
+  /// - Returns: The path to the download script used to fetch the CLI binary.
+  private func downloadScriptPath(context: XcodePluginContext) throws -> String {
+    let xcodeVersion = try xcodeVersion(context: context)
+    let relativeScriptPath = "SourcePackages/checkouts/apollo-ios/scripts/download-cli.sh"
+    let absoluteScriptPath: String
+
+    if xcodeVersion.lexicographicallyPrecedes("16.3") {
+      absoluteScriptPath = "\(context.pluginWorkDirectory)/../../../\(relativeScriptPath)"
+    } else {
+      absoluteScriptPath = "\(context.pluginWorkDirectory)/../../../../\(relativeScriptPath)"
+    }
+
+    return absoluteScriptPath
+  }
+
+  /// Used to get a string representation of Xcode in the current toolchain.
+  ///
+  /// - Parameter context: Contextual information based on the plugin's stated intent and requirements.
+  /// - Returns: A string representation of the Xcode version.
+  private func xcodeVersion(context: XcodePluginContext) throws -> String {
+    let process = Process()
+    let toolPath = try context.tool(named: "xcrun").path
+    process.executableURL = URL(fileURLWithPath: toolPath.string)
+    process.arguments = ["xcodebuild", "-version"]
+
+    let outputPipe = Pipe()
+    process.standardOutput = outputPipe
+
+    try process.run()
+    process.waitUntilExit()
+
+    guard
+      let outputData = try outputPipe.fileHandleForReading.readToEnd(),
+      let output = String(data: outputData, encoding: .utf8)
+    else {
+      throw Error.CannotDetermineXcodeVersion
+    }
+
+    let xcodeVersionString = output.components(separatedBy: "\n")[0]
+    guard !xcodeVersionString.isEmpty else {
+      throw Error.CannotDetermineXcodeVersion
+    }
+
+    Logger().info("Found Xcode Version: \(xcodeVersionString)")
+
+    let versionString = xcodeVersionString
+      .components(separatedBy: CharacterSet.decimalDigits.inverted)
+      .compactMap({ $0.isEmpty ? nil : $0 })
+      .joined(separator: ".")
+
+    return versionString
   }
 
 }

--- a/apollo-ios/Plugins/InstallCLI/InstallCLIPluginCommand.swift
+++ b/apollo-ios/Plugins/InstallCLI/InstallCLIPluginCommand.swift
@@ -39,8 +39,6 @@ extension InstallCLIPluginCommand: XcodeCommandPlugin {
     let downloadScriptPath = try downloadScriptPath(context: context)
     process.arguments = [downloadScriptPath, context.xcodeProject.directory.string]
 
-    Logger().info("Using download script path: \(downloadScriptPath)")
-
     try process.run()
     process.waitUntilExit()
   }
@@ -90,8 +88,6 @@ extension InstallCLIPluginCommand: XcodeCommandPlugin {
     guard !xcodeVersionString.isEmpty else {
       throw Error.CannotDetermineXcodeVersion
     }
-
-    Logger().info("Found Xcode Version: \(xcodeVersionString)")
 
     let versionString = xcodeVersionString
       .components(separatedBy: CharacterSet.decimalDigits.inverted)


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3518.

#### Cause
Investigating this issue revealed that Xcode 16.2 has the plugins execute from within the `SourcePackages` directory; that made sense why we could [simply backtrack two folders](https://github.com/apollographql/apollo-ios-dev/blob/1.19.0/apollo-ios/Plugins/InstallCLI/InstallCLIPluginCommand.swift#L31) (`../../`) and get access to `checkouts`. Xcode 16.3 now has a separate directory that it gives the plugin complete control over, which is outside of `SourcePackages`. The result is that we need to backtrack further up the directory tree to get to `checkouts`.

#### Solution
* This changeset gets the active version of Xcode by using `xcrun`. This will allow for different Xcode versions being installed in `/Applications`, or wherever else, and only get the version for the 'active' application. Once we know the version of Xcode being used then the correct known script location can be used.
* I've tested this with Xcode 16.2, all the Xcode 16.3 beta versions, and the latest Xcode 16.3 RC 2. The version-based solution works for all of them.
* This bug and subsequent fix is targeted at Xcode projects vs. SPM projects. SPM projects appear unaffected by the change in plugin execution context.

#### Discarded
These are the other solutions I discarded:
1. `if #available(..)` - I don't think this can dynamically get the installed Swift version and instead targets a specific OS version. I believe Xcode 16.2 and 16.3 can both be installed on macOS Sequoia (15.3) so that's not helpful.
2. `#if swift(..)` - This is conditional compilation code for build time; we need the solution to operate on the users' machine. Also not helpful.
3. Crawl up the directory tree from the plugin context work directory until `SourcePackages` is found. This is still a viable alternative and if the Xcode version approach causes more problems in the future we should try this.