### PR TITLE
Custom SQLiteDatabase Implementations

### DIFF
--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -6,6 +6,11 @@ import Apollo
 public struct DatabaseRow {
   let cacheKey: CacheKey
   let storedInfo: String
+
+  public init(cacheKey: CacheKey, storedInfo: String) {
+    self.cacheKey = cacheKey
+    self.storedInfo = storedInfo
+  }
 }
 
 public enum SQLiteError: Error, CustomStringConvertible {


### PR DESCRIPTION
Add a public initializer to `DatabaseRow` to enable custom `SQLiteDatabase` implementations

### Background

The `SQLiteNormalizedCache` is nicely structured with protocols so that consumers of the library can implement their own components under the hood if they choose to. There are a couple reasons one might want to do this:

* to use a different SQLite implementation (mentioned as a goal in [a comment on the original dependency inversion PR](https://github.com/apollographql/apollo-ios/pull/1722#discussion_r595590746))
* to add custom functionality under the hood, like a TTL policy for rows in the cache (I am trying to follow this path, motivating this PR)

### The Problem

All of that is possible! ...almost

The use of `SQLiteDatabase` protocol makes it easy to implement and inject your own implementation, with one blocking exception. The missing piece is a public initializer for `DatabaseRow`, a type returned by one of the methods:

https://github.com/apollographql/apollo-ios-dev/blob/aad10caa4bda217c55ad01312e40cb4c1cb9b8ad/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift#L37

If I as a consumer try to implement the public `SQLiteDatabase` protocol, I am blocked by this method, because I cannot instantiate `DatabaseRow` values. The default, automatic memberwise initializer for any Swift struct is _internal_, meaning that consumers of a library cannot use it, and get an error if trying to instantiate:

<img width="1228" alt="Screenshot 2025-06-03 at 6 56 02 PM" src="https://github.com/user-attachments/assets/bbdca24e-1d05-4b2d-8a1f-8b7d37167a15" />

The change here, to add an explicit `public init` to this struct type, is all that is needed to enable custom SQLite implementations, as [the original PR from 2021](https://github.com/apollographql/apollo-ios/pull/1722#discussion_r595590746) seems to have intended. This change would allow me to implement the custom TTL policy on my own Apollo cache

### Testing

There is no imperative logic change here to test. The best way to unit test this would be to add a full custom SQLiteDatabase implementation to the test suite, which I am happy to do, but seemed like a larger change. Risk here is low, so I skipped doing that for now

### Alternatives

I could implement an entire `NormalizedCache`, possibly copying lots of code already in the repo. That is possible, but it would be much easier to allow flexibility with the utilities already provided by the sdk, by making this small change