### PR TITLE
Change interceptors back to being created all at once

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
+++ b/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
@@ -44,8 +44,8 @@ public final class MockNetworkTransport: NetworkTransport {
 
 
   private struct MockInterceptorProvider: InterceptorProvider {
-    func graphQLInterceptors<Request: GraphQLRequest>(for request: Request) -> [any ApolloInterceptor] {
-      return DefaultInterceptorProvider.shared.graphQLInterceptors(for: request) + [TaskLocalRequestInterceptor()]
+    func graphQLInterceptors<Operation: GraphQLOperation>(for operation: Operation) -> [any ApolloInterceptor] {
+      return DefaultInterceptorProvider.shared.graphQLInterceptors(for: operation) + [TaskLocalRequestInterceptor()]
     }
   }
 

--- a/Tests/ApolloTests/Cache/CacheDependentInterceptorTests.swift
+++ b/Tests/ApolloTests/Cache/CacheDependentInterceptorTests.swift
@@ -360,8 +360,8 @@ class GraphQLInterceptor_ErrorHandling_Tests: XCTestCase, CacheDependentTesting,
     struct TestProvider: InterceptorProvider {
       let errorInterceptor = RerouteToCacheErrorInterceptor()
 
-      func graphQLInterceptors<Request>(for request: Request) -> [any ApolloInterceptor] where Request : GraphQLRequest {
-        DefaultInterceptorProvider.shared.graphQLInterceptors(for: request) + [
+      func graphQLInterceptors<Operation: GraphQLOperation>(for operation: Operation) -> [any ApolloInterceptor] {
+        DefaultInterceptorProvider.shared.graphQLInterceptors(for: operation) + [
           errorInterceptor
         ]
       }

--- a/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
@@ -641,15 +641,16 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
     }
 
     let urlSession: MockURLSession = MockURLSession(responseProvider: Self.self)
+    let operation = MockQuery<Hero>()
 
     let requestChain = RequestChain<JSONRequest<MockQuery<Hero>>>(
       urlSession: urlSession,
-      interceptorProvider: DefaultInterceptorProvider.shared,
+      interceptors: Interceptors(provider: DefaultInterceptorProvider.shared, operation: operation),
       store: store
     )
 
     let request = JSONRequest.mock(
-      operation: MockQuery<Hero>(),
+      operation: operation,
       fetchBehavior: .NetworkOnly,
       graphQLEndpoint: TestURL.mockServer.url
     )    

--- a/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -24,7 +24,6 @@ public final class RequestChainNetworkTransport: NetworkTransport, Sendable {
   /// Defaults to an empty dictionary.
   public let additionalHeaders: [String: String]
 
-  #warning("Should this be moved into Client Config? APQs wont work for anything that doesn't use RequestChain with APQInterceptor.")
   /// A configuration struct used by a `GraphQLRequest` to configure the usage of
   /// [Automatic Persisted Queries (APQs).](https://www.apollographql.com/docs/apollo-server/performance/apq)
   /// By default, APQs are disabled.
@@ -141,7 +140,7 @@ public final class RequestChainNetworkTransport: NetworkTransport, Sendable {
   ) -> RequestChain<Request> {
     return RequestChain<Request>(
       urlSession: urlSession,
-      interceptorProvider: interceptorProvider,
+      interceptors: Interceptors(provider: interceptorProvider, operation: request.operation),
       store: store
     )
   }


### PR DESCRIPTION
I had changed the interceptors to being initialized on demand so that we could prevent initializing interceptors that ended up not being needed. But this meant that we were re-initializing the interceptors on a retry. That prevented them from carrying state over to the retry, which was not intended. It broke the MaxRetryInterceptor completely.

This could have been fixed by having the MaxRetryInterceptor use TaskLocal values for state, but that’s not the API we want to provide publicly. User created interceptors should be able to hold state.

So I moved back to providing all interceptors during initialization of the `RequestChain`.

I had also changed the interceptor provider to passing through the `GraphQLRequest` instead of just the `GraphQLOperation`. When we were getting providers on demand, that meant that we could pass through the request as it had been mutated by previous parts of the request chain. But since we are no longer doing that, we shouldn’t be providing users the request since it will only be the inital request and that could be unclear.

Instead, we should go back to the 1.0 behavior or just providing the immutable `GraphQLOperation.