### PR TITLE
[v2] [4/x] NetworkTransport APIs

### DIFF
--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -29,7 +29,7 @@ public enum CachePolicy: Sendable, Hashable {
 public typealias GraphQLResultHandler<Data: RootSelectionSet> = @Sendable (Result<GraphQLResult<Data>, any Error>) -> Void
 
 /// The `ApolloClient` class implements the core API for Apollo by conforming to `ApolloClientProtocol`.
-public class ApolloClient {
+public class ApolloClient: ApolloClientProtocol, @unchecked Sendable {
 
   let networkTransport: any NetworkTransport
 
@@ -87,17 +87,12 @@ public class ApolloClient {
       sendEnhancedClientAwareness: sendEnhancedClientAwareness
     )
   }
-}
-
-// MARK: - ApolloClientProtocol conformance
-
-extension ApolloClient: ApolloClientProtocol {
 
   public func clearCache(callbackQueue: DispatchQueue = .main,
                          completion: (@Sendable (Result<Void, any Error>) -> Void)? = nil) {
     self.store.clearCache(callbackQueue: callbackQueue, completion: completion)
   }
-  
+
   @discardableResult public func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy = .default,
@@ -105,14 +100,48 @@ extension ApolloClient: ApolloClientProtocol {
     context: (any RequestContext)? = nil,
     queue: DispatchQueue = .main,
     resultHandler: GraphQLResultHandler<Query.Data>? = nil
-  ) -> (any Cancellable) {
-    return self.networkTransport.send(operation: query,
-                                      cachePolicy: cachePolicy,
-                                      contextIdentifier: contextIdentifier,
-                                      context: context,
-                                      callbackQueue: queue) { result in
-      resultHandler?(result)
+  ) -> (any Cancellable) {    
+    return awaitStreamInTask(
+      {
+        try await self.networkTransport.send(
+          operation: query,
+          cachePolicy: cachePolicy,
+          contextIdentifier: contextIdentifier,
+          context: context
+        )
+      },
+      callbackQueue: queue,
+      completion: resultHandler
+    )
+  }
+
+  @available(*, deprecated)
+  private func awaitStreamInTask<T: Sendable>(
+    _ body: @escaping @Sendable () async throws -> AsyncThrowingStream<T, any Swift.Error>,
+    callbackQueue: DispatchQueue?,
+    completion: (@Sendable (Result<T, any Swift.Error>) -> Void)?
+  ) -> some Cancellable {
+    let task = Task {
+      do {
+        let resultStream = try await body()
+
+        for try await result in resultStream {
+          DispatchQueue.returnResultAsyncIfNeeded(
+            on: callbackQueue,
+            action: completion,
+            result: .success(result)
+          )
+        }
+
+      } catch {
+        DispatchQueue.returnResultAsyncIfNeeded(
+          on: callbackQueue,
+          action: completion,
+          result: .failure(error)
+        )
+      }
     }
+    return TaskCancellable(task: task)
   }
 
   /// Watches a query by first fetching an initial result from the server or from the local cache, depending on the current contents of the cache and the specified cache policy. After the initial fetch, the returned query watcher object will get notified whenever any of the data the query result depends on changes in the local cache, and calls the result handler again with the new result.
@@ -153,15 +182,17 @@ extension ApolloClient: ApolloClientProtocol {
     queue: DispatchQueue = .main,
     resultHandler: GraphQLResultHandler<Mutation.Data>? = nil
   ) -> (any Cancellable) {
-    return self.networkTransport.send(
-      operation: mutation,
-      cachePolicy: publishResultToStore ? .default : .fetchIgnoringCacheCompletely,
-      contextIdentifier: contextIdentifier,
-      context: context,
+    return awaitStreamInTask(
+      {
+        try await self.networkTransport.send(
+          operation: mutation,
+          cachePolicy: publishResultToStore ? .default : .fetchIgnoringCacheCompletely,
+          contextIdentifier: contextIdentifier,
+          context: context
+        )
+      },
       callbackQueue: queue,
-      completionHandler: { result in
-        resultHandler?(result)
-      }
+      completion: resultHandler
     )
   }
 
@@ -181,12 +212,17 @@ extension ApolloClient: ApolloClientProtocol {
       return EmptyCancellable()
     }
 
-    return uploadingTransport.upload(operation: operation,
-                                     files: files,
-                                     context: context,
-                                     callbackQueue: queue) { result in
-      resultHandler?(result)
-    }
+    return awaitStreamInTask(
+      {
+        try await uploadingTransport.upload(
+          operation: operation,
+          files: files,
+          context: context
+        )
+      },
+      callbackQueue: queue,
+      completion: resultHandler
+    )
   }
 
   public func subscribe<Subscription: GraphQLSubscription>(
@@ -195,12 +231,17 @@ extension ApolloClient: ApolloClientProtocol {
     queue: DispatchQueue = .main,
     resultHandler: @escaping GraphQLResultHandler<Subscription.Data>
   ) -> any Cancellable {
-    return self.networkTransport.send(operation: subscription,
-                                      cachePolicy: .default,
-                                      contextIdentifier: nil,
-                                      context: context,
-                                      callbackQueue: queue,
-                                      completionHandler: resultHandler)
+    return awaitStreamInTask(
+      {
+        try await self.networkTransport.send(
+          operation: subscription,
+          cachePolicy: .default,
+          contextIdentifier: nil,
+          context: context)
+      },
+      callbackQueue: queue,
+      completion: resultHandler
+    )    
   }
 }
 

--- a/apollo-ios/Sources/Apollo/Interceptors/CacheInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/CacheInterceptor.swift
@@ -18,7 +18,11 @@ public protocol CacheInterceptor: Sendable {
 
 public struct DefaultCacheInterceptor: CacheInterceptor {
 
-  let store: ApolloStore
+  public let store: ApolloStore
+
+  public init(store: ApolloStore) {
+    self.store = store
+  }
 
   public func readCacheData<Query: GraphQLQuery>(
     for query: Query

--- a/apollo-ios/Sources/Apollo/Interceptors/JSONResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/JSONResponseParsingInterceptor.swift
@@ -24,10 +24,6 @@ public struct JSONResponseParsingInterceptor: ApolloInterceptor {
 
     let currentResult = CurrentResult<Request.Operation>()
 
-    if let request = request as? UploadRequest<Request.Operation> {
-
-    }
-
     return try await next(request).compactMap { result -> InterceptorResult<Request.Operation>? in
       let parser = JSONResponseParser<Request.Operation>(
         response: result.response,

--- a/apollo-ios/Sources/Apollo/Interceptors/MaxRetryInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/MaxRetryInterceptor.swift
@@ -3,7 +3,6 @@ import Foundation
 import ApolloAPI
 #endif
 
-#warning("TODO: remove unchecked when making interceptor functions async.")
 /// An interceptor to enforce a maximum number of retries of any `HTTPRequest`
 public actor MaxRetryInterceptor: ApolloInterceptor, Sendable {
 

--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -21,7 +21,7 @@ public protocol NetworkTransport: AnyObject, Sendable {
     cachePolicy: CachePolicy,
     contextIdentifier: UUID?,
     context: (any RequestContext)?
-  ) async throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error>
 
 }
 

--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -16,12 +16,32 @@ public protocol NetworkTransport: AnyObject, Sendable {
   ///   - contextIdentifier:  [optional] A unique identifier for this request, to help with deduping cache hits for watchers. Defaults to `nil`.
   ///   - context: [optional] A context that is being passed through the request chain. Defaults to `nil`.
   /// - Returns: A stream of `GraphQLResult`s for each response.
-  func send<Operation: GraphQLOperation>(
-    operation: Operation,
+  func send<Query: GraphQLQuery>(
+    query: Query,
     cachePolicy: CachePolicy,
     contextIdentifier: UUID?,
     context: (any RequestContext)?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
+
+  func send<Mutation: GraphQLMutation>(
+    mutation: Mutation,
+    cachePolicy: CachePolicy,
+    contextIdentifier: UUID?,
+    context: (any RequestContext)?
+  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error>
+
+}
+
+// MARK: -
+
+public protocol SubscriptionNetworkTransport: NetworkTransport {
+
+  func send<Subscription: GraphQLSubscription>(
+    subscription: Subscription,
+    cachePolicy: CachePolicy,
+    contextIdentifier: UUID?,
+    context: (any RequestContext)?
+  ) throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error>
 
 }
 
@@ -37,9 +57,10 @@ public protocol UploadingNetworkTransport: NetworkTransport {
   ///   - files: An array of `GraphQLFile` objects to send.
   ///   - context: [optional] A context that is being passed through the request chain.
   /// - Returns: A stream of `GraphQLResult`s for each response.
+#warning("TODO: should support query and mutation as seperate functions")
   func upload<Operation: GraphQLOperation>(
     operation: Operation,
     files: [GraphQLFile],
     context: (any RequestContext)?
-  ) async throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error>
 }

--- a/apollo-ios/Sources/Apollo/RequestChain.swift
+++ b/apollo-ios/Sources/Apollo/RequestChain.swift
@@ -74,7 +74,7 @@ struct RequestChain<Request: GraphQLRequest>: Sendable {
       }
     }
   }
-
+  
   func kickoff(
     request: Request
   ) -> ResultStream {

--- a/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -113,9 +113,9 @@ public final class RequestChainNetworkTransport: NetworkTransport, Sendable {
   public func send<Operation: GraphQLOperation>(
     operation: Operation,
     cachePolicy: CachePolicy,
-    contextIdentifier: UUID?,
-    context: (any RequestContext)?
-  ) async throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
+    contextIdentifier: UUID? = nil,
+    context: (any RequestContext)? = nil
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
     let request = self.constructRequest(
       for: operation,
       cachePolicy: cachePolicy,

--- a/apollo-ios/Sources/ApolloTestSupport/TestMock.swift
+++ b/apollo-ios/Sources/ApolloTestSupport/TestMock.swift
@@ -200,7 +200,7 @@ fileprivate extension Array {
     case let innerArray as Array<Any>:
       return innerArray._unsafelyConvertToSelectionSetData() as JSONValue
 
-    case let optionalElement as Optional<Any>:
+    case let optionalElement as Optional<any Sendable>:
       guard case let .some(element) = optionalElement.asNullable else {
         return nil
       }

--- a/apollo-ios/Sources/ApolloWebSocket/OperationMessage.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/OperationMessage.swift
@@ -57,24 +57,24 @@ final class OperationMessage {
     self.serialized = serialized
   }
 
-  func parse(handler: (ParseHandler) -> Void) {
+  func parse(handler: (ParseHandler) async -> Void) async {
     guard let serialized = self.serialized else {
-      handler(ParseHandler(nil,
-                           nil,
-                           nil,
-                           WebSocketError(payload: nil,
-                                          error: nil,
-                                          kind: .serializedMessageError)))
+      await handler(ParseHandler(nil,
+                                 nil,
+                                 nil,
+                                 WebSocketError(payload: nil,
+                                                error: nil,
+                                                kind: .serializedMessageError)))
       return
     }
 
     guard let data = self.serialized?.data(using: (.utf8) ) else {
-      handler(ParseHandler(nil,
-                           nil,
-                           nil,
-                           WebSocketError(payload: nil,
-                                          error: nil,
-                                          kind: .unprocessedMessage(serialized))))
+      await handler(ParseHandler(nil,
+                                 nil,
+                                 nil,
+                                 WebSocketError(payload: nil,
+                                                error: nil,
+                                                kind: .unprocessedMessage(serialized))))
       return
     }
 
@@ -89,18 +89,18 @@ final class OperationMessage {
       type = json["type"] as? String
       payload = json["payload"] as? JSONObject
 
-      handler(ParseHandler(type,
-                           id,
-                           payload,
-                           nil))
+      await handler(ParseHandler(type,
+                                 id,
+                                 payload,
+                                 nil))
     }
     catch {
-      handler(ParseHandler(type,
-                           id,
-                           payload,
-                           WebSocketError(payload: payload,
-                                          error: error,
-                                          kind: .unprocessedMessage(serialized))))
+      await handler(ParseHandler(type,
+                                 id,
+                                 payload,
+                                 WebSocketError(payload: payload,
+                                                error: error,
+                                                kind: .unprocessedMessage(serialized))))
     }
   }
 }

--- a/apollo-ios/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -53,15 +53,15 @@ extension SplitNetworkTransport: NetworkTransport {
     cachePolicy: CachePolicy,
     contextIdentifier: UUID? = nil,
     context: (any RequestContext)? = nil
-  ) async throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
     if Operation.operationType == .subscription {
-      return try await webSocketNetworkTransport.send(
+      return try webSocketNetworkTransport.send(
         operation: operation,
         cachePolicy: cachePolicy,
         contextIdentifier: contextIdentifier,
         context: context)
     } else {
-      return try await uploadingNetworkTransport.send(
+      return try uploadingNetworkTransport.send(
         operation: operation,
         cachePolicy: cachePolicy,
         contextIdentifier: contextIdentifier,

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTask.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTask.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 import Foundation
 
 /// A task to wrap sending/canceling operations over a websocket.
-final class WebSocketTask<Operation: GraphQLOperation>: Cancellable {
+final class WebSocketTask<Operation: GraphQLOperation>: Sendable, Cancellable {
   let sequenceNumber : String?
   let transport: WebSocketTransport
 

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTask.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTask.swift
@@ -16,7 +16,7 @@ final class WebSocketTask<Operation: GraphQLOperation>: Sendable, Cancellable {
   /// - Parameter completionHandler: A completion handler to fire when the operation has a result.
   init(_ ws: WebSocketTransport,
        _ operation: Operation,
-       _ completionHandler: @escaping @Sendable (_ result: Result<JSONObject, any Error>) -> Void) {
+       _ completionHandler: @escaping @Sendable (_ result: Result<JSONObject, any Error>) async -> Void) {
     sequenceNumber = ws.sendHelper(operation: operation, resultHandler: completionHandler)
     transport = ws
   }

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -451,7 +451,7 @@ extension WebSocketTransport: NetworkTransport {
     cachePolicy: CachePolicy,
     contextIdentifier: UUID? = nil,
     context: (any RequestContext)? = nil
-  ) async throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
     if let error = self.error {
       return AsyncThrowingStream.init {
         throw error

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -450,49 +450,48 @@ extension WebSocketTransport: NetworkTransport {
     operation: Operation,
     cachePolicy: CachePolicy,
     contextIdentifier: UUID? = nil,
-    context: (any RequestContext)? = nil,
-    callbackQueue: DispatchQueue = .main,
-    completionHandler: @escaping @Sendable (Result<GraphQLResult<Operation.Data>, any Error>) -> Void) -> any Cancellable {
+    context: (any RequestContext)? = nil
+  ) async throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
+    if let error = self.error {
+      return AsyncThrowingStream.init {
+        throw error
+      }
+    }
 
-      @Sendable func callCompletion(with result: Result<GraphQLResult<Operation.Data>, any Error>) {
-        callbackQueue.async {
-          completionHandler(result)
+    #warning("TODO: stream never finishes. WebSocketTask does not report subscription termination.")
+    return AsyncThrowingStream { continuation in
+      let task = WebSocketTask(self, operation) { [weak store, contextIdentifier] result in
+        Task {
+          try Task.checkCancellation()
+
+          let jsonBody = try result.get()
+          let response = GraphQLResponse(operation: operation, body: jsonBody)
+
+          if let store = store {
+            let (graphQLResult, parsedRecords) = try await response.parseResult()
+
+            try Task.checkCancellation()
+
+            guard let records = parsedRecords else {
+              continuation.yield(graphQLResult)
+              return
+            }
+
+            try await store.publish(records: records, identifier: contextIdentifier)
+            continuation.yield(graphQLResult)
+
+          } else {
+            let graphQLResult = try await response.parseResultFast()
+            try Task.checkCancellation()
+
+            continuation.yield(graphQLResult)
+          }
         }
       }
 
-      if let error = self.error {
-        callCompletion(with: .failure(error))
-        return EmptyCancellable()
-      }
-
-      return WebSocketTask(self, operation) { [weak store, contextIdentifier] result in
-        Task {
-          do {
-            let jsonBody = try result.get()
-            let response = GraphQLResponse(operation: operation, body: jsonBody)
-            
-            if let store = store {
-              let (graphQLResult, parsedRecords) = try await response.parseResult()
-              guard let records = parsedRecords else {
-                callCompletion(with: .success(graphQLResult))
-                return
-              }
-              
-              try await store.publish(records: records, identifier: contextIdentifier)
-              
-              callCompletion(with: .success(graphQLResult))
-              
-            } else {
-              let graphQLResult = try await response.parseResultFast()
-              callCompletion(with: .success(graphQLResult))
-            }
-            
-          } catch {
-            callCompletion(with: .failure(error))
-          }
-        }        
-      }
+      continuation.onTermination = { _ in task.cancel() }
     }
+  }
 }
 
 // MARK: - WebSocketDelegate implementation


### PR DESCRIPTION
Changes the `NetworkTransport` protocol and implementations to return an `AsyncThrowingStream` of results instead of using a completion handler.

`ApolloClient` will have new APIs that return the `AsyncThrowingStream` in a later PR in the stack. For now, we are wrapping that stream and returning its results through the completion handlers for `ApolloClient`.