### PR TITLE
Create ClientContext for ClientAwareness

### DIFF
--- a/apollo-ios/Sources/Apollo/ClientAwarenessMetadata.swift
+++ b/apollo-ios/Sources/Apollo/ClientAwarenessMetadata.swift
@@ -11,12 +11,12 @@ public struct ClientAwarenessMetadata: Sendable {
   /// The name of the application. This value is sent for the header "apollographql-client-name".
   ///
   /// Defaults to `nil`.
-  public var clientApplicationName: String?
+  public let clientApplicationName: String?
 
   /// The version of the application. This value is sent for the header "apollographql-client-version".
   ///
   /// Defaults to `nil`.
-  public var clientApplicationVersion: String?
+  public let clientApplicationVersion: String?
 
   /// Determines if the Apollo iOS library name and version should be sent with the telemetry data.
   ///

--- a/apollo-ios/Sources/Apollo/JSONRequest.swift
+++ b/apollo-ios/Sources/Apollo/JSONRequest.swift
@@ -1,6 +1,7 @@
 import Foundation
+
 #if !COCOAPODS
-@_spi(Internal) import ApolloAPI
+  @_spi(Internal) import ApolloAPI
 #endif
 
 /// A request which sends JSON related to a GraphQL operation.
@@ -30,12 +31,7 @@ public struct JSONRequest<Operation: GraphQLOperation>: GraphQLRequest, AutoPers
   /// to cache the results of queries that rarely change.
   ///
   /// Mutation operations always use POST, even when this is `false`
-  public let useGETForQueries: Bool
-
-  /// The telemetry metadata about the client. This is used by GraphOS Studio's
-  /// [client awareness](https://www.apollographql.com/docs/graphos/platform/insights/client-segmentation)
-  /// feature.
-  public var clientAwarenessMetadata: ClientAwarenessMetadata
+  public let useGETForQueries: Bool  
 
   /// Designated initializer
   ///
@@ -56,35 +52,34 @@ public struct JSONRequest<Operation: GraphQLOperation>: GraphQLRequest, AutoPers
     fetchBehavior: FetchBehavior,
     apqConfig: AutoPersistedQueryConfiguration = .init(),
     useGETForQueries: Bool = false,
-    requestBodyCreator: any JSONRequestBodyCreator = DefaultRequestBodyCreator(),
-    clientAwarenessMetadata: ClientAwarenessMetadata = ClientAwarenessMetadata()
+    requestBodyCreator: any JSONRequestBodyCreator = DefaultRequestBodyCreator()
   ) {
     self.operation = operation
     self.graphQLEndpoint = graphQLEndpoint
     self.fetchBehavior = fetchBehavior
-    self.context = context
     self.requestBodyCreator = requestBodyCreator
 
     self.apqConfig = apqConfig
     self.useGETForQueries = useGETForQueries
-    self.clientAwarenessMetadata = clientAwarenessMetadata
 
     self.setupDefaultHeaders()
   }
 
   private mutating func setupDefaultHeaders() {
-    self.addHeader(name: "Content-Type", value: "application/json")    
+    self.addHeader(name: "Content-Type", value: "application/json")
 
     if Operation.operationType == .subscription {
       self.addHeader(
         name: "Accept",
-        value: "multipart/mixed;\(MultipartResponseSubscriptionParser.protocolSpec),application/graphql-response+json,application/json"
+        value:
+          "multipart/mixed;\(MultipartResponseSubscriptionParser.protocolSpec),application/graphql-response+json,application/json"
       )
 
     } else {
       self.addHeader(
         name: "Accept",
-        value: "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/graphql-response+json,application/json"
+        value:
+          "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/graphql-response+json,application/json"
       )
     }
   }
@@ -100,15 +95,15 @@ public struct JSONRequest<Operation: GraphQLOperation>: GraphQLRequest, AutoPers
       if isPersistedQueryRetry {
         useGetMethod = self.apqConfig.useGETForPersistedQueryRetry
       } else {
-        useGetMethod = self.useGETForQueries ||
-        (self.apqConfig.autoPersistQueries && self.apqConfig.useGETForPersistedQueryRetry)
+        useGetMethod =
+          self.useGETForQueries || (self.apqConfig.autoPersistQueries && self.apqConfig.useGETForPersistedQueryRetry)
       }
     default:
       useGetMethod = false
     }
-    
+
     let httpMethod: GraphQLHTTPMethod = useGetMethod ? .GET : .POST
-    
+
     switch httpMethod {
     case .GET:
       let transformer = GraphQLGETTransformer(body: body, url: self.graphQLEndpoint)
@@ -130,7 +125,7 @@ public struct JSONRequest<Operation: GraphQLOperation>: GraphQLRequest, AutoPers
         throw GraphQLHTTPRequestError.serializedBodyMessageError
       }
     }
-    
+
     return request
   }
 
@@ -159,12 +154,12 @@ public struct JSONRequest<Operation: GraphQLOperation>: GraphQLRequest, AutoPers
       sendQueryDocument = true
       autoPersistQueries = false
     }
-    
+
     let body = self.requestBodyCreator.requestBody(
-      for: self,
+      for: self.operation,
       sendQueryDocument: sendQueryDocument,
       autoPersistQuery: autoPersistQueries
-    )    
+    )
 
     return body
   }

--- a/apollo-ios/Sources/Apollo/RequestBodyCreator.swift
+++ b/apollo-ios/Sources/Apollo/RequestBodyCreator.swift
@@ -7,6 +7,7 @@ public struct DefaultRequestBodyCreator: JSONRequestBodyCreator {
   public init() { }
 }
 
+#warning("TODO: Do we really need this? Should it be part of RequestChainNetworkTransport, or just on JSONRequest")
 public protocol JSONRequestBodyCreator: Sendable {
   #warning("TODO: replace with version that takes request after rewriting websocket")
   /// Creates a `JSONEncodableDictionary` out of the passed-in operation
@@ -26,8 +27,7 @@ public protocol JSONRequestBodyCreator: Sendable {
   func requestBody<Operation: GraphQLOperation>(
     for operation: Operation,
     sendQueryDocument: Bool,
-    autoPersistQuery: Bool,
-    clientAwarenessMetadata: ClientAwarenessMetadata
+    autoPersistQuery: Bool
   ) -> JSONEncodableDictionary
 
 }
@@ -36,31 +36,10 @@ public protocol JSONRequestBodyCreator: Sendable {
 
 extension JSONRequestBodyCreator {
 
-  /// Creates a `JSONEncodableDictionary` out of the passed-in request
-  ///
-  /// - Parameters:
-  ///   - request: The `GraphQLRequest` to create the JSON body for.
-  ///   - sendQueryDocument: Whether or not to send the full query document. Should default to `true`.
-  ///   - autoPersistQuery: Whether to use auto-persisted query information. Should default to `false`.
-  /// - Returns: The created `JSONEncodableDictionary`
-  public func requestBody<Request: GraphQLRequest>(
-    for request: Request,
-    sendQueryDocument: Bool,
-    autoPersistQuery: Bool
-  ) -> JSONEncodableDictionary {
-    self.requestBody(
-      for: request.operation,
-      sendQueryDocument: sendQueryDocument,
-      autoPersistQuery: autoPersistQuery,
-      clientAwarenessMetadata: request.clientAwarenessMetadata
-    )
-  }
-
   public func requestBody<Operation: GraphQLOperation>(
     for operation: Operation,
     sendQueryDocument: Bool,
-    autoPersistQuery: Bool,
-    clientAwarenessMetadata: ClientAwarenessMetadata
+    autoPersistQuery: Bool    
   ) -> JSONEncodableDictionary {
     var body: JSONEncodableDictionary = [
       "operationName": Operation.operationName,
@@ -87,7 +66,9 @@ extension JSONRequestBodyCreator {
       ]
     }
 
-    clientAwarenessMetadata.applyExtension(to: &body)
+    if let clientAwarenessMetadata = ApolloClient.context?.clientAwarenessMetadata {
+      clientAwarenessMetadata.applyExtension(to: &body)
+    }
 
     return body
   }


### PR DESCRIPTION
Added `ClientContext` as an internal `@TaskLocal` value that can be consumed by other internal parts of the system.

We are currently using this to provide a `ClientAwarenessMetadata` that is provided by the user during client initialization. This is used by the default implementations of `DefaultRequestBodyCreator` and `GraphQLRequest.createDefaultRequest()`.