### PR TITLE
[v2] Refactor GraphQLResult

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
+++ b/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
@@ -24,7 +24,7 @@ public final class MockNetworkTransport: NetworkTransport {
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error> {
     try requestChainTransport.send(
       query: query,
       fetchBehavior: fetchBehavior,
@@ -35,7 +35,7 @@ public final class MockNetworkTransport: NetworkTransport {
   public func send<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error> {
     try requestChainTransport.send(
       mutation: mutation,
       requestConfiguration: requestConfiguration

--- a/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
+++ b/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
@@ -24,7 +24,7 @@ public final class MockNetworkTransport: NetworkTransport {
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error> {
     try requestChainTransport.send(
       query: query,
       fetchBehavior: fetchBehavior,
@@ -35,7 +35,7 @@ public final class MockNetworkTransport: NetworkTransport {
   public func send<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Mutation>, any Error> {
     try requestChainTransport.send(
       mutation: mutation,
       requestConfiguration: requestConfiguration
@@ -56,7 +56,7 @@ public final class MockNetworkTransport: NetworkTransport {
       request: Request,
       next: (Request) async -> InterceptorResultStream<Request>
     ) async throws -> InterceptorResultStream<Request> {
-      return try await TaskLocalRequestInterceptor.$currentRequest.withValue(request) {
+      return await TaskLocalRequestInterceptor.$currentRequest.withValue(request) {
         return await next(request)
       }
     }

--- a/Tests/ApolloInternalTestHelpers/XCTestCase+Helpers.swift
+++ b/Tests/ApolloInternalTestHelpers/XCTestCase+Helpers.swift
@@ -41,7 +41,7 @@ import ApolloAPI
 
 public extension XCTestCase {
   /// Make  an `AsyncResultObserver` for receiving results of the specified GraphQL operation.
-  func makeResultObserver<Operation: GraphQLOperation>(for operation: Operation, file: StaticString = #filePath, line: UInt = #line) -> AsyncResultObserver<GraphQLResult<Operation>, any Error> {
+  func makeResultObserver<Operation: GraphQLOperation>(for operation: Operation, file: StaticString = #filePath, line: UInt = #line) -> AsyncResultObserver<GraphQLResponse<Operation>, any Error> {
     return AsyncResultObserver(testCase: self, file: file, line: line)
   }
 }
@@ -60,7 +60,7 @@ extension StoreLoading where Self: XCTestCase {
     operation: Operation,
     file: StaticString = #filePath,
     line: UInt = #line,
-    resultHandler: @escaping AsyncResultObserver<GraphQLResult<Operation>, any Error>.ResultHandler
+    resultHandler: @escaping AsyncResultObserver<GraphQLResponse<Operation>, any Error>.ResultHandler
   ) {
     let resultObserver = makeResultObserver(for: operation, file: file, line: line)
         

--- a/Tests/ApolloInternalTestHelpers/XCTestCase+Helpers.swift
+++ b/Tests/ApolloInternalTestHelpers/XCTestCase+Helpers.swift
@@ -41,7 +41,7 @@ import ApolloAPI
 
 public extension XCTestCase {
   /// Make  an `AsyncResultObserver` for receiving results of the specified GraphQL operation.
-  func makeResultObserver<Operation: GraphQLOperation>(for operation: Operation, file: StaticString = #filePath, line: UInt = #line) -> AsyncResultObserver<GraphQLResult<Operation.Data>, any Error> {
+  func makeResultObserver<Operation: GraphQLOperation>(for operation: Operation, file: StaticString = #filePath, line: UInt = #line) -> AsyncResultObserver<GraphQLResult<Operation>, any Error> {
     return AsyncResultObserver(testCase: self, file: file, line: line)
   }
 }
@@ -60,7 +60,7 @@ extension StoreLoading where Self: XCTestCase {
     operation: Operation,
     file: StaticString = #filePath,
     line: UInt = #line,
-    resultHandler: @escaping AsyncResultObserver<GraphQLResult<Operation.Data>, any Error>.ResultHandler
+    resultHandler: @escaping AsyncResultObserver<GraphQLResult<Operation>, any Error>.ResultHandler
   ) {
     let resultObserver = makeResultObserver(for: operation, file: file, line: line)
         

--- a/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
+++ b/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
@@ -90,7 +90,7 @@ class ParsingPerformanceTests: XCTestCase {
     for query: Query,
     file: StaticString = #file,
     line: UInt = #line
-  ) throws -> GraphQLResponse<Query.Data> {
+  ) throws -> ParsedResult<Query.Data> {
     let bundle = Bundle(for: type(of: self))
 
     guard let url = bundle.url(forResource: Query.operationName, withExtension: "json") else {
@@ -102,6 +102,6 @@ class ParsingPerformanceTests: XCTestCase {
     let data = try Data(contentsOf: url)
     let body = try JSONSerialization.jsonObject(with: data, options: []) as! JSONObject
 
-    return GraphQLResponse(operation: query, body: body)
+    return ParsedResult(operation: query, body: body)
   }
 }

--- a/Tests/ApolloTests/CancellationHandlingInterceptor.swift
+++ b/Tests/ApolloTests/CancellationHandlingInterceptor.swift
@@ -1,11 +1,3 @@
-//
-//  CancellationHandlingInterceptor.swift
-//  ApolloTests
-//
-//  Created by Ellen Shapiro on 9/17/20.
-//  Copyright © 2020 Apollo GraphQL. All rights reserved.
-//
-
 import Apollo
 import ApolloAPI
 import Foundation

--- a/Tests/ApolloTests/GraphQLResultTests.swift
+++ b/Tests/ApolloTests/GraphQLResultTests.swift
@@ -56,7 +56,7 @@ final class GraphQLResultTests: XCTestCase {
     ])
 
     // when
-    let result = GraphQLResult<MockHeroQuery>(
+    let result = GraphQLResponse<MockHeroQuery>(
       data: heroData,
       extensions: nil,
       errors: nil,
@@ -85,7 +85,7 @@ final class GraphQLResultTests: XCTestCase {
     ])
 
     // when
-    let result = GraphQLResult<MockHeroQuery>(
+    let result = GraphQLResponse<MockHeroQuery>(
       data: heroData,
       extensions: nil,
       errors: nil,
@@ -121,7 +121,7 @@ final class GraphQLResultTests: XCTestCase {
     ])
 
     // when
-    let result = GraphQLResult<MockHeroQuery>(
+    let result = GraphQLResponse<MockHeroQuery>(
       data: nil,
       extensions: nil,
       errors: [error],
@@ -174,7 +174,7 @@ final class GraphQLResultTests: XCTestCase {
     )
 
     // when
-    let result = GraphQLResult<MockHeroQuery>(
+    let result = GraphQLResponse<MockHeroQuery>(
       data: resultData,
       extensions: nil,
       errors: nil,
@@ -208,7 +208,7 @@ final class GraphQLResultTests: XCTestCase {
 
     // then
     XCTAssertEqual(merged.asJSONDictionary(), expected)
-    XCTAssertEqual(merged.source, GraphQLResult<MockHeroQuery>.Source.server)
+    XCTAssertEqual(merged.source, GraphQLResponse<MockHeroQuery>.Source.server)
 
     XCTAssertNil(merged.extensions)
     XCTAssertNil(merged.errors)
@@ -217,7 +217,7 @@ final class GraphQLResultTests: XCTestCase {
 
   func test__merging__givenIncrementalErrors_shouldMergeErrors() throws {
     // given
-    let result = GraphQLResult<MockHeroQuery>(
+    let result = GraphQLResponse<MockHeroQuery>(
       data: nil,
       extensions: nil,
       errors: [GraphQLError("Base Error")],
@@ -252,7 +252,7 @@ final class GraphQLResultTests: XCTestCase {
 
   func test__merging__givenIncrementalExtensions_shouldMergeExtensions() throws {
     // given
-    let result = GraphQLResult<MockHeroQuery>(
+    let result = GraphQLResponse<MockHeroQuery>(
       data: nil,
       extensions: ["FeatureA": true],
       errors: nil,
@@ -286,7 +286,7 @@ final class GraphQLResultTests: XCTestCase {
 
   func test__merging__givenIncrementalDependentKeys_shouldMergeDependentKeys() throws {
     // given
-    let result = GraphQLResult<MockHeroQuery>(
+    let result = GraphQLResponse<MockHeroQuery>(
       data: nil,
       extensions: nil,
       errors: nil,

--- a/Tests/ApolloTests/GraphQLResultTests.swift
+++ b/Tests/ApolloTests/GraphQLResultTests.swift
@@ -6,15 +6,15 @@ import ApolloInternalTestHelpers
 final class GraphQLResultTests: XCTestCase {
 
   // given
-  private class MockHeroQuery: MockQuery<MockHeroQuery.Data> {
-    class Data: MockSelectionSet {
+  private class MockHeroQuery: MockQuery<MockHeroQuery.Data>, @unchecked Sendable {
+    class Data: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("hero", Hero?.self)
       ]}
 
       public var hero: Hero? { __data["hero"] }
 
-      class Hero: AbstractMockSelectionSet<Hero.Fragments, MockSchemaMetadata> {
+      class Hero: AbstractMockSelectionSet<Hero.Fragments, MockSchemaMetadata>, @unchecked Sendable {
         override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
@@ -33,7 +33,7 @@ final class GraphQLResultTests: XCTestCase {
           @Deferred var deferredFriends: DeferredFriends?
         }
 
-        class DeferredFriends: MockTypeCase {
+        class DeferredFriends: MockTypeCase, @unchecked Sendable {
           override class var __selections: [Selection] {[
             .field("friends", [String].self)
           ]}
@@ -56,7 +56,7 @@ final class GraphQLResultTests: XCTestCase {
     ])
 
     // when
-    let result = GraphQLResult(
+    let result = GraphQLResult<MockHeroQuery>(
       data: heroData,
       extensions: nil,
       errors: nil,
@@ -85,7 +85,7 @@ final class GraphQLResultTests: XCTestCase {
     ])
 
     // when
-    let result = GraphQLResult(
+    let result = GraphQLResult<MockHeroQuery>(
       data: heroData,
       extensions: nil,
       errors: nil,
@@ -121,7 +121,7 @@ final class GraphQLResultTests: XCTestCase {
     ])
 
     // when
-    let result = GraphQLResult<MockHeroQuery.Data>(
+    let result = GraphQLResult<MockHeroQuery>(
       data: nil,
       extensions: nil,
       errors: [error],
@@ -174,7 +174,7 @@ final class GraphQLResultTests: XCTestCase {
     )
 
     // when
-    let result = GraphQLResult(
+    let result = GraphQLResult<MockHeroQuery>(
       data: resultData,
       extensions: nil,
       errors: nil,
@@ -208,7 +208,7 @@ final class GraphQLResultTests: XCTestCase {
 
     // then
     XCTAssertEqual(merged.asJSONDictionary(), expected)
-    XCTAssertEqual(merged.source, GraphQLResult<MockHeroQuery.Data>.Source.server)
+    XCTAssertEqual(merged.source, GraphQLResult<MockHeroQuery>.Source.server)
 
     XCTAssertNil(merged.extensions)
     XCTAssertNil(merged.errors)
@@ -217,7 +217,7 @@ final class GraphQLResultTests: XCTestCase {
 
   func test__merging__givenIncrementalErrors_shouldMergeErrors() throws {
     // given
-    let result = GraphQLResult<MockHeroQuery.Data>(
+    let result = GraphQLResult<MockHeroQuery>(
       data: nil,
       extensions: nil,
       errors: [GraphQLError("Base Error")],
@@ -252,7 +252,7 @@ final class GraphQLResultTests: XCTestCase {
 
   func test__merging__givenIncrementalExtensions_shouldMergeExtensions() throws {
     // given
-    let result = GraphQLResult<MockHeroQuery.Data>(
+    let result = GraphQLResult<MockHeroQuery>(
       data: nil,
       extensions: ["FeatureA": true],
       errors: nil,
@@ -286,7 +286,7 @@ final class GraphQLResultTests: XCTestCase {
 
   func test__merging__givenIncrementalDependentKeys_shouldMergeDependentKeys() throws {
     // given
-    let result = GraphQLResult<MockHeroQuery.Data>(
+    let result = GraphQLResult<MockHeroQuery>(
       data: nil,
       extensions: nil,
       errors: nil,

--- a/Tests/ApolloTests/Interceptors/GraphQLInterceptor_ErrorHandling_Tests.swift
+++ b/Tests/ApolloTests/Interceptors/GraphQLInterceptor_ErrorHandling_Tests.swift
@@ -539,7 +539,7 @@ class GraphQLInterceptor_ErrorHandling_Tests: XCTestCase, CacheDependentTesting,
       }
 
       expect(heroName).to(equal("R2-D2"))
-      expect(response.source).to(equal(GraphQLResult<GivenSelectionSet>.Source.cache))
+      expect(response.source).to(equal(GraphQLResult<MockQuery<GivenSelectionSet>>.Source.cache))
     }
 
     expect(responseCount).to(equal(1))

--- a/Tests/ApolloTests/Interceptors/GraphQLInterceptor_ErrorHandling_Tests.swift
+++ b/Tests/ApolloTests/Interceptors/GraphQLInterceptor_ErrorHandling_Tests.swift
@@ -539,7 +539,7 @@ class GraphQLInterceptor_ErrorHandling_Tests: XCTestCase, CacheDependentTesting,
       }
 
       expect(heroName).to(equal("R2-D2"))
-      expect(response.source).to(equal(GraphQLResult<MockQuery<GivenSelectionSet>>.Source.cache))
+      expect(response.source).to(equal(GraphQLResponse<MockQuery<GivenSelectionSet>>.Source.cache))
     }
 
     expect(responseCount).to(equal(1))

--- a/Tests/ApolloTests/JSONResponseParser_SingleResponseParsingTests.swift
+++ b/Tests/ApolloTests/JSONResponseParser_SingleResponseParsingTests.swift
@@ -18,7 +18,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
 
     // then
@@ -35,7 +35,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
 
     // then
@@ -52,7 +52,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ] as JSONObject
 
     // when
-    let response: GraphQLResponse<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
 
     // then
@@ -68,7 +68,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
 
     // then
@@ -90,7 +90,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
 
     // then
@@ -113,7 +113,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ] as JSONObject
 
     // when
-    let response: GraphQLResponse<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
 
     // then
@@ -136,7 +136,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
 
     // then
@@ -159,7 +159,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
 
     // then
@@ -183,7 +183,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<MockSelectionSet>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
 
     // then
@@ -228,7 +228,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
     let recordSet = response.cacheRecords
 
@@ -251,7 +251,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
     let recordSet = response.cacheRecords
 
@@ -292,7 +292,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
     let recordSet = response.cacheRecords
 
@@ -333,7 +333,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
     let recordSet = response.cacheRecords
 
@@ -374,7 +374,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
     let recordSet = response.cacheRecords
 
@@ -415,7 +415,7 @@ class JSONResponseParser_SingleResponseParsingTests: XCTestCase {
     ]
 
     // when
-    let response: GraphQLResponse<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
+    let response: ParsedResult<MockQuery<HeroQueryRoot>> = try await parser.parseSingleResponse(body: body)
     let result = response.result
     let recordSet = response.cacheRecords
 

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -101,7 +101,7 @@ class JSONTests: XCTestCase {
   }
   
   func testJSONConvertSelectionSetEncoding() async throws {
-    class Hero: MockSelectionSet {
+    class Hero: MockSelectionSet, @unchecked Sendable {
       typealias Schema = MockSchemaMetadata
       
       override class var __selections: [Selection] {[
@@ -122,7 +122,7 @@ class JSONTests: XCTestCase {
   }
   
   func testJSONConvertGraphQLResultEncoding() async throws {
-    class MockData: MockSelectionSet {
+    class MockData: MockSelectionSet, @unchecked Sendable {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -131,7 +131,7 @@ class JSONTests: XCTestCase {
 
       var hero: Hero? { __data["hero"] }
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         typealias Schema = MockSchemaMetadata
 
         override class var __selections: [Selection] {[
@@ -152,7 +152,7 @@ class JSONTests: XCTestCase {
     
     let heroData = try await MockData(data: jsonObj)
 
-    let result = GraphQLResult(
+    let result = GraphQLResult<MockQuery<MockData>>(
       data: heroData,
       extensions: nil,
       errors: nil,

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -152,7 +152,7 @@ class JSONTests: XCTestCase {
     
     let heroData = try await MockData(data: jsonObj)
 
-    let result = GraphQLResult<MockQuery<MockData>>(
+    let result = GraphQLResponse<MockQuery<MockData>>(
       data: heroData,
       extensions: nil,
       errors: nil,

--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -112,7 +112,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     fetchBehavior: FetchBehavior = FetchBehavior.CacheFirst,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error> {
     return try doInClientContext {
       return try self.networkTransport.send(
         query: query,
@@ -128,7 +128,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.SingleResponse,
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> GraphQLResult<Query.Data>
+  ) async throws -> GraphQLResult<Query>
   where Query.ResponseFormat == SingleResponseFormat {
     for try await result in try fetch(
       query: query,
@@ -144,7 +144,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
   where Query.ResponseFormat == SingleResponseFormat {
     return try fetch(
       query: query,
@@ -159,7 +159,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.SingleResponse,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat {
     return try fetch(
       query: query,
@@ -172,7 +172,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat {
     return try fetch(
       query: query,
@@ -187,7 +187,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.CacheOnly,
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> GraphQLResult<Query.Data> {
+  ) async throws -> GraphQLResult<Query> {
     for try await result in try fetch(
       query: query,
       fetchBehavior: cachePolicy.toFetchBehavior(),
@@ -345,7 +345,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   public func perform<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> GraphQLResult<Mutation.Data>
+  ) async throws -> GraphQLResult<Mutation>
   where Mutation.ResponseFormat == SingleResponseFormat {
     for try await result in try self.sendMutation(
       mutation: mutation,
@@ -368,7 +368,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   public func perform<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error>
   where Mutation.ResponseFormat == IncrementalDeferredResponseFormat {
     return try sendMutation(mutation: mutation, requestConfiguration: requestConfiguration)
   }
@@ -376,7 +376,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   public func sendMutation<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error> {
     return try doInClientContext {
       return try self.networkTransport.send(
         mutation: mutation,
@@ -400,7 +400,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> GraphQLResult<Operation.Data>
+  ) async throws -> GraphQLResult<Operation>
   where Operation.ResponseFormat == SingleResponseFormat {
     for try await result in try self.sendUpload(
       operation: operation,
@@ -425,7 +425,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error>
   where Operation.ResponseFormat == IncrementalDeferredResponseFormat {
     return try self.sendUpload(
       operation: operation,
@@ -438,7 +438,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error> {
     guard let uploadingTransport = self.networkTransport as? (any UploadingNetworkTransport) else {
       assertionFailure(
         "Trying to upload without an uploading transport. Please make sure your network transport conforms to `UploadingNetworkTransport`."
@@ -467,7 +467,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     subscription: Subscription,
     cachePolicy: CachePolicy.Subscription = .cacheThenNetwork,
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error> {
+  ) async throws -> AsyncThrowingStream<GraphQLResult<Subscription>, any Error> {
     guard let subscriptionTransport = self.networkTransport as? (any SubscriptionNetworkTransport) else {
       assertionFailure(
         "Trying to subscribe without a subscription transport. Please make sure your network transport conforms to `SubscriptionNetworkTransport`."
@@ -512,7 +512,9 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
 /// - Parameters:
 ///   - result: The result of a performed operation. Will have a `GraphQLResult` with any parsed data and any GraphQL errors on `success`, and an `Error` on `failure`.
 @available(*, deprecated)
-public typealias GraphQLResultHandler<Data: RootSelectionSet> = @Sendable (Result<GraphQLResult<Data>, any Error>) ->
+public typealias GraphQLResultHandler<Operation: GraphQLOperation> = @Sendable (
+  Result<GraphQLResult<Operation>, any Error>
+) ->
   Void
 
 @available(*, deprecated)
@@ -564,7 +566,7 @@ extension ApolloClient {
     cachePolicy: CachePolicy_v1? = nil,
     context: (any RequestContext)? = nil,
     queue: DispatchQueue = .main,
-    resultHandler: GraphQLResultHandler<Query.Data>? = nil
+    resultHandler: GraphQLResultHandler<Query>? = nil
   ) -> (any Cancellable) {
     let cachePolicy = cachePolicy ?? CachePolicy_v1.default
     return awaitStreamInTask(
@@ -620,7 +622,7 @@ extension ApolloClient {
     cachePolicy: CachePolicy_v1? = nil,
     context: (any RequestContext)? = nil,
     callbackQueue: DispatchQueue = .main,
-    resultHandler: @escaping GraphQLResultHandler<Query.Data>
+    resultHandler: @escaping GraphQLResultHandler<Query>
   ) async -> GraphQLQueryWatcher<Query> {
     let cachePolicy = cachePolicy ?? CachePolicy_v1.default
     let config = RequestConfiguration(
@@ -647,7 +649,7 @@ extension ApolloClient {
     mutation: Mutation,
     publishResultToStore: Bool = true,
     queue: DispatchQueue = .main,
-    resultHandler: GraphQLResultHandler<Mutation.Data>? = nil
+    resultHandler: GraphQLResultHandler<Mutation>? = nil
   ) -> (any Cancellable) {
     let config = RequestConfiguration(
       requestTimeout: defaultRequestConfiguration.requestTimeout,
@@ -677,7 +679,7 @@ extension ApolloClient {
     operation: Operation,
     files: [GraphQLFile],
     queue: DispatchQueue = .main,
-    resultHandler: GraphQLResultHandler<Operation.Data>? = nil
+    resultHandler: GraphQLResultHandler<Operation>? = nil
   ) -> (any Cancellable) {
     return awaitStreamInTask(
       {
@@ -702,7 +704,7 @@ extension ApolloClient {
   public func subscribe<Subscription: GraphQLSubscription>(
     subscription: Subscription,
     queue: DispatchQueue = .main,
-    resultHandler: @escaping GraphQLResultHandler<Subscription.Data>
+    resultHandler: @escaping GraphQLResultHandler<Subscription>
   ) -> any Cancellable {
     return awaitStreamInTask(
       {

--- a/apollo-ios/Sources/Apollo/ApolloClient.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClient.swift
@@ -112,7 +112,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     fetchBehavior: FetchBehavior = FetchBehavior.CacheFirst,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error> {
     return try doInClientContext {
       return try self.networkTransport.send(
         query: query,
@@ -128,7 +128,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.SingleResponse,
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> GraphQLResult<Query>
+  ) async throws -> GraphQLResponse<Query>
   where Query.ResponseFormat == SingleResponseFormat {
     for try await result in try fetch(
       query: query,
@@ -144,7 +144,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
   where Query.ResponseFormat == SingleResponseFormat {
     return try fetch(
       query: query,
@@ -159,7 +159,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.SingleResponse,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat {
     return try fetch(
       query: query,
@@ -172,7 +172,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat {
     return try fetch(
       query: query,
@@ -187,7 +187,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     query: Query,
     cachePolicy: CachePolicy.Query.CacheOnly,
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> GraphQLResult<Query> {
+  ) async throws -> GraphQLResponse<Query> {
     for try await result in try fetch(
       query: query,
       fetchBehavior: cachePolicy.toFetchBehavior(),
@@ -345,7 +345,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   public func perform<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> GraphQLResult<Mutation>
+  ) async throws -> GraphQLResponse<Mutation>
   where Mutation.ResponseFormat == SingleResponseFormat {
     for try await result in try self.sendMutation(
       mutation: mutation,
@@ -368,7 +368,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   public func perform<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Mutation>, any Error>
   where Mutation.ResponseFormat == IncrementalDeferredResponseFormat {
     return try sendMutation(mutation: mutation, requestConfiguration: requestConfiguration)
   }
@@ -376,7 +376,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
   public func sendMutation<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Mutation>, any Error> {
     return try doInClientContext {
       return try self.networkTransport.send(
         mutation: mutation,
@@ -400,7 +400,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> GraphQLResult<Operation>
+  ) async throws -> GraphQLResponse<Operation>
   where Operation.ResponseFormat == SingleResponseFormat {
     for try await result in try self.sendUpload(
       operation: operation,
@@ -425,7 +425,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration? = nil
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Operation>, any Error>
   where Operation.ResponseFormat == IncrementalDeferredResponseFormat {
     return try self.sendUpload(
       operation: operation,
@@ -438,7 +438,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Operation>, any Error> {
     guard let uploadingTransport = self.networkTransport as? (any UploadingNetworkTransport) else {
       assertionFailure(
         "Trying to upload without an uploading transport. Please make sure your network transport conforms to `UploadingNetworkTransport`."
@@ -467,7 +467,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
     subscription: Subscription,
     cachePolicy: CachePolicy.Subscription = .cacheThenNetwork,
     requestConfiguration: RequestConfiguration? = nil
-  ) async throws -> AsyncThrowingStream<GraphQLResult<Subscription>, any Error> {
+  ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription>, any Error> {
     guard let subscriptionTransport = self.networkTransport as? (any SubscriptionNetworkTransport) else {
       assertionFailure(
         "Trying to subscribe without a subscription transport. Please make sure your network transport conforms to `SubscriptionNetworkTransport`."
@@ -513,7 +513,7 @@ public final class ApolloClient: ApolloClientProtocol, Sendable {
 ///   - result: The result of a performed operation. Will have a `GraphQLResult` with any parsed data and any GraphQL errors on `success`, and an `Error` on `failure`.
 @available(*, deprecated)
 public typealias GraphQLResultHandler<Operation: GraphQLOperation> = @Sendable (
-  Result<GraphQLResult<Operation>, any Error>
+  Result<GraphQLResponse<Operation>, any Error>
 ) ->
   Void
 

--- a/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
@@ -27,34 +27,34 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
   where Query.ResponseFormat == SingleResponseFormat
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.SingleResponse,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.CacheOnly,
     requestConfiguration: RequestConfiguration?
-  ) async throws -> GraphQLResult<Query>
+  ) async throws -> GraphQLResponse<Query>
 
   // MARK: - Watch Functions
 
@@ -119,13 +119,13 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
   func perform<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration?
-  ) async throws -> GraphQLResult<Mutation>
+  ) async throws -> GraphQLResponse<Mutation>
   where Mutation.ResponseFormat == SingleResponseFormat
 
   func perform<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Mutation>, any Error>
   where Mutation.ResponseFormat == IncrementalDeferredResponseFormat
 
   // MARK: - Upload Functions
@@ -143,7 +143,7 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration?
-  ) async throws -> GraphQLResult<Operation>
+  ) async throws -> GraphQLResponse<Operation>
   where Operation.ResponseFormat == SingleResponseFormat
 
   // MARK: - Subscription Functions
@@ -158,6 +158,6 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
     subscription: Subscription,
     cachePolicy: CachePolicy.Subscription,
     requestConfiguration: RequestConfiguration?
-  ) async throws -> AsyncThrowingStream<GraphQLResult<Subscription>, any Error>
+  ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription>, any Error>
 
 }

--- a/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
@@ -27,34 +27,34 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
   where Query.ResponseFormat == SingleResponseFormat
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.SingleResponse,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.CacheOnly,
     requestConfiguration: RequestConfiguration?
-  ) async throws -> GraphQLResult<Query.Data>
+  ) async throws -> GraphQLResult<Query>
 
   // MARK: - Watch Functions
 
@@ -119,13 +119,13 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
   func perform<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration?
-  ) async throws -> GraphQLResult<Mutation.Data>
+  ) async throws -> GraphQLResult<Mutation>
   where Mutation.ResponseFormat == SingleResponseFormat
 
   func perform<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error>
   where Mutation.ResponseFormat == IncrementalDeferredResponseFormat
 
   // MARK: - Upload Functions
@@ -143,7 +143,7 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration?
-  ) async throws -> GraphQLResult<Operation.Data>
+  ) async throws -> GraphQLResult<Operation>
   where Operation.ResponseFormat == SingleResponseFormat
 
   // MARK: - Subscription Functions
@@ -158,6 +158,6 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
     subscription: Subscription,
     cachePolicy: CachePolicy.Subscription,
     requestConfiguration: RequestConfiguration?
-  ) async throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error>
+  ) async throws -> AsyncThrowingStream<GraphQLResult<Subscription>, any Error>
 
 }

--- a/apollo-ios/Sources/Apollo/ApolloStore.swift
+++ b/apollo-ios/Sources/Apollo/ApolloStore.swift
@@ -128,7 +128,7 @@ public final class ApolloStore: Sendable {
   ///   - operation: The operation to load results for
   public func load<Operation: GraphQLOperation>(
     _ operation: Operation
-  ) async throws -> GraphQLResult<Operation.Data> {
+  ) async throws -> GraphQLResult<Operation> {
     try await withinReadTransaction { transaction in
       let (dataDict, dependentKeys) = try await transaction.readObject(
         ofType: Operation.Data.self,
@@ -454,7 +454,7 @@ public final class ApolloStore: Sendable {
   public func load<Operation: GraphQLOperation>(
     _ operation: Operation,
     callbackQueue: DispatchQueue? = nil,
-    resultHandler: @escaping GraphQLResultHandler<Operation.Data>
+    resultHandler: @escaping GraphQLResultHandler<Operation>
   ) {
     performInTask(
       {

--- a/apollo-ios/Sources/Apollo/ApolloStore.swift
+++ b/apollo-ios/Sources/Apollo/ApolloStore.swift
@@ -128,7 +128,7 @@ public final class ApolloStore: Sendable {
   ///   - operation: The operation to load results for
   public func load<Operation: GraphQLOperation>(
     _ operation: Operation
-  ) async throws -> GraphQLResult<Operation> {
+  ) async throws -> GraphQLResponse<Operation> {
     try await withinReadTransaction { transaction in
       let (dataDict, dependentKeys) = try await transaction.readObject(
         ofType: Operation.Data.self,
@@ -140,7 +140,7 @@ public final class ApolloStore: Sendable {
         )
       )
 
-      return GraphQLResult(
+      return GraphQLResponse(
         data: Operation.Data(_dataDict: dataDict),
         extensions: nil,
         errors: nil,

--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -11,9 +11,9 @@ import Foundation
 /// longer need results. Failure to call `cancel()` before releasing your reference to the returned watcher will result
 /// in a memory leak.
 public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber, Apollo.Cancellable {
-  public typealias ResultHandler = @Sendable (Result<GraphQLResult<Query.Data>, any Swift.Error>) -> Void
+  public typealias ResultHandler = @Sendable (Result<GraphQLResult<Query>, any Swift.Error>) -> Void
   private typealias FetchBlock = @Sendable (FetchBehavior, RequestConfiguration?) throws -> AsyncThrowingStream<
-    GraphQLResult<Query.Data>, any Error
+    GraphQLResult<Query>, any Error
   >?
 
   /// The ``GraphQLQuery`` for the watcher.
@@ -165,7 +165,7 @@ public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber, Ap
 
   // MARK: - Result Handling
 
-  private func didReceiveResult(_ result: GraphQLResult<Query.Data>) {
+  private func didReceiveResult(_ result: GraphQLResult<Query>) {
     guard !self.cancelled else { return }
     resultHandler(.success(result))
   }
@@ -241,7 +241,7 @@ extension GraphQLQueryWatcher {
     refetchOnFailedUpdates: Bool = true,
     context: (any RequestContext)? = nil,
     callbackQueue: DispatchQueue = .main,
-    resultHandler: @escaping GraphQLResultHandler<Query.Data>
+    resultHandler: @escaping GraphQLResultHandler<Query>
   ) async {
     await self.init(
       client: client,

--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -11,9 +11,9 @@ import Foundation
 /// longer need results. Failure to call `cancel()` before releasing your reference to the returned watcher will result
 /// in a memory leak.
 public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber, Apollo.Cancellable {
-  public typealias ResultHandler = @Sendable (Result<GraphQLResult<Query>, any Swift.Error>) -> Void
+  public typealias ResultHandler = @Sendable (Result<GraphQLResponse<Query>, any Swift.Error>) -> Void
   private typealias FetchBlock = @Sendable (FetchBehavior, RequestConfiguration?) throws -> AsyncThrowingStream<
-    GraphQLResult<Query>, any Error
+    GraphQLResponse<Query>, any Error
   >?
 
   /// The ``GraphQLQuery`` for the watcher.
@@ -165,7 +165,7 @@ public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber, Ap
 
   // MARK: - Result Handling
 
-  private func didReceiveResult(_ result: GraphQLResult<Query>) {
+  private func didReceiveResult(_ result: GraphQLResponse<Query>) {
     guard !self.cancelled else { return }
     resultHandler(.success(result))
   }

--- a/apollo-ios/Sources/Apollo/GraphQLResult.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLResult.swift
@@ -2,9 +2,8 @@
 @_spi(Internal) import ApolloAPI
 #endif
 
-#warning("TODO: change to GraphQLResponse when we delete the existing response object?")
 /// Represents the result of a GraphQL operation.
-public struct GraphQLResult<Operation: GraphQLOperation>: Sendable {
+public struct GraphQLResponse<Operation: GraphQLOperation>: Sendable {
 
   /// Represents source of data
   public enum Source: Sendable, Hashable {
@@ -37,7 +36,7 @@ public struct GraphQLResult<Operation: GraphQLOperation>: Sendable {
     self.dependentKeys = dependentKeys
   }
 
-  func merging(_ incrementalResult: IncrementalGraphQLResult) throws -> GraphQLResult<Operation> {
+  func merging(_ incrementalResult: IncrementalGraphQLResult) throws -> GraphQLResponse<Operation> {
     let mergedDataDict = try merge(
       incrementalResult.data?.__data,
       into: self.data?.__data
@@ -70,7 +69,7 @@ public struct GraphQLResult<Operation: GraphQLOperation>: Sendable {
       currentDependentKeys.union(incrementalDependentKeys)
     }
 
-    return GraphQLResult(
+    return GraphQLResponse(
       data: mergedData,
       extensions: mergedExtensions,
       errors: mergedErrors,
@@ -98,8 +97,8 @@ public struct GraphQLResult<Operation: GraphQLOperation>: Sendable {
 }
 
 // MARK: - Equatable/Hashable Conformance
-extension GraphQLResult: Equatable where Operation.Data: Equatable {
-  public static func == (lhs: GraphQLResult<Operation>, rhs: GraphQLResult<Operation>) -> Bool {
+extension GraphQLResponse: Equatable where Operation.Data: Equatable {
+  public static func == (lhs: GraphQLResponse<Operation>, rhs: GraphQLResponse<Operation>) -> Bool {
     lhs.data == rhs.data &&
     lhs.errors == rhs.errors &&
     AnySendableHashable.equatableCheck(lhs.extensions, rhs.extensions) &&
@@ -108,7 +107,7 @@ extension GraphQLResult: Equatable where Operation.Data: Equatable {
   }
 }
 
-extension GraphQLResult: Hashable where Operation.Data: Hashable {
+extension GraphQLResponse: Hashable where Operation.Data: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(data)
     hasher.combine(errors)
@@ -118,11 +117,11 @@ extension GraphQLResult: Hashable where Operation.Data: Hashable {
   }
 }
 
-extension GraphQLResult {
+extension GraphQLResponse {
 
-  /// Converts a ``GraphQLResult`` into a basic JSON dictionary for use.
+  /// Converts a ``GraphQLResponse`` into a basic JSON dictionary for use.
   ///
-  /// - Returns: A `[String: Any]` JSON dictionary representing the ``GraphQLResult``.
+  /// - Returns: A `[String: Any]` JSON dictionary representing the ``GraphQLResponse``.
   public func asJSONDictionary() -> [String: Any] {
     var dict: [String: Any] = [:]
     if let data { dict["data"] = JSONConverter.convert(data) }

--- a/apollo-ios/Sources/Apollo/Interceptors/ApolloInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/ApolloInterceptor.swift
@@ -17,10 +17,10 @@ public protocol ResponseParsingInterceptor: Sendable {
 }
 
 public struct GraphQLResponse<Operation: GraphQLOperation>: Sendable, Hashable {
-  public let result: GraphQLResult<Operation.Data>
+  public let result: GraphQLResult<Operation>
   public let cacheRecords: RecordSet?
 
-  public init(result: GraphQLResult<Operation.Data>, cacheRecords: RecordSet?) {
+  public init(result: GraphQLResult<Operation>, cacheRecords: RecordSet?) {
     self.result = result
     self.cacheRecords = cacheRecords
   }
@@ -53,9 +53,9 @@ public struct HTTPResponse: Sendable, ~Copyable {
 
   public consuming func mapChunks(
     _ transform: @escaping @Sendable (HTTPURLResponse, Data) async throws -> (Data)
-  ) async throws -> HTTPResponse {
+  ) async -> HTTPResponse {
     let response = self.response
-    let stream = try await chunks.map { chunk in
+    let stream = await chunks.map { chunk in
       return try await transform(response, chunk)
     }
     return HTTPResponse(response: response, chunks: stream)

--- a/apollo-ios/Sources/Apollo/Interceptors/ApolloInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/ApolloInterceptor.swift
@@ -6,7 +6,7 @@ import Foundation
 #endif
 
 public typealias InterceptorResultStream<Request: GraphQLRequest> =
-NonCopyableAsyncThrowingStream<GraphQLResponse<Request.Operation>>
+NonCopyableAsyncThrowingStream<ParsedResult<Request.Operation>>
 
 public protocol ResponseParsingInterceptor: Sendable {
   func parse<Request: GraphQLRequest>(
@@ -16,11 +16,11 @@ public protocol ResponseParsingInterceptor: Sendable {
   ) async throws -> InterceptorResultStream<Request>
 }
 
-public struct GraphQLResponse<Operation: GraphQLOperation>: Sendable, Hashable {
-  public let result: GraphQLResult<Operation>
+public struct ParsedResult<Operation: GraphQLOperation>: Sendable, Hashable {
+  public let result: GraphQLResponse<Operation>
   public let cacheRecords: RecordSet?
 
-  public init(result: GraphQLResult<Operation>, cacheRecords: RecordSet?) {
+  public init(result: GraphQLResponse<Operation>, cacheRecords: RecordSet?) {
     self.result = result
     self.cacheRecords = cacheRecords
   }

--- a/apollo-ios/Sources/Apollo/Interceptors/CacheInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/CacheInterceptor.swift
@@ -7,12 +7,12 @@ public protocol CacheInterceptor: Sendable {
   func readCacheData<Request: GraphQLRequest>(
     from store: ApolloStore,
     request: Request
-  ) async throws -> GraphQLResult<Request.Operation>?
+  ) async throws -> GraphQLResponse<Request.Operation>?
 
   func writeCacheData<Request: GraphQLRequest>(
     to store: ApolloStore,
     request: Request,
-    response: GraphQLResponse<Request.Operation>,
+    response: ParsedResult<Request.Operation>,
   ) async throws
 
 }
@@ -24,14 +24,14 @@ public struct DefaultCacheInterceptor: CacheInterceptor {
   public func readCacheData<Request: GraphQLRequest>(
     from store: ApolloStore,
     request: Request
-  ) async throws -> GraphQLResult<Request.Operation>? {
+  ) async throws -> GraphQLResponse<Request.Operation>? {
     return try await store.load(request.operation)
   }
 
   public func writeCacheData<Request: GraphQLRequest>(
     to store: ApolloStore,
     request: Request,
-    response: GraphQLResponse<Request.Operation>,
+    response: ParsedResult<Request.Operation>,
   ) async throws {
     if let records = response.cacheRecords {
       try await store.publish(records: records)

--- a/apollo-ios/Sources/Apollo/Interceptors/CacheInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/CacheInterceptor.swift
@@ -7,7 +7,7 @@ public protocol CacheInterceptor: Sendable {
   func readCacheData<Request: GraphQLRequest>(
     from store: ApolloStore,
     request: Request
-  ) async throws -> GraphQLResult<Request.Operation.Data>?
+  ) async throws -> GraphQLResult<Request.Operation>?
 
   func writeCacheData<Request: GraphQLRequest>(
     to store: ApolloStore,
@@ -24,7 +24,7 @@ public struct DefaultCacheInterceptor: CacheInterceptor {
   public func readCacheData<Request: GraphQLRequest>(
     from store: ApolloStore,
     request: Request
-  ) async throws -> GraphQLResult<Request.Operation.Data>? {
+  ) async throws -> GraphQLResult<Request.Operation>? {
     return try await store.load(request.operation)
   }
 

--- a/apollo-ios/Sources/Apollo/Interceptors/JSONResponseParsingInterceptor.swift
+++ b/apollo-ios/Sources/Apollo/Interceptors/JSONResponseParsingInterceptor.swift
@@ -10,9 +10,9 @@ public actor JSONResponseParsingInterceptor: ResponseParsingInterceptor {
   public init() {}
 
   private actor ResultStorage<Request: GraphQLRequest> {
-    var currentResult: GraphQLResponse<Request.Operation>?
+    var currentResult: ParsedResult<Request.Operation>?
 
-    func setResult(_ result: GraphQLResponse<Request.Operation>) {
+    func setResult(_ result: ParsedResult<Request.Operation>) {
       currentResult = result
     }
   }

--- a/apollo-ios/Sources/Apollo/JSONConverter.swift
+++ b/apollo-ios/Sources/Apollo/JSONConverter.swift
@@ -19,7 +19,7 @@ public enum JSONConverter {
   /// Converts a ``GraphQLResult`` into a basic JSON dictionary for use.
   ///
   /// - Returns: A `[String: Any]` JSON dictionary representing the ``GraphQLResult``.
-  public static func convert<T>(_ result: GraphQLResult<T>) -> [String: Any] {
+  public static func convert<T>(_ result: GraphQLResponse<T>) -> [String: Any] {
     result.asJSONDictionary()
   }
 

--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -19,12 +19,12 @@ public protocol NetworkTransport: AnyObject, Sendable {
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
 
   func send<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error>
 
 }
 
@@ -36,7 +36,7 @@ public protocol SubscriptionNetworkTransport {
     subscription: Subscription,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Subscription>, any Error>
 
 }
 
@@ -56,5 +56,5 @@ public protocol UploadingNetworkTransport {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error>
 }

--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -19,12 +19,12 @@ public protocol NetworkTransport: AnyObject, Sendable {
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
 
   func send<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Mutation>, any Error>
 
 }
 
@@ -36,7 +36,7 @@ public protocol SubscriptionNetworkTransport {
     subscription: Subscription,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Subscription>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Subscription>, any Error>
 
 }
 
@@ -56,5 +56,5 @@ public protocol UploadingNetworkTransport {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Operation>, any Error>
 }

--- a/apollo-ios/Sources/Apollo/RequestChain.swift
+++ b/apollo-ios/Sources/Apollo/RequestChain.swift
@@ -32,7 +32,7 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
   private let interceptors: Interceptors
   private let store: ApolloStore
 
-  public typealias ResultStream = AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error>
+  public typealias ResultStream = AsyncThrowingStream<GraphQLResult<Operation>, any Error>
   public typealias Operation = Request.Operation
 
   /// Creates a chain with the given interceptor array.
@@ -99,7 +99,7 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
       request in
       finalRequest = request
 
-      return await execute(request: request)
+      return execute(request: request)
     }
 
     for interceptor in interceptors.reversed() {
@@ -205,7 +205,7 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
 
   private func attemptCacheRead(
     request: Request
-  ) async throws -> GraphQLResult<Operation.Data>? {
+  ) async throws -> GraphQLResult<Operation>? {
     let cacheInterceptor = self.interceptors.cache
     return try await cacheInterceptor.readCacheData(from: self.store, request: request)
   }

--- a/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -109,7 +109,7 @@ public final class RequestChainNetworkTransport: NetworkTransport, Sendable {
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error> {
     let request = self.constructRequest(
       for: query,
       fetchBehavior: fetchBehavior,
@@ -124,7 +124,7 @@ public final class RequestChainNetworkTransport: NetworkTransport, Sendable {
   public func send<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Mutation>, any Error> {
     let request = self.constructRequest(
       for: mutation,
       fetchBehavior: FetchBehavior.NetworkOnly,
@@ -178,7 +178,7 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Operation>, any Error> {
     let request = self.constructUploadRequest(
       for: operation,
       files: files,

--- a/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -109,7 +109,7 @@ public final class RequestChainNetworkTransport: NetworkTransport, Sendable {
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error> {
     let request = self.constructRequest(
       for: query,
       fetchBehavior: fetchBehavior,
@@ -124,7 +124,7 @@ public final class RequestChainNetworkTransport: NetworkTransport, Sendable {
   public func send<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error> {
     let request = self.constructRequest(
       for: mutation,
       fetchBehavior: FetchBehavior.NetworkOnly,
@@ -178,7 +178,7 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error> {
     let request = self.constructUploadRequest(
       for: operation,
       files: files,

--- a/apollo-ios/Sources/Apollo/ResponseParsing/JSONResponseParser.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/JSONResponseParser.swift
@@ -52,8 +52,8 @@ public struct JSONResponseParser: Sendable {
 
   public func parse<Operation: GraphQLOperation>(
     dataChunk: Data,
-    mergingIncrementalItemsInto existingResult: GraphQLResponse<Operation>?
-  ) async throws -> GraphQLResponse<Operation>? {
+    mergingIncrementalItemsInto existingResult: ParsedResult<Operation>?
+  ) async throws -> ParsedResult<Operation>? {
     switch response.isMultipart {
     case false:
       return try await parseSingleResponse(data: dataChunk)
@@ -97,7 +97,7 @@ public struct JSONResponseParser: Sendable {
 
   public func parseSingleResponse<Operation: GraphQLOperation>(
     data: Data
-  ) async throws -> GraphQLResponse<Operation> {
+  ) async throws -> ParsedResult<Operation> {
     guard
       let body = try? JSONSerializationFormat.deserialize(data: data) as JSONObject
     else {
@@ -109,7 +109,7 @@ public struct JSONResponseParser: Sendable {
 
   public func parseSingleResponse<Operation: GraphQLOperation>(
     body: JSONObject
-  ) async throws -> GraphQLResponse<Operation> {
+  ) async throws -> ParsedResult<Operation> {
     let executionHandler = SingleResponseExecutionHandler<Operation>(
       responseBody: body,
       operationVariables: operationVariables
@@ -135,8 +135,8 @@ public struct JSONResponseParser: Sendable {
 
   private func executeIncrementalResponses<Operation: GraphQLOperation>(
     merging incrementalItems: [JSONObject],
-    into existingResult: GraphQLResponse<Operation>
-  ) async throws -> GraphQLResponse<Operation> {
+    into existingResult: ParsedResult<Operation>
+  ) async throws -> ParsedResult<Operation> {
     var currentResult = existingResult.result
     var currentCacheRecords = existingResult.cacheRecords
 
@@ -154,7 +154,7 @@ public struct JSONResponseParser: Sendable {
       }
     }
 
-    return GraphQLResponse(result: currentResult, cacheRecords: currentCacheRecords)
+    return ParsedResult(result: currentResult, cacheRecords: currentCacheRecords)
   }
 
   private func executeIncrementalItem<Operation: GraphQLOperation>(

--- a/apollo-ios/Sources/Apollo/ResponseParsing/SingleResponseExecutionHandler.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/SingleResponseExecutionHandler.swift
@@ -63,7 +63,7 @@ extension JSONResponseParser {
     /// create dependent keys or a `RecordSet` for the cache.
     ///
     /// This is faster than `parseResult()` and should be used when cache the response is not needed.
-    public func parseResultOmittingCacheRecords() async throws -> GraphQLResult<Operation.Data> {
+    public func parseResultOmittingCacheRecords() async throws -> GraphQLResult<Operation> {
       let accumulator = DataDictMapper()
       let data = try await base.execute(
         selectionSet: Operation.Data.self,
@@ -79,9 +79,9 @@ extension JSONResponseParser {
     private func makeResult(
       data: Operation.Data?,
       dependentKeys: Set<CacheKey>?
-    ) -> GraphQLResult<Operation.Data> {
+    ) -> GraphQLResult<Operation> {
       #warning("TODO: Do we need to make sure that there is either data or errors in the result?")
-      return GraphQLResult<Operation.Data>(
+      return GraphQLResult<Operation>(
         data: data,
         extensions: base.parseExtensions(),
         errors: base.parseErrors(),

--- a/apollo-ios/Sources/Apollo/SplitNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/SplitNetworkTransport.swift
@@ -42,7 +42,7 @@ public final class SplitNetworkTransport<
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error> {
     return try queryTransport.send(
       query: query,
       fetchBehavior: fetchBehavior,
@@ -53,7 +53,7 @@ public final class SplitNetworkTransport<
   public func send<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Mutation>, any Error> {
     return try mutationTransport.send(
       mutation: mutation,
       requestConfiguration: requestConfiguration
@@ -70,7 +70,7 @@ where SubscriptionTransport: SubscriptionNetworkTransport {
     subscription: Subscription,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Subscription>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Subscription>, any Error> {
     return try subscriptionTransport.send(
       subscription: subscription,
       fetchBehavior: fetchBehavior,
@@ -87,7 +87,7 @@ extension SplitNetworkTransport: UploadingNetworkTransport where UploadTransport
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Operation>, any Error> {
     return try uploadTransport.upload(
       operation: operation,
       files: files,

--- a/apollo-ios/Sources/Apollo/SplitNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/SplitNetworkTransport.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 #if !COCOAPODS
-  import Apollo
   import ApolloAPI
 #endif
 
@@ -43,7 +42,7 @@ public final class SplitNetworkTransport<
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Query.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Query>, any Error> {
     return try queryTransport.send(
       query: query,
       fetchBehavior: fetchBehavior,
@@ -54,7 +53,7 @@ public final class SplitNetworkTransport<
   public func send<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Mutation>, any Error> {
     return try mutationTransport.send(
       mutation: mutation,
       requestConfiguration: requestConfiguration
@@ -71,7 +70,7 @@ where SubscriptionTransport: SubscriptionNetworkTransport {
     subscription: Subscription,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Subscription.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Subscription>, any Error> {
     return try subscriptionTransport.send(
       subscription: subscription,
       fetchBehavior: fetchBehavior,
@@ -88,7 +87,7 @@ extension SplitNetworkTransport: UploadingNetworkTransport where UploadTransport
     operation: Operation,
     files: [GraphQLFile],
     requestConfiguration: RequestConfiguration
-  ) throws -> AsyncThrowingStream<GraphQLResult<Operation.Data>, any Error> {
+  ) throws -> AsyncThrowingStream<GraphQLResult<Operation>, any Error> {
     return try uploadTransport.upload(
       operation: operation,
       files: files,

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -8,6 +8,8 @@ import Foundation
 public final class WebSocketTransport: SubscriptionNetworkTransport {
 
   public enum Error: Swift.Error {
+    /// WebSocketTransport has not yet been implemented for Apollo iOS 2.0. This will be implemented prior to
+    /// Beta release.
     case notImplemented
   }
 
@@ -15,7 +17,7 @@ public final class WebSocketTransport: SubscriptionNetworkTransport {
     subscription: Subscription,
     fetchBehavior: Apollo.FetchBehavior,
     requestConfiguration: Apollo.RequestConfiguration
-  ) throws -> AsyncThrowingStream<Apollo.GraphQLResult<Subscription.Data>, any Swift.Error> {
+  ) throws -> AsyncThrowingStream<Apollo.GraphQLResult<Subscription>, any Swift.Error> {
     throw Error.notImplemented
   }
 

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -17,7 +17,7 @@ public final class WebSocketTransport: SubscriptionNetworkTransport {
     subscription: Subscription,
     fetchBehavior: Apollo.FetchBehavior,
     requestConfiguration: Apollo.RequestConfiguration
-  ) throws -> AsyncThrowingStream<Apollo.GraphQLResult<Subscription>, any Swift.Error> {
+  ) throws -> AsyncThrowingStream<Apollo.GraphQLResponse<Subscription>, any Swift.Error> {
     throw Error.notImplemented
   }
 


### PR DESCRIPTION
This PR renames `GraphQLResult` to `GraphQLResponse`. "Response" is more accurate to what this actually _is_. 

We used to have an internal type in 1.0 called `GraphQLResponse` which handled parsing the response data into the `GraphQLResult`. 2.0 removes this struct and handles parsing through a `JSONResponseParser` object. This allows us to use the name `GraphQLResponse` where it is more accurate in the public API.

The intermediary struct that is created by the `JSONResponseParser` is now named `ParsedResult`. This struct just holds a `GraphQLResponse` and the cache records to be written to the cache.

---

This PR also changes the new `GraphQLResponse` struct to be generic over the `GraphQLOperation` instead of the operation's `Data` object directly. I think this is more expressive and makes reading the code clearer.