### PR TITLE
[v2] [13/X] Refactor GraphQLQueryWatcher

### DIFF
--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -100,15 +100,31 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
 
   // MARK: - Fetch Query
 
+  // MARK: Fetch Query w/Fetch Behavior
+
+  public func fetch<Query: GraphQLQuery>(
+    query: Query,
+    fetchBehavior: FetchBehavior = FetchBehavior.CacheElseNetwork,
+    requestConfiguration: RequestConfiguration? = nil
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error> {
+    return try doInClientContext {
+      return try self.networkTransport.send(
+        query: query,
+        fetchBehavior: fetchBehavior,
+        requestConfiguration: requestConfiguration ?? self.defaultRequestConfiguration
+      )
+    }
+  }
+
   // MARK: Single Response Format
 
   public func fetch<Query: GraphQLQuery>(
     query: Query,
-    cachePolicy: CachePolicy.Query.SingleResponse = .cacheElseNetwork,
+    cachePolicy: CachePolicy.Query.SingleResponse,
     requestConfiguration: RequestConfiguration? = nil
   ) async throws -> GraphQLResult<Query.Data>
   where Query.ResponseFormat == SingleResponseFormat {
-    for try await result in try sendQuery(
+    for try await result in try fetch(
       query: query,
       fetchBehavior: cachePolicy.toFetchBehavior(),
       requestConfiguration: requestConfiguration
@@ -135,7 +151,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
 
   public func fetch<Query: GraphQLQuery>(
     query: Query,
-    cachePolicy: CachePolicy.Query.SingleResponse = .cacheElseNetwork,
+    cachePolicy: CachePolicy.Query.SingleResponse,
     requestConfiguration: RequestConfiguration? = nil
   ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat {
@@ -176,52 +192,138 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     throw ApolloClientError.noResults
   }
 
-  // MARK: Fetch Query w/Fetch Behavior
-
-  public func fetch<Query: GraphQLQuery>(
-    query: Query,
-    fetchBehavior: FetchBehavior,
-    requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error> {
-    return try doInClientContext {
-      return try self.networkTransport.send(
-        query: query,
-        fetchBehavior: fetchBehavior,
-        requestConfiguration: requestConfiguration ?? self.defaultRequestConfiguration
-      )
-    }
-  }
-
   // MARK: - Watch Query
 
-  /// Watches a query by first fetching an initial result from the server or from the local cache, depending on the current contents of the cache and the specified cache policy. After the initial fetch, the returned query watcher object will get notified whenever any of the data the query result depends on changes in the local cache, and calls the result handler again with the new result.
+  // MARK: Watch Query w/Fetch Behavior
+
+  /// Watches a query by first fetching an initial result from the server or from the local cache, depending on the
+  /// current contents of the cache and the specified cache policy. After the initial fetch, the returned query
+  /// watcher object will get notified whenever any of the data the query result depends on changes in the local cache,
+  /// and calls the result handler again with the new result.
   ///
   /// - Parameters:
   ///   - query: The query to fetch.
-  ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
+  ///   - fetchBehavior: A ``FetchBehavior`` that specifies when results should be fetched from the server or from the
+  ///   local cache.
+  ///   - requestConfiguration: A ``RequestConfiguration`` to use for the watcher's initial fetch. If `nil` the
+  ///   client's `defaultRequestConfiguration` will be used.
   ///   - refetchOnFailedUpdates: Should the watcher perform a network fetch when it's watched
-  ///     objects have changed, but reloading them from the cache fails. Should default to `true`.
-  ///   - context: [optional] A context that is being passed through the request chain. Should default to `nil`.
-  ///   - callbackQueue: A dispatch queue on which the result handler will be called. Should default to the main queue.
-  ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
+  ///   objects have changed, but reloading them from the cache fails. Defaults to `true`.
+  ///   - resultHandler: A closure that is called when query results are available or when an error occurs.
   /// - Returns: A query watcher object that can be used to control the watching behavior.
   public func watch<Query: GraphQLQuery>(
     query: Query,
-    cachePolicy: CachePolicy? = nil,
+    fetchBehavior: FetchBehavior = FetchBehavior.CacheElseNetwork,
+    requestConfiguration: RequestConfiguration? = nil,
     refetchOnFailedUpdates: Bool = true,
-    callbackQueue: DispatchQueue = .main,
-    resultHandler: @escaping GraphQLResultHandler<Query.Data>
+    resultHandler: @escaping GraphQLQueryWatcher<Query>.ResultHandler
   ) -> GraphQLQueryWatcher<Query> {
     let watcher = GraphQLQueryWatcher(
       client: self,
       query: query,
       refetchOnFailedUpdates: refetchOnFailedUpdates,
-      callbackQueue: callbackQueue,
       resultHandler: resultHandler
     )
-    watcher.fetch(cachePolicy: cachePolicy ?? self.defaultCachePolicy)
+    Task {
+      await watcher.fetch(fetchBehavior: fetchBehavior, requestConfiguration: requestConfiguration)
+    }
     return watcher
   }
+
+  /// Watches a query by first fetching an initial result from the server or from the local cache, depending on the
+  /// current contents of the cache and the specified cache policy. After the initial fetch, the returned query
+  /// watcher object will get notified whenever any of the data the query result depends on changes in the local cache,
+  /// and calls the result handler again with the new result.
+  ///
+  /// - Parameters:
+  ///   - query: The query to fetch.
+  ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the
+  ///   local cache.
+  ///   - requestConfiguration: A ``RequestConfiguration`` to use for the watcher's initial fetch. If `nil` the
+  ///   client's `defaultRequestConfiguration` will be used.
+  ///   - refetchOnFailedUpdates: Should the watcher perform a network fetch when it's watched
+  ///   objects have changed, but reloading them from the cache fails. Defaults to `true`.
+  ///   - resultHandler: A closure that is called when query results are available or when an error occurs.
+  /// - Returns: A query watcher object that can be used to control the watching behavior.
+  public func watch<Query: GraphQLQuery>(
+    query: Query,
+    cachePolicy: CachePolicy.Query.SingleResponse,
+    requestConfiguration: RequestConfiguration? = nil,
+    refetchOnFailedUpdates: Bool = true,
+    resultHandler: @escaping GraphQLQueryWatcher<Query>.ResultHandler
+  ) -> GraphQLQueryWatcher<Query> {
+    return self.watch(
+      query: query,
+      fetchBehavior: cachePolicy.toFetchBehavior(),
+      requestConfiguration: requestConfiguration,
+      refetchOnFailedUpdates: refetchOnFailedUpdates,
+      resultHandler: resultHandler
+    )
+  }
+
+  /// Watches a query by first fetching an initial result from the server or from the local cache, depending on the
+  /// current contents of the cache and the specified cache policy. After the initial fetch, the returned query
+  /// watcher object will get notified whenever any of the data the query result depends on changes in the local cache,
+  /// and calls the result handler again with the new result.
+  ///
+  /// - Parameters:
+  ///   - query: The query to fetch.
+  ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the
+  ///   local cache.
+  ///   - requestConfiguration: A ``RequestConfiguration`` to use for the watcher's initial fetch. If `nil` the
+  ///   client's `defaultRequestConfiguration` will be used.
+  ///   - refetchOnFailedUpdates: Should the watcher perform a network fetch when it's watched
+  ///   objects have changed, but reloading them from the cache fails. Defaults to `true`.
+  ///   - resultHandler: A closure that is called when query results are available or when an error occurs.
+  /// - Returns: A query watcher object that can be used to control the watching behavior.
+  public func watch<Query: GraphQLQuery>(
+    query: Query,
+    cachePolicy: CachePolicy.Query.CacheThenNetwork,
+    requestConfiguration: RequestConfiguration? = nil,
+    refetchOnFailedUpdates: Bool = true,
+    resultHandler: @escaping GraphQLQueryWatcher<Query>.ResultHandler
+  ) -> GraphQLQueryWatcher<Query> {
+    return self.watch(
+      query: query,
+      fetchBehavior: FetchBehavior.CacheThenNetwork,
+      requestConfiguration: requestConfiguration,
+      refetchOnFailedUpdates: refetchOnFailedUpdates,
+      resultHandler: resultHandler
+    )
+  }
+
+  /// Watches a query by first fetching an initial result from the server or from the local cache, depending on the
+  /// current contents of the cache and the specified cache policy. After the initial fetch, the returned query
+  /// watcher object will get notified whenever any of the data the query result depends on changes in the local cache,
+  /// and calls the result handler again with the new result.
+  ///
+  /// - Parameters:
+  ///   - query: The query to fetch.
+  ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the
+  ///   local cache.
+  ///   - requestConfiguration: A ``RequestConfiguration`` to use for the watcher's initial fetch. If `nil` the
+  ///   client's `defaultRequestConfiguration` will be used.
+  ///   - refetchOnFailedUpdates: Should the watcher perform a network fetch when it's watched
+  ///   objects have changed, but reloading them from the cache fails. Defaults to `true`.
+  ///   - resultHandler: A closure that is called when query results are available or when an error occurs.
+  /// - Returns: A query watcher object that can be used to control the watching behavior.
+  public func watch<Query: GraphQLQuery>(
+    query: Query,
+    cachePolicy: CachePolicy.Query.CacheOnly,
+    requestConfiguration: RequestConfiguration? = nil,
+    refetchOnFailedUpdates: Bool = true,
+    resultHandler: @escaping GraphQLQueryWatcher<Query>.ResultHandler
+  ) -> GraphQLQueryWatcher<Query> {
+    return self.watch(
+      query: query,
+      fetchBehavior: FetchBehavior.CacheThenNetwork,
+      requestConfiguration: requestConfiguration,
+      refetchOnFailedUpdates: refetchOnFailedUpdates,
+      resultHandler: resultHandler
+    )
+  }
+
+  // MARK: - Perform Mutation
 
   @discardableResult
   public func perform<Mutation: GraphQLMutation>(
@@ -328,6 +430,38 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
 public typealias GraphQLResultHandler<Data: RootSelectionSet> = @Sendable (Result<GraphQLResult<Data>, any Error>) ->
   Void
 
+@available(*, deprecated)
+public enum CachePolicy_v1: Sendable, Hashable {
+  /// Return data from the cache if available, else fetch results from the server.
+  case returnCacheDataElseFetch
+  ///  Always fetch results from the server.
+  case fetchIgnoringCacheData
+  ///  Always fetch results from the server, and don't store these in the cache.
+  case fetchIgnoringCacheCompletely
+  /// Return data from the cache if available, else return an error.
+  case returnCacheDataDontFetch
+  /// Return data from the cache if available, and always fetch results from the server.
+  case returnCacheDataAndFetch
+
+  /// The current default cache policy.
+  nonisolated(unsafe) public static var `default`: CachePolicy_v1 = .returnCacheDataElseFetch
+
+  func toFetchBehavior() -> FetchBehavior {
+    switch self {
+    case .returnCacheDataElseFetch:
+      return FetchBehavior.CacheElseNetwork
+    case .fetchIgnoringCacheData:
+      return FetchBehavior.NetworkOnly
+    case .fetchIgnoringCacheCompletely:
+      return FetchBehavior.NetworkOnly
+    case .returnCacheDataDontFetch:
+      return FetchBehavior.CacheOnly
+    case .returnCacheDataAndFetch:
+      return FetchBehavior.CacheThenNetwork
+    }
+  }
+}
+
 extension ApolloClient {
 
   @available(*, deprecated)
@@ -341,16 +475,18 @@ extension ApolloClient {
   @available(*, deprecated)
   @discardableResult public func fetch<Query: GraphQLQuery>(
     query: Query,
-    cachePolicy: CachePolicy? = nil,
+    cachePolicy: CachePolicy_v1? = nil,
     context: (any RequestContext)? = nil,
     queue: DispatchQueue = .main,
     resultHandler: GraphQLResultHandler<Query.Data>? = nil
   ) -> (any Cancellable) {
+    let cachePolicy = cachePolicy ?? CachePolicy_v1.default
     return awaitStreamInTask(
       {
-        try self.networkTransport.send(
+        try self.fetch(
           query: query,
-          cachePolicy: cachePolicy ?? self.defaultCachePolicy
+          fetchBehavior: cachePolicy.toFetchBehavior(),
+          requestConfiguration: RequestConfiguration(writeResultsToCache: cachePolicy != .fetchIgnoringCacheCompletely)
         )
       },
       callbackQueue: queue,
@@ -395,37 +531,23 @@ extension ApolloClient {
   )
   public func watch<Query: GraphQLQuery>(
     query: Query,
-    cachePolicy: CachePolicy? = nil,
+    cachePolicy: CachePolicy_v1? = nil,
     context: (any RequestContext)? = nil,
     callbackQueue: DispatchQueue = .main,
     resultHandler: @escaping GraphQLResultHandler<Query.Data>
   ) -> GraphQLQueryWatcher<Query> {
-    let watcher = GraphQLQueryWatcher(
-      client: self,
+    let cachePolicy = cachePolicy ?? CachePolicy_v1.default
+    let config = RequestConfiguration(
+      requestTimeout: defaultRequestConfiguration.requestTimeout,
+      writeResultsToCache: cachePolicy == .fetchIgnoringCacheCompletely ?
+      false : defaultRequestConfiguration.writeResultsToCache
+    )
+    return self.watch(
       query: query,
-      context: context,
-      callbackQueue: callbackQueue,
+      fetchBehavior: cachePolicy.toFetchBehavior(),
+      requestConfiguration: config,
       resultHandler: resultHandler
     )
-    watcher.fetch(cachePolicy: cachePolicy ?? self.defaultCachePolicy)
-    return watcher
   }
 
-}
-
-// MARK: - Fetch Behavior Creation
-extension CachePolicy.Query.SingleResponse {
-  fileprivate func toFetchBehavior() -> FetchBehavior {
-    switch self {
-    case .cacheElseNetwork:
-      return FetchBehavior.CacheElseNetwork
-
-    case .networkElseCache:
-      return FetchBehavior.NetworkElseCache
-
-    case .networkOnly:
-      return FetchBehavior.NetworkOnly
-    }
-
-  }
 }

--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -170,7 +170,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   where Query.ResponseFormat == IncrementalDeferredResponseFormat {
     return try fetch(
       query: query,
-      fetchBehavior: FetchBehavior.CacheThenNetwork,
+      fetchBehavior: cachePolicy.toFetchBehavior(),
       requestConfiguration: requestConfiguration
     )
   }
@@ -184,7 +184,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   ) async throws -> GraphQLResult<Query.Data> {
     for try await result in try fetch(
       query: query,
-      fetchBehavior: FetchBehavior.CacheOnly,
+      fetchBehavior: cachePolicy.toFetchBehavior(),
       requestConfiguration: requestConfiguration
     ) {
       return result
@@ -285,7 +285,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   ) -> GraphQLQueryWatcher<Query> {
     return self.watch(
       query: query,
-      fetchBehavior: FetchBehavior.CacheThenNetwork,
+      fetchBehavior: cachePolicy.toFetchBehavior(),
       requestConfiguration: requestConfiguration,
       refetchOnFailedUpdates: refetchOnFailedUpdates,
       resultHandler: resultHandler
@@ -316,7 +316,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   ) -> GraphQLQueryWatcher<Query> {
     return self.watch(
       query: query,
-      fetchBehavior: FetchBehavior.CacheThenNetwork,
+      fetchBehavior: cachePolicy.toFetchBehavior(),
       requestConfiguration: requestConfiguration,
       refetchOnFailedUpdates: refetchOnFailedUpdates,
       resultHandler: resultHandler

--- a/apollo-ios/Sources/Apollo/AsyncThrowingStream+ExecutingInAsyncTask.swift
+++ b/apollo-ios/Sources/Apollo/AsyncThrowingStream+ExecutingInAsyncTask.swift
@@ -1,8 +1,11 @@
 import Foundation
 
 extension AsyncThrowingStream where Failure == any Swift.Error {
-  static func executingInAsyncTask(_ block: @escaping @Sendable (Continuation) async throws -> Void) -> Self {
-    return AsyncThrowingStream { continuation in
+  static func executingInAsyncTask(
+    bufferingPolicy: AsyncThrowingStream<Element, Failure>.Continuation.BufferingPolicy = .unbounded,
+    _ block: @escaping @Sendable (Continuation) async throws -> Void
+  ) -> Self {
+    return AsyncThrowingStream(bufferingPolicy: bufferingPolicy) { continuation in
       let task = Task {
         do {
           try await block(continuation)

--- a/apollo-ios/Sources/Apollo/AsyncThrowingStream+ExecutingInAsyncTask.swift
+++ b/apollo-ios/Sources/Apollo/AsyncThrowingStream+ExecutingInAsyncTask.swift
@@ -24,7 +24,7 @@ extension AsyncThrowingStream where Failure == any Swift.Error {
 extension AsyncThrowingStream.Continuation {
   func passthroughResults(
     of stream: AsyncThrowingStream<Element, Failure>
-  ) async throws {
+  ) async throws where Element: Sendable {
     for try await element in stream {
       self.yield(element)
     }

--- a/apollo-ios/Sources/Apollo/CachePolicy.swift
+++ b/apollo-ios/Sources/Apollo/CachePolicy.swift
@@ -49,6 +49,29 @@ extension CachePolicy.Query.SingleResponse {
     case .networkOnly:
       return FetchBehavior.NetworkOnly
     }
+  }
+}
 
+extension CachePolicy.Query.CacheOnly {
+  public func toFetchBehavior() -> FetchBehavior {
+    return FetchBehavior.CacheOnly
+  }
+}
+
+extension CachePolicy.Query.CacheThenNetwork {
+  public func toFetchBehavior() -> FetchBehavior {
+    return FetchBehavior.CacheThenNetwork
+  }
+}
+
+extension CachePolicy.Subscription {
+  public func toFetchBehavior() -> FetchBehavior {
+    switch self {
+    case .cacheThenNetwork:
+      return FetchBehavior.CacheThenNetwork
+
+    case .networkOnly:
+      return FetchBehavior.NetworkOnly
+    }
   }
 }

--- a/apollo-ios/Sources/Apollo/Cancellable.swift
+++ b/apollo-ios/Sources/Apollo/Cancellable.swift
@@ -1,22 +1,22 @@
+import Combine
 import Foundation
 
 /// An object that can be used to cancel an in progress action.
-@available(*, deprecated)
-public protocol Cancellable: AnyObject, Sendable {
-    /// Cancel an in progress action.
-    func cancel()
+public protocol Cancellable: Sendable, Combine.Cancellable {
+  /// Cancel an in progress action.
+  func cancel()
 }
 
 // MARK: - URL Session Conformance
 
 @available(*, deprecated)
-extension URLSessionTask: Cancellable {}
+extension URLSessionTask: Apollo.Cancellable {}
 
 // MARK: - Early-Exit Helper
 
 /// A class to return when we need to bail out of something which still needs to return `Cancellable`.
 @available(*, deprecated)
-public final class EmptyCancellable: Cancellable {
+public final class EmptyCancellable: Apollo.Cancellable {
 
   // Needs to be public so this can be instantiated outside of the current framework.
   public init() {}
@@ -26,11 +26,13 @@ public final class EmptyCancellable: Cancellable {
   }
 }
 
-// MARK: - Task Conformance
+// MARK: - Task Cancellable
+
+extension Task: Apollo.Cancellable { }
 
 #warning("Test that this works. Task is a struct, not a class.")
 @available(*, deprecated)
-public final class TaskCancellable<Success: Sendable, Failure: Error>: Cancellable {
+public final class TaskCancellable<Success: Sendable, Failure: Error>: Combine.Cancellable, Apollo.Cancellable {
 
   let task: Task<Success, Failure>
 
@@ -46,7 +48,7 @@ public final class TaskCancellable<Success: Sendable, Failure: Error>: Cancellab
 // MARK: - CancellationState
 
 @available(*, deprecated)
-public class CancellationState: Cancellable, @unchecked Sendable {
+public class CancellationState: Apollo.Cancellable, @unchecked Sendable {
 
   @Atomic var isCancelled: Bool = false
 

--- a/apollo-ios/Sources/Apollo/FetchBehavior.swift
+++ b/apollo-ios/Sources/Apollo/FetchBehavior.swift
@@ -54,12 +54,11 @@ public struct FetchBehavior: Sendable, Hashable {
     case onCacheMiss
   }
 
-  public var cacheRead: CacheReadBehavior
+  public let cacheRead: CacheReadBehavior
 
-  public var networkFetch: NetworkFetchBehavior
+  public let networkFetch: NetworkFetchBehavior
 
-
-  public init(
+  fileprivate init(
     cacheRead: CacheReadBehavior,
     networkFetch: NetworkFetchBehavior
   ) {

--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -97,6 +97,8 @@ public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber, Ap
     try await block(self)
   }
 
+  // MARK: - Fetch
+
   public func fetch(
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration? = nil
@@ -138,6 +140,28 @@ public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber, Ap
     }
   }
 
+  public func fetch(
+    cachePolicy: CachePolicy.Query.SingleResponse,
+    requestConfiguration: RequestConfiguration? = nil
+  ) {
+    self.fetch(fetchBehavior: cachePolicy.toFetchBehavior(), requestConfiguration: requestConfiguration)
+  }
+
+  public func fetch(
+    cachePolicy: CachePolicy.Query.CacheOnly,
+    requestConfiguration: RequestConfiguration? = nil
+  ) {
+    self.fetch(fetchBehavior: cachePolicy.toFetchBehavior(), requestConfiguration: requestConfiguration)
+  }
+
+  public func fetch(
+    cachePolicy: CachePolicy.Query.CacheThenNetwork,
+    requestConfiguration: RequestConfiguration? = nil
+  ) {
+    self.fetch(fetchBehavior: cachePolicy.toFetchBehavior(), requestConfiguration: requestConfiguration)
+  }
+
+  // MARK: - Result Handling
 
   private func didReceiveResult(_ result: GraphQLResult<Query.Data>) {
     guard !self.cancelled else { return }

--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -69,7 +69,7 @@ public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber, Ap
 
     self.fetchBlock = { [weak client] in
       guard let client else { return nil }
-
+      
       return try client.fetch(
         query: query,
         fetchBehavior: $0,

--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -232,8 +232,9 @@ private enum QueryWatcherContext {
 
 extension GraphQLQueryWatcher {
   @available(*, deprecated)
+  @_disfavoredOverload
   public init(
-    client: any ApolloClientProtocol,
+    client: ApolloClient,
     query: Query,
     refetchOnFailedUpdates: Bool = true,
     context: (any RequestContext)? = nil,

--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -12,7 +12,7 @@ public protocol NetworkTransport: AnyObject, Sendable {
   ///   - operation: The operation to send.
   ///   - fetchBehavior: The `FetchBehavior` to use for this request.
   ///                    Determines if fetching will include cache/network fetches.
-  ///   - requestConfiguration: TODO
+  ///   - requestConfiguration: A configuration used to configure per-request behaviors for this request
   /// - Returns: A stream of `GraphQLResult`s for each response.
   func send<Query: GraphQLQuery>(
     query: Query,
@@ -32,7 +32,8 @@ public protocol NetworkTransport: AnyObject, Sendable {
 public protocol SubscriptionNetworkTransport: NetworkTransport {
 
   func send<Subscription: GraphQLSubscription>(
-    subscription: Subscription,    
+    subscription: Subscription,
+    fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
   ) throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error>
 
@@ -48,9 +49,8 @@ public protocol UploadingNetworkTransport: NetworkTransport {
   /// - Parameters:
   ///   - operation: The operation to send
   ///   - files: An array of `GraphQLFile` objects to send.
-  ///   - context: [optional] A context that is being passed through the request chain.
+  ///   - requestConfiguration: A configuration used to configure per-request behaviors for this request
   /// - Returns: A stream of `GraphQLResult`s for each response.
-#warning("TODO: should support query and mutation as seperate functions")
   func upload<Operation: GraphQLOperation>(
     operation: Operation,
     files: [GraphQLFile],

--- a/apollo-ios/Sources/Apollo/RequestChain.swift
+++ b/apollo-ios/Sources/Apollo/RequestChain.swift
@@ -136,7 +136,7 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
     return InterceptorResultStream(
       stream: AsyncThrowingStream<GraphQLResponse<Operation>, any Error>.executingInAsyncTask { continuation in
         let fetchBehavior = request.fetchBehavior
-        var didYieldCacheData: Bool
+        var didYieldCacheData: Bool = false
 
         // If read from cache before network fetch
         if fetchBehavior.shouldReadFromCache(hadFailedNetworkFetch: false) {
@@ -150,7 +150,6 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
             }
 
             // Cache miss
-            didYieldCacheData = false
 
           } catch {
             #warning(
@@ -165,8 +164,6 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
             // Cache read failure
             if !fetchBehavior.shouldFetchFromNetwork(hadSuccessfulCacheRead: false) {
               throw error
-            } else {
-              didYieldCacheData = false
             }
           }
         }

--- a/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
@@ -138,7 +138,10 @@ public extension GraphQLMutation {
 
 // MARK: - GraphQLSubscription
 
-public protocol GraphQLSubscription: GraphQLOperation {}
+public protocol GraphQLSubscription: GraphQLOperation {
+  associatedtype ResponseFormat: OperationResponseFormat = SubscriptionResponseFormat
+}
+
 public extension GraphQLSubscription {
   @inlinable static var operationType: GraphQLOperationType { return .subscription }
 }
@@ -161,6 +164,8 @@ public struct IncrementalDeferredResponseFormat: OperationResponseFormat {
     self.deferredFragments = deferredFragments
   }
 }
+
+public struct SubscriptionResponseFormat: OperationResponseFormat {}
 
 // MARK: - GraphQLOperationVariableValue
 

--- a/apollo-ios/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -5,16 +5,20 @@ import Foundation
   import ApolloAPI
 #endif
 
-#warning(
-  """
-  TODO: This is messy. Why is http network transport called "uploadingNetworkTransport"?
-  Websocket transport should be typesafe to a protocol that guaruntees it supports web sockets/ subscriptions
-  """
-)
-/// A network transport that sends subscriptions using one `NetworkTransport` and other requests using another `NetworkTransport`. Ideal for sending subscriptions via a web socket but everything else via HTTP.
-public final class SplitNetworkTransport: Sendable {
-  private let uploadingNetworkTransport: any UploadingNetworkTransport
-  private let webSocketNetworkTransport: any SubscriptionNetworkTransport
+/// A network transport that sends allows you to use different `NetworkTransport` types for each operation type.
+///
+/// This can be used, for example, to send subscriptions via a web socket transport but everything else via HTTP.
+public final class SplitNetworkTransport<
+  QueryTransport: NetworkTransport,
+  MutationTransport: NetworkTransport,
+  SubscriptionTransport: Sendable,
+  UploadTransport: Sendable
+>: NetworkTransport, Sendable {
+
+  private let queryTransport: QueryTransport
+  private let mutationTransport: MutationTransport
+  private let subscriptionTransport: SubscriptionTransport
+  private let uploadTransport: UploadTransport
 
   /// Designated initializer
   ///
@@ -22,64 +26,73 @@ public final class SplitNetworkTransport: Sendable {
   ///   - uploadingNetworkTransport: An `UploadingNetworkTransport` to use for non-subscription requests. Should generally be a `RequestChainNetworkTransport` or something similar.
   ///   - webSocketNetworkTransport: A `NetworkTransport` to use for subscription requests. Should generally be a `WebSocketTransport` or something similar.
   public init(
-    uploadingNetworkTransport: any UploadingNetworkTransport,
-    webSocketNetworkTransport: any SubscriptionNetworkTransport
+    queryTransport: QueryTransport,
+    mutationTransport: MutationTransport,
+    subscriptionTransport: SubscriptionTransport = Void(),
+    uploadTransport: UploadTransport = Void(),
   ) {
-    self.uploadingNetworkTransport = uploadingNetworkTransport
-    self.webSocketNetworkTransport = webSocketNetworkTransport
+    self.queryTransport = queryTransport
+    self.mutationTransport = mutationTransport
+    self.subscriptionTransport = subscriptionTransport
+    self.uploadTransport = uploadTransport
   }
-}
 
-// MARK: - NetworkTransport conformance
+  // MARK: - NetworkTransport conformance
 
-extension SplitNetworkTransport: NetworkTransport {
-
-  public func send<Query>(
+  public func send<Query: GraphQLQuery>(
     query: Query,
-    cachePolicy: CachePolicy
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error> where Query: GraphQLQuery {
-    return try uploadingNetworkTransport.send(
+    fetchBehavior: FetchBehavior,
+    requestConfiguration: RequestConfiguration
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error> {
+    return try queryTransport.send(
       query: query,
-      cachePolicy: cachePolicy
+      fetchBehavior: fetchBehavior,
+      requestConfiguration: requestConfiguration
     )
   }
 
-  public func send<Mutation>(
+  public func send<Mutation: GraphQLMutation>(
     mutation: Mutation,
-    cachePolicy: CachePolicy
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error> where Mutation: GraphQLMutation {
-    return try uploadingNetworkTransport.send(
+    requestConfiguration: RequestConfiguration
+  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error> {
+    return try mutationTransport.send(
       mutation: mutation,
-      cachePolicy: cachePolicy
+      requestConfiguration: requestConfiguration
     )
   }
 }
 
 // MARK: - SubscriptionNetworkTransport conformance
 
-extension SplitNetworkTransport: SubscriptionNetworkTransport {
-  public func send<Subscription>(
+extension SplitNetworkTransport: SubscriptionNetworkTransport
+where SubscriptionTransport: SubscriptionNetworkTransport {
+
+  public func send<Subscription: GraphQLSubscription>(
     subscription: Subscription,
-    cachePolicy: CachePolicy
-  ) throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error> where Subscription: GraphQLSubscription {
-    return try webSocketNetworkTransport.send(
+    fetchBehavior: FetchBehavior,
+    requestConfiguration: RequestConfiguration
+  ) throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error> {
+    return try subscriptionTransport.send(
       subscription: subscription,
-      cachePolicy: cachePolicy
+      fetchBehavior: fetchBehavior,
+      requestConfiguration: requestConfiguration
     )
   }
 }
 
 // MARK: - UploadingNetworkTransport conformance
 
-extension SplitNetworkTransport: UploadingNetworkTransport {
+extension SplitNetworkTransport: UploadingNetworkTransport where UploadTransport: UploadingNetworkTransport {
 
   public func upload<Operation: GraphQLOperation>(
     operation: Operation,
-    files: [GraphQLFile]
+    files: [GraphQLFile],
+    requestConfiguration: RequestConfiguration
   ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
-    return try uploadingNetworkTransport.upload(
+    return try uploadTransport.upload(
       operation: operation,
-      files: files
+      files: files,
+      requestConfiguration: requestConfiguration
     )
   }
 }


### PR DESCRIPTION
The `GraphQLQueryWatcher` is now an `Actor` to ensure its thread safety. Significant changes to the implementation have been made to use structured concurrency, but the usage stays very similar.


Only significant difference is that I removed the `refetch()` function. The fetch functions are now public and there are overloads for all cache policies and `FetchBehavior`.