### PR TITLE
[v2] [14/X] NetworkTransport and Client Cleanup

### DIFF
--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -82,9 +82,10 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     let store = ApolloStore(cache: InMemoryNormalizedCache())
     let provider = DefaultInterceptorProvider()
     let transport = RequestChainNetworkTransport(
+      urlSession: URLSession(configuration: .default),
       interceptorProvider: provider,
-      endpointURL: url,
-      clientAwarenessMetadata: clientAwarenessMetadata
+      store: store,
+      endpointURL: url
     )
 
     self.init(
@@ -620,7 +621,7 @@ extension ApolloClient {
   @available(
     *,
     deprecated,
-    renamed: "upload(:requestConfiguration:)"
+    renamed: "upload(operation:files:requestConfiguration:)"
   )
   public func upload<Operation: GraphQLOperation>(
     operation: Operation,

--- a/apollo-ios/Sources/Apollo/AsyncThrowingStream+ExecutingInAsyncTask.swift
+++ b/apollo-ios/Sources/Apollo/AsyncThrowingStream+ExecutingInAsyncTask.swift
@@ -24,7 +24,7 @@ extension AsyncThrowingStream where Failure == any Swift.Error {
 extension AsyncThrowingStream.Continuation {
   func passthroughResults(
     of stream: AsyncThrowingStream<Element, Failure>
-  ) async throws {
+  ) async throws where Element: Sendable {
     for try await element in stream {
       self.yield(element)
     }

--- a/apollo-ios/Sources/Apollo/FetchBehavior.swift
+++ b/apollo-ios/Sources/Apollo/FetchBehavior.swift
@@ -54,12 +54,11 @@ public struct FetchBehavior: Sendable, Hashable {
     case onCacheMiss
   }
 
-  public var cacheRead: CacheReadBehavior
+  public let cacheRead: CacheReadBehavior
 
-  public var networkFetch: NetworkFetchBehavior
+  public let networkFetch: NetworkFetchBehavior
 
-
-  public init(
+  fileprivate init(
     cacheRead: CacheReadBehavior,
     networkFetch: NetworkFetchBehavior
   ) {

--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -69,7 +69,7 @@ public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber, Ap
 
     self.fetchBlock = { [weak client] in
       guard let client else { return nil }
-
+      
       return try client.fetch(
         query: query,
         fetchBehavior: $0,

--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -12,7 +12,7 @@ public protocol NetworkTransport: AnyObject, Sendable {
   ///   - operation: The operation to send.
   ///   - fetchBehavior: The `FetchBehavior` to use for this request.
   ///                    Determines if fetching will include cache/network fetches.
-  ///   - requestConfiguration: TODO
+  ///   - requestConfiguration: A configuration used to configure per-request behaviors for this request
   /// - Returns: A stream of `GraphQLResult`s for each response.
   func send<Query: GraphQLQuery>(
     query: Query,
@@ -48,7 +48,7 @@ public protocol UploadingNetworkTransport: NetworkTransport {
   /// - Parameters:
   ///   - operation: The operation to send
   ///   - files: An array of `GraphQLFile` objects to send.
-  ///   - requestConfiguration: TODO
+  ///   - requestConfiguration: A configuration used to configure per-request behaviors for this request
   /// - Returns: A stream of `GraphQLResult`s for each response.
   func upload<Operation: GraphQLOperation>(
     operation: Operation,

--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -48,9 +48,8 @@ public protocol UploadingNetworkTransport: NetworkTransport {
   /// - Parameters:
   ///   - operation: The operation to send
   ///   - files: An array of `GraphQLFile` objects to send.
-  ///   - context: [optional] A context that is being passed through the request chain.
+  ///   - requestConfiguration: TODO
   /// - Returns: A stream of `GraphQLResult`s for each response.
-#warning("TODO: should support query and mutation as seperate functions")
   func upload<Operation: GraphQLOperation>(
     operation: Operation,
     files: [GraphQLFile],

--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -32,7 +32,8 @@ public protocol NetworkTransport: AnyObject, Sendable {
 public protocol SubscriptionNetworkTransport: NetworkTransport {
 
   func send<Subscription: GraphQLSubscription>(
-    subscription: Subscription,    
+    subscription: Subscription,
+    fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
   ) throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error>
 

--- a/apollo-ios/Sources/Apollo/RequestChain.swift
+++ b/apollo-ios/Sources/Apollo/RequestChain.swift
@@ -136,7 +136,7 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
     return InterceptorResultStream(
       stream: AsyncThrowingStream<GraphQLResponse<Operation>, any Error>.executingInAsyncTask { continuation in
         let fetchBehavior = request.fetchBehavior
-        var didYieldCacheData: Bool
+        var didYieldCacheData: Bool = false
 
         // If read from cache before network fetch
         if fetchBehavior.shouldReadFromCache(hadFailedNetworkFetch: false) {
@@ -150,7 +150,6 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
             }
 
             // Cache miss
-            didYieldCacheData = false
 
           } catch {
             #warning(
@@ -165,8 +164,6 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
             // Cache read failure
             if !fetchBehavior.shouldFetchFromNetwork(hadSuccessfulCacheRead: false) {
               throw error
-            } else {
-              didYieldCacheData = false
             }
           }
         }

--- a/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
@@ -138,7 +138,10 @@ public extension GraphQLMutation {
 
 // MARK: - GraphQLSubscription
 
-public protocol GraphQLSubscription: GraphQLOperation {}
+public protocol GraphQLSubscription: GraphQLOperation {
+  associatedtype ResponseFormat: OperationResponseFormat = SubscriptionResponseFormat
+}
+
 public extension GraphQLSubscription {
   @inlinable static var operationType: GraphQLOperationType { return .subscription }
 }
@@ -161,6 +164,8 @@ public struct IncrementalDeferredResponseFormat: OperationResponseFormat {
     self.deferredFragments = deferredFragments
   }
 }
+
+public struct SubscriptionResponseFormat: OperationResponseFormat {}
 
 // MARK: - GraphQLOperationVariableValue
 

--- a/apollo-ios/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -69,10 +69,12 @@ where SubscriptionTransport: SubscriptionNetworkTransport {
 
   public func send<Subscription: GraphQLSubscription>(
     subscription: Subscription,
+    fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
   ) throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error> {
     return try subscriptionTransport.send(
       subscription: subscription,
+      fetchBehavior: fetchBehavior,
       requestConfiguration: requestConfiguration
     )
   }


### PR DESCRIPTION
This PR :
- Creates the new APIs for Mutation and Upload requests on `ApolloClient` and `NetworkTransport`.
- Reimagines `SplitNetworkTransport` as a generic type that allows for more flexible use cases.
- Aligns `ApolloClientProtocol` with new APIs
- Cleans up a lot of the documentation and code