### PR TITLE
fix: Multiline warning annotation line separator

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -12657,7 +12657,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      #warning("Argument 'name' of field 'friend' is deprecated. Reason: 'Someone broke it.'"),
+      #warning("Argument 'name' of field 'friend' is deprecated. Reason: 'Someone broke it.'")
       #warning("Argument 'species' of field 'friend' is deprecated. Reason: 'Who cares?'")
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
@@ -12707,7 +12707,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      #warning("Argument 'name' of field 'friend' is deprecated. Reason: 'Someone broke it.'"),
+      #warning("Argument 'name' of field 'friend' is deprecated. Reason: 'Someone broke it.'")
       #warning("Argument 'species' of field 'species' is deprecated. Reason: 'Redundant'")
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -295,7 +295,7 @@ struct SelectionSetTemplate {
       \(if: deprecatedArguments != nil && !deprecatedArguments.unsafelyUnwrapped.isEmpty, """
       \(deprecatedArguments.unsafelyUnwrapped.map { """
         \(field: $0.field, argument: $0.arg, warningReason: $0.reason)
-        """})
+        """}, separator: "\n")
       """)
       \(selectionsTemplate)
       """


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3559.

Simple fix - needs the line separator to be explicit rather than the default list-style separator `,\n`.