### PR TITLE
V2 stream error handling fixes

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
+++ b/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
@@ -14,7 +14,7 @@ public final class MockNetworkTransport: NetworkTransport {
     let session = MockSession(server: mockServer)
     self.requestChainTransport = RequestChainNetworkTransport(
       urlSession: session,
-      interceptorProvider: DefaultInterceptorProvider.shared,
+      interceptorProvider: MockInterceptorProvider(),
       store: store,
       endpointURL: TestURL.mockServer.url
     )
@@ -54,10 +54,10 @@ public final class MockNetworkTransport: NetworkTransport {
 
     func intercept<Request>(
       request: Request,
-      next: (Request) async throws -> InterceptorResultStream<Request>
+      next: (Request) async -> InterceptorResultStream<Request>
     ) async throws -> InterceptorResultStream<Request> {
       return try await TaskLocalRequestInterceptor.$currentRequest.withValue(request) {
-        return try await next(request)
+        return await next(request)
       }
     }
   }

--- a/Tests/ApolloInternalTestHelpers/TestError.swift
+++ b/Tests/ApolloInternalTestHelpers/TestError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TestError: Error, CustomDebugStringConvertible {
+public struct TestError: Error, CustomDebugStringConvertible, Equatable {
   let message: String?
 
   public init(_ message: String? = nil) {

--- a/Tests/ApolloTests/BlindRetryingTestInterceptor.swift
+++ b/Tests/ApolloTests/BlindRetryingTestInterceptor.swift
@@ -8,7 +8,7 @@ class BlindRetryingTestInterceptor: ApolloInterceptor, @unchecked Sendable {
 
   func intercept<Request: GraphQLRequest>(
     request: Request,
-    next: (Request) async throws -> InterceptorResultStream<Request>
+    next: (Request) async -> InterceptorResultStream<Request>
   ) async throws -> InterceptorResultStream<Request> {
     self.hitCount += 1
     throw RequestChain.Retry(request: request)

--- a/Tests/ApolloTests/CancellationHandlingInterceptor.swift
+++ b/Tests/ApolloTests/CancellationHandlingInterceptor.swift
@@ -15,11 +15,11 @@ final class CancellationTestingInterceptor: ApolloInterceptor {
 
   func intercept<Request: GraphQLRequest>(
     request: Request,
-    next: (Request) async throws -> InterceptorResultStream<Request>
+    next: (Request) async -> InterceptorResultStream<Request>
   ) async throws -> InterceptorResultStream<Request> {
     do {
       try Task.checkCancellation()
-      return try await next(request)
+      return await next(request)
 
     } catch is CancellationError {
       self.hasBeenCancelled = true

--- a/Tests/ApolloTests/RetryToCountThenSucceedInterceptor.swift
+++ b/Tests/ApolloTests/RetryToCountThenSucceedInterceptor.swift
@@ -20,14 +20,14 @@ final class RetryToCountThenSucceedInterceptor: ApolloInterceptor {
 
   func intercept<Request: GraphQLRequest>(
     request: Request,
-    next: (Request) async throws -> InterceptorResultStream<Request>
+    next: (Request) async -> InterceptorResultStream<Request>
   ) async throws -> InterceptorResultStream<Request> {
     if self.timesRetryHasBeenCalled < self.timesToCallRetry {
       self.timesRetryHasBeenCalled += 1
       throw RequestChain.Retry(request: request)
 
     } else {
-      return try await next(request)
+      return await next(request)
     }
   }
 }

--- a/apollo-ios/Sources/Apollo/InterceptorResultStream.swift
+++ b/apollo-ios/Sources/Apollo/InterceptorResultStream.swift
@@ -16,15 +16,16 @@ import Foundation
 /// When a stream reaches it's final consumer, `getStream()` may be called to return the
 /// underlying `AsyncThrowingStream`. The caller is then responsible for ensuring the stream
 /// is only awaited by a single consumer.
-public struct NonCopyableAsyncThrowingStream<T: Sendable>: Sendable, ~Copyable {
+public struct NonCopyableAsyncThrowingStream<Element: Sendable>: Sendable, ~Copyable {
 
-  private let stream: AsyncThrowingStream<T, any Error>
+  private let stream: AsyncThrowingStream<Element, any Error>
 
-  public init(stream: AsyncThrowingStream<T, any Error>) {
+#warning("Maybe these shouldn't be public inits. Easy to create bugs when creating your own stream")
+  public init(stream: AsyncThrowingStream<Element, any Error>) {
     self.stream = stream
   }
 
-  public init<S: AsyncSequence & Sendable>(stream wrapped: sending S) where S.Element == T {
+  public init<S: AsyncSequence & Sendable>(stream wrapped: sending S) where S.Element == Element {
     self.stream = AsyncThrowingStream.executingInAsyncTask { [wrapped] continuation in
       for try await element in wrapped {
         continuation.yield(element)
@@ -32,9 +33,9 @@ public struct NonCopyableAsyncThrowingStream<T: Sendable>: Sendable, ~Copyable {
     }
   }
 
-  public consuming func map(
-    _ transform: @escaping @Sendable (T) async throws -> T
-  ) async throws -> NonCopyableAsyncThrowingStream<T> {
+  public consuming func map<ElementOfResult>(
+    _ transform: @escaping @Sendable (Element) async throws -> ElementOfResult
+  ) async rethrows -> NonCopyableAsyncThrowingStream<ElementOfResult> {
     let stream = self.stream
 
     let newStream = AsyncThrowingStream.executingInAsyncTask { continuation in
@@ -45,12 +46,12 @@ public struct NonCopyableAsyncThrowingStream<T: Sendable>: Sendable, ~Copyable {
       }
     }
 
-    return NonCopyableAsyncThrowingStream.init(stream: newStream)
+    return NonCopyableAsyncThrowingStream<ElementOfResult>.init(stream: newStream)
   }
 
-  public consuming func compactMap(
-    _ transform: @escaping @Sendable (T) async throws -> T?
-  ) async throws -> NonCopyableAsyncThrowingStream<T> {
+  public consuming func compactMap<ElementOfResult>(
+    _ transform: @escaping @Sendable (Element) async throws -> ElementOfResult?
+  ) async rethrows -> NonCopyableAsyncThrowingStream<ElementOfResult> {
     let stream = self.stream
 
     let newStream = AsyncThrowingStream.executingInAsyncTask { continuation in
@@ -65,7 +66,7 @@ public struct NonCopyableAsyncThrowingStream<T: Sendable>: Sendable, ~Copyable {
       }
     }
 
-    return NonCopyableAsyncThrowingStream.init(stream: newStream)
+    return NonCopyableAsyncThrowingStream<ElementOfResult>.init(stream: newStream)
   }
 
   /// Exposes the underlying `AsyncThrowingStream` for final consumption.
@@ -75,7 +76,7 @@ public struct NonCopyableAsyncThrowingStream<T: Sendable>: Sendable, ~Copyable {
   /// is only awaited by a single consumer.
   ///
   /// - Returns: The underlying `AsyncThrowingStream`
-  public consuming func getStream() -> AsyncThrowingStream<T, any Error> {
+  public consuming func getStream() -> AsyncThrowingStream<Element, any Error> {
     return stream
   }
 
@@ -83,8 +84,8 @@ public struct NonCopyableAsyncThrowingStream<T: Sendable>: Sendable, ~Copyable {
 
   #warning("TODO: Write unit tests for this. Docs: if return nil, error is supressed and stream finishes.")
   public consuming func mapErrors(
-    _ transform: @escaping @Sendable (any Error) async throws -> T?
-  ) async throws -> NonCopyableAsyncThrowingStream<T> {
+    _ transform: @escaping @Sendable (any Error) async throws -> Element?
+  ) async throws -> NonCopyableAsyncThrowingStream<Element> {
     let stream = self.stream
 
     let newStream = AsyncThrowingStream.executingInAsyncTask { continuation in

--- a/apollo-ios/Sources/Apollo/InterceptorResultStream.swift
+++ b/apollo-ios/Sources/Apollo/InterceptorResultStream.swift
@@ -35,7 +35,7 @@ public struct NonCopyableAsyncThrowingStream<Element: Sendable>: Sendable, ~Copy
 
   public consuming func map<ElementOfResult>(
     _ transform: @escaping @Sendable (Element) async throws -> ElementOfResult
-  ) async rethrows -> NonCopyableAsyncThrowingStream<ElementOfResult> {
+  ) async -> NonCopyableAsyncThrowingStream<ElementOfResult> {
     let stream = self.stream
 
     let newStream = AsyncThrowingStream.executingInAsyncTask { continuation in
@@ -51,7 +51,7 @@ public struct NonCopyableAsyncThrowingStream<Element: Sendable>: Sendable, ~Copy
 
   public consuming func compactMap<ElementOfResult>(
     _ transform: @escaping @Sendable (Element) async throws -> ElementOfResult?
-  ) async rethrows -> NonCopyableAsyncThrowingStream<ElementOfResult> {
+  ) async -> NonCopyableAsyncThrowingStream<ElementOfResult> {
     let stream = self.stream
 
     let newStream = AsyncThrowingStream.executingInAsyncTask { continuation in
@@ -85,7 +85,7 @@ public struct NonCopyableAsyncThrowingStream<Element: Sendable>: Sendable, ~Copy
   #warning("TODO: Write unit tests for this. Docs: if return nil, error is supressed and stream finishes.")
   public consuming func mapErrors(
     _ transform: @escaping @Sendable (any Error) async throws -> Element?
-  ) async throws -> NonCopyableAsyncThrowingStream<Element> {
+  ) async -> NonCopyableAsyncThrowingStream<Element> {
     let stream = self.stream
 
     let newStream = AsyncThrowingStream.executingInAsyncTask { continuation in
@@ -113,7 +113,7 @@ public struct NonCopyableAsyncThrowingStream<Element: Sendable>: Sendable, ~Copy
 
 }
 
-#warning("Do we keep this? Helps make TaskLocalValues work, but extension on Swift standard lib type could conflict with other extensions")
+#warning("Do we keep this public? Helps make TaskLocalValues work, but extension on Swift standard lib type could conflict with other extensions")
 extension TaskLocal {
 
   @_disfavoredOverload

--- a/apollo-ios/Sources/Apollo/Interceptors/ApolloInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/ApolloInterceptor.swift
@@ -29,7 +29,7 @@ public struct GraphQLResponse<Operation: GraphQLOperation>: Sendable, Hashable {
 /// A protocol to set up a chainable unit of networking work.
 public protocol ApolloInterceptor: Sendable {
 
-  typealias NextInterceptorFunction<Request: GraphQLRequest> = @Sendable (Request) async throws ->
+  typealias NextInterceptorFunction<Request: GraphQLRequest> = @Sendable (Request) async ->
     InterceptorResultStream<Request>
 
   /// Called when this interceptor should do its work.

--- a/apollo-ios/Sources/Apollo/Interceptors/AutomaticPersistedQueryInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/AutomaticPersistedQueryInterceptor.swift
@@ -40,12 +40,12 @@ public struct AutomaticPersistedQueryInterceptor: ApolloInterceptor {
     guard let jsonRequest = request as? JSONRequest<Request.Operation>,
           jsonRequest.apqConfig.autoPersistQueries else {
       // Not a request that handles APQs, continue along
-      return try await next(request)
+      return await next(request)
     }
 
     let isInitialResult = IsInitialResult()
 
-    return try await next(request).map { response in
+    return await next(request).map { response in
 #warning("TODO: Test if cache returns result, then server returns failed result, APQ retry still occurs")
       guard response.result.source == .server,
             await isInitialResult.get() else {

--- a/apollo-ios/Sources/Apollo/Interceptors/JSONResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/JSONResponseParsingInterceptor.swift
@@ -30,7 +30,7 @@ public actor JSONResponseParsingInterceptor: ResponseParsingInterceptor {
 
     let storage = ResultStorage<Request>()
 
-    return try await response.chunks.compactMap { chunk in
+    return await response.chunks.compactMap { chunk in
       try Task.checkCancellation()
 
       if let parsedResponse = try await parser.parse(

--- a/apollo-ios/Sources/Apollo/Interceptors/MaxRetryInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/MaxRetryInterceptor.swift
@@ -37,6 +37,6 @@ public actor MaxRetryInterceptor: ApolloInterceptor, Sendable {
     }
 
     self.hitCount += 1
-    return try await next(request)
+    return await next(request)
   }
 }


### PR DESCRIPTION
Fixes for Interceptor Error Handling

Interceptor `next` functions now are non-throwing. Interceptors may still throw errors, but those errors will be consumed by the `RequestChain` and thrown back out of the current `InterceptorResultStream`. This ensures that error handling interceptors receive all emitted errors by calling `mapError { error in }`.

Previously the error interceptor would need to catch the errors from calling `next` and also map the errors returned in the stream seperately.