### PR TITLE
[v2] [1/X] ApolloStore async Read/Write lock

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",
       "state" : {
-        "revision" : "3ef6999c73b6938cc0da422f2c912d0158abb0a0",
-        "version" : "2.2.0"
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
       "state" : {
-        "revision" : "2ef56b2caf25f55fa7eef8784c30d5a767550f54",
-        "version" : "2.2.1"
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "1c49fc1243018f81a7ea99cb5e0985b00096e9f4",
-        "version" : "13.3.0"
+        "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
+        "version" : "13.7.1"
       }
     },
     {
@@ -41,8 +41,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
-        "version" : "1.4.0"
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
-        "version" : "1.1.1"
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
       }
     }
   ],

--- a/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
+++ b/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
@@ -69,16 +69,18 @@ class AutomaticPersistedQueriesTests: XCTestCase {
     operation: O,
     queryDocument: Bool = false,
     persistedQuery: Bool = false,
+    fileID: String = #fileID,
     file: Nimble.FileString = #filePath,
-    line: UInt = #line
+    line: UInt = #line,
+    column: UInt = #column
   ) throws {
-
+    let location = SourceLocation(fileID: fileID, filePath: file, line: line, column: column)
     guard
       let httpBody = request.httpBody,
       let jsonBody = try? JSONSerializationFormat.deserialize(data: httpBody) as JSONObject else {
       fail(
         "httpBody invalid",
-        location: SourceLocation(file: file, line: line)
+        location: location
       )
       return
     }
@@ -102,7 +104,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
       } else {
         fail(
           "variables should not be nil",
-          location: SourceLocation(file: file, line: line)
+          location: location
         )
       }
     }
@@ -112,7 +114,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
       guard let ext = ext else {
         fail(
           "extensions json data should not be nil",
-          location: SourceLocation(file: file, line: line)
+          location: location
         )
         return
       }
@@ -120,7 +122,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
       guard let persistedQuery = ext["persistedQuery"] as? JSONObject else {
         fail(
           "persistedQuery is missing",
-          location: SourceLocation(file: file, line: line)
+          location: location
         )
         return
       }
@@ -128,7 +130,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
       guard let version = persistedQuery["version"] as? Int else {
         fail(
           "version is missing",
-          location: SourceLocation(file: file, line: line)
+          location: location
         )
         return
       }
@@ -136,7 +138,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
       guard let sha256Hash = persistedQuery["sha256Hash"] as? String else {
         fail(
           "sha256Hash is missing",
-          location: SourceLocation(file: file, line: line)
+          location: location
         )
         return
       }
@@ -153,13 +155,16 @@ class AutomaticPersistedQueriesTests: XCTestCase {
     query: MockHeroNameQuery,
     queryDocument: Bool = false,
     persistedQuery: Bool = false,
+    fileID: String = #fileID,
     file: Nimble.FileString = #filePath,
-    line: UInt = #line
+    line: UInt = #line,
+    column: UInt = #column
   ) throws {
+    let location = SourceLocation(fileID: fileID, filePath: file, line: line, column: column)
     guard let url = request.url else {
       fail(
         "URL not valid",
-        location: SourceLocation(file: file, line: line)
+        location: location
       )
       return
     }
@@ -190,7 +195,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
     } else {
       fail(
         "variables should not be nil",
-        location: SourceLocation(file: file, line: line)
+        location: location
       )
     }
     
@@ -203,7 +208,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
         else {
         fail(
           "extensions json data should not be nil",
-          location: SourceLocation(file: file, line: line)
+          location: location
         )
         return
       }
@@ -211,7 +216,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
       guard let persistedQuery = jsonBody["persistedQuery"] as? JSONObject else {
         fail(
           "persistedQuery is missing",
-          location: SourceLocation(file: file, line: line)
+          location: location
         )
         return
       }
@@ -219,7 +224,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
       guard let sha256Hash = persistedQuery["sha256Hash"] as? String else {
         fail(
           "sha256Hash is missing",
-          location: SourceLocation(file: file, line: line)
+          location: location
         )
         return
       }
@@ -227,7 +232,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
       guard let version = persistedQuery["version"] as? Int else {
         fail(
           "version is missing",
-          location: SourceLocation(file: file, line: line)
+          location: location
         )
         return
       }

--- a/apollo-ios/Package.swift
+++ b/apollo-ios/Package.swift
@@ -21,12 +21,16 @@ let package = Package(
     .plugin(name: "InstallCLI", targets: ["Install CLI"])
   ],
   dependencies: [
+    .package(
+      url: "https://github.com/apple/swift-atomics",
+      .upToNextMajor(from: "1.2.0"))
   ],
   targets: [
     .target(
       name: "Apollo",
       dependencies: [
-        "ApolloAPI"
+        "ApolloAPI",
+        .product(name: "Atomics", package: "swift-atomics"),
       ],
       resources: [
         .copy("Resources/PrivacyInfo.xcprivacy")

--- a/apollo-ios/Sources/Apollo/ApolloStore+ReaderWriter.swift
+++ b/apollo-ios/Sources/Apollo/ApolloStore+ReaderWriter.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Atomics
+
+extension ApolloStore {
+  final class ReaderWriter: Sendable {
+
+    /// Atomic counter for number of current readers.
+    /// While writing, this will have a value of `WRITING`
+    private let readerCount = ManagedAtomic(0)
+
+    /// Value for `readerCount` while in writing state
+    private static let WRITING = -1
+
+    // MARK: - Read
+
+    func read(_ body: () async throws -> Void) async rethrows {
+      await beginReading()
+      defer { finishReading() }
+
+      try await body()
+    }
+
+    private func beginReading() async {
+      var didIncrementReadCount = false
+
+      while true {
+        let currentReaderCount = readerCount.load(ordering: .relaxed)
+
+        guard currentReaderCount != Self.WRITING else {
+          await Task.yield()
+          continue
+        }
+
+        (didIncrementReadCount, _) = readerCount.weakCompareExchange(
+          // Ensure no other thread has changed count before increment
+          expected: currentReaderCount,
+          // Increment count to add reader
+          desired: currentReaderCount + 1,
+          ordering: .acquiringAndReleasing
+        )
+
+        if didIncrementReadCount { return }
+      }
+    }
+
+    private func finishReading() {
+      readerCount.wrappingDecrement(ordering: .acquiringAndReleasing)
+    }
+
+    // MARK: - Write
+    func write(_ body: () async throws -> Void) async rethrows {
+      await beginWriting()
+      defer { finishWriting() }
+      try await body()
+    }
+
+    private func beginWriting() async {
+      while true {
+        let (didSetWritingFlag, _) = readerCount.weakCompareExchange(
+          expected: 0,
+          desired: Self.WRITING,
+          ordering: .acquiringAndReleasing
+        )
+
+        if didSetWritingFlag { return } else {
+          await Task.yield()
+        }
+      }
+    }
+
+    func finishWriting() {
+      readerCount.store(0, ordering: .releasing)
+    }
+  }
+}
+


### PR DESCRIPTION
Creates a `ReaderWriter` using `SwiftAtomics` that allows for multiple parallel reads while locking for writes.

This will replace the current barrier queue for ApolloStore. Usage of this will be implemented in stacked PR.