### PR TITLE
Make cache public within ReadTransaction

### DIFF
--- a/apollo-ios/Sources/Apollo/ApolloStore.swift
+++ b/apollo-ios/Sources/Apollo/ApolloStore.swift
@@ -201,11 +201,13 @@ public class ApolloStore {
   }
 
   public class ReadTransaction {
-    fileprivate let cache: any NormalizedCache
-      
+    fileprivate let _cache: any NormalizedCache
+
+    public var readOnlyCache: any ReadOnlyNormalizedCache { _cache }
+
     fileprivate lazy var loader: DataLoader<CacheKey, Record> = DataLoader { [weak self] batchLoad in
           guard let self else { return [:] }
-          return try cache.loadRecords(forKeys: batchLoad)
+          return try _cache.loadRecords(forKeys: batchLoad)
     }
 
     fileprivate lazy var executor = GraphQLExecutor(
@@ -213,7 +215,7 @@ public class ApolloStore {
     ) 
 
     fileprivate init(store: ApolloStore) {
-      self.cache = store.cache
+      self._cache = store.cache
     }
 
     public func read<Query: GraphQLQuery>(query: Query) throws -> Query.Data {
@@ -263,6 +265,8 @@ public class ApolloStore {
   }
 
   public final class ReadWriteTransaction: ReadTransaction {
+
+    public var cache: any NormalizedCache { _cache }
 
     fileprivate var updateChangedKeysFunc: DidChangeKeysFunc?
 

--- a/apollo-ios/Sources/Apollo/NormalizedCache.swift
+++ b/apollo-ios/Sources/Apollo/NormalizedCache.swift
@@ -1,12 +1,12 @@
-public protocol NormalizedCache: AnyObject {
-  
+public protocol NormalizedCache: AnyObject, ReadOnlyNormalizedCache {
+
   /// Loads records corresponding to the given keys.
   ///
   /// - Parameters:
   ///   - key: The cache keys to load data for
   /// - Returns: A dictionary of cache keys to records containing the records that have been found.
   func loadRecords(forKeys keys: Set<CacheKey>) throws -> [CacheKey: Record]
-    
+
   /// Merges a set of records into the cache.
   ///
   /// - Parameters:
@@ -45,4 +45,16 @@ public protocol NormalizedCache: AnyObject {
 
   /// Clears all records.
   func clear() throws
+}
+
+/// A read-only view of a `NormalizedCache` for use within a `ReadTransaction`.
+public protocol ReadOnlyNormalizedCache: AnyObject {
+
+  /// Loads records corresponding to the given keys.
+  ///
+  /// - Parameters:
+  ///   - key: The cache keys to load data for
+  /// - Returns: A dictionary of cache keys to records containing the records that have been found.
+  func loadRecords(forKeys keys: Set<CacheKey>) throws -> [CacheKey: Record]
+
 }


### PR DESCRIPTION
Some users have use cases for accessing a custom `NormalizedCache` implementation directly while performing cache transactions. We don’t want to make `cache` a `public` property on the `ApolloStore`, because that would allow users to manipulate the cache outside of the Reader/Writer lock (implemented by the barrier queue). Making this `public` on the `ReadTransaction` (and therby it’s subclass `ReadWriteTransaction`), we can allow custom cache access only when it is safe to do so from within a transaction.

By adding a new `ReadOnlyNormalizedCache` protocol, we can expose the cache as read-only in the `ReadTransaction` and as writable in the `ReadWriteTransaction`.

I don't really think there is anything to be unit tested here. We're not adding any behavior, just exposing an already existing property.