### PR TITLE
refactor: More contextual multipart parsing errors

### DIFF
--- a/Tests/ApolloTests/Interceptors/MultipartResponseParsingInterceptorTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseParsingInterceptorTests.swift
@@ -45,7 +45,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
 
       expect(result).to(beFailure { error in
         expect(error).to(
-          matchError(MultipartResponseParsingInterceptor.ParsingError.cannotParseResponse)
+          matchError(MultipartResponseParsingInterceptor.ParsingError.missingMultipartBoundary)
         )
       })
     }
@@ -53,7 +53,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
     wait(for: [expectation], timeout: defaultTimeout)
   }
 
-  func test__error__givenResponse_withMissingMultipartProtocolHeader_shouldReturnError() throws {
+  func test__error__givenResponse_withMissingMultipartProtocolSpecifier_shouldReturnError() throws {
     let subject = InterceptorTester(interceptor: MultipartResponseParsingInterceptor())
 
     let expectation = expectation(description: "Received callback")
@@ -68,7 +68,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
 
       expect(result).to(beFailure { error in
         expect(error).to(
-          matchError(MultipartResponseParsingInterceptor.ParsingError.cannotParseResponse)
+          matchError(MultipartResponseParsingInterceptor.ParsingError.invalidMultipartProtocol)
         )
       })
     }
@@ -76,7 +76,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
     wait(for: [expectation], timeout: defaultTimeout)
   }
 
-  func test__error__givenResponse_withUnknownMultipartParser_shouldReturnError() throws {
+  func test__error__givenResponse_withUnknownMultipartProtocolSpecifier_shouldReturnError() throws {
     let subject = InterceptorTester(interceptor: MultipartResponseParsingInterceptor())
 
     let expectation = expectation(description: "Received callback")
@@ -91,7 +91,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
 
       expect(result).to(beFailure { error in
         expect(error).to(
-          matchError(MultipartResponseParsingInterceptor.ParsingError.cannotParseResponse)
+          matchError(MultipartResponseParsingInterceptor.ParsingError.invalidMultipartProtocol)
         )
       })
     }


### PR DESCRIPTION
Related to https://github.com/apollographql/apollo-ios/issues/3536#issuecomment-2763230360.

It takes a bit of [familiarity with the multipart parsing interceptor](https://github.com/apollographql/apollo-ios/issues/3536#issuecomment-2762950300) to understand why responses like that in the above issue fail. These new error messages should provide more context to help others understand why the response might be failing.