### PR TITLE
[v2] Exposed all errors in multipart subscription parser 

### DIFF
--- a/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptor_MultipartResponseSubscriptionParser_Tests.swift
+++ b/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptor_MultipartResponseSubscriptionParser_Tests.swift
@@ -98,7 +98,7 @@ final class JSONResponseParsingInterceptor_MultipartResponseSubscriptionParser_T
       try await actualResultsIterator.next()
     }.to(
       throwError(
-        MultipartResponseSubscriptionParser.ParsingError.irrecoverableError(message: "forced test failure!")
+        MultipartResponseSubscriptionParser.ParsingError.irrecoverableErrors([GraphQLError("forced test failure!")])
       )
     )
   }
@@ -141,7 +141,7 @@ final class JSONResponseParsingInterceptor_MultipartResponseSubscriptionParser_T
       try await actualResultsIterator.next()
     }.to(
       throwError(
-        MultipartResponseSubscriptionParser.ParsingError.irrecoverableError(message: "forced test failure!")
+        MultipartResponseSubscriptionParser.ParsingError.irrecoverableErrors([GraphQLError("forced test failure!")])
       )
     )
   }
@@ -189,7 +189,7 @@ final class JSONResponseParsingInterceptor_MultipartResponseSubscriptionParser_T
       try await actualResultsIterator.next()
     }.to(
       throwError(
-        MultipartResponseSubscriptionParser.ParsingError.irrecoverableError(message: "forced test failure!")
+        MultipartResponseSubscriptionParser.ParsingError.irrecoverableErrors([GraphQLError("forced test failure!")])
       )
     )
   }
@@ -235,7 +235,15 @@ final class JSONResponseParsingInterceptor_MultipartResponseSubscriptionParser_T
       try await actualResultsIterator.next()
     }.to(
       throwError(
-        MultipartResponseSubscriptionParser.ParsingError.irrecoverableError(message: "forced test failure!")
+        MultipartResponseSubscriptionParser.ParsingError.irrecoverableErrors([
+          GraphQLError([
+            "message": "forced test failure!",
+            "path": [
+              "hello"
+            ],
+            "foo": "bar",
+          ])
+        ])
       )
     )
   }


### PR DESCRIPTION
`MultipartResponseSubscriptionParser.ParsingError.irrecoverableError(message: String)` has been changed to `irrecoverableErrors([GraphQLError])`.

This change is due to a user request. When there are multiple errors, they should all be exposed to the user.