### PR TITLE
[v2] Return nil on cache miss

### DIFF
--- a/Tests/ApolloTests/ApolloStore_BatchedLoadTests.swift
+++ b/Tests/ApolloTests/ApolloStore_BatchedLoadTests.swift
@@ -104,9 +104,9 @@ class ApolloStore_BatchedLoadTests: XCTestCase {
     // when
     let graphQLResult = try await store.load(query)
 
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertNil(graphQLResult?.errors)
 
-    guard let data = graphQLResult.data else {
+    guard let data = graphQLResult?.data else {
       XCTFail("No data returned with result!")
       return
     }
@@ -178,9 +178,9 @@ class ApolloStore_BatchedLoadTests: XCTestCase {
         group.addTask {
           let graphQLResult = try await store.load(query)
 
-          XCTAssertNil(graphQLResult.errors)
+          XCTAssertNil(graphQLResult?.errors)
 
-          guard let data = graphQLResult.data else {
+          guard let data = graphQLResult?.data else {
             XCTFail("No data returned with query!")
             return
 

--- a/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
@@ -1,10 +1,13 @@
-import XCTest
-@testable import Apollo
 import ApolloAPI
-#if canImport(ApolloSQLite)
-import ApolloSQLite
-#endif
 import ApolloInternalTestHelpers
+import Nimble
+import XCTest
+
+@testable import Apollo
+
+#if canImport(ApolloSQLite)
+  import ApolloSQLite
+#endif
 
 class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, MockResponseProvider {
   var cacheType: any TestCacheProvider.Type {
@@ -15,14 +18,14 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
 
   var cache: (any NormalizedCache)!
   var store: ApolloStore!
-  
+
   override func setUp() async throws {
     try await super.setUp()
 
     cache = try await makeNormalizedCache()
     store = ApolloStore(cache: cache)
   }
-  
+
   override func tearDown() async throws {
     cache = nil
     store = nil
@@ -30,171 +33,175 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
     await Self.cleanUpRequestHandlers()
     try await super.tearDown()
   }
-  
+
   func testLoadingHeroNameQuery() async throws {
     // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self)
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self)
+        ]
+      }
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self)
-        ]}
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+          ]
+        }
       }
     }
 
     await mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero": CacheReference("hero")],
-      "hero": ["__typename": "Droid", "name": "R2-D2"]
+      "hero": ["__typename": "Droid", "name": "R2-D2"],
     ])
 
     // when
     let query = MockQuery<GivenSelectionSet>()
-    
-    loadFromStore(operation: query) { result in
-      // then
-      try XCTAssertSuccessResult(result) { graphQLResult in
-        XCTAssertEqual(graphQLResult.source, .cache)
-        XCTAssertNil(graphQLResult.errors)
-        
-        let data = try XCTUnwrap(graphQLResult.data)
-        XCTAssertEqual(data.hero?.name, "R2-D2")
-      }
-    }
+
+    let response = try await store.load(query)
+    let data = try XCTUnwrap(response?.data)
+
+    // then
+    XCTAssertEqual(data.hero?.name, "R2-D2")
   }
-  
+
   func testLoadingHeroNameQueryWithVariable() async throws {
     // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
+        ]
+      }
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self)
-        ]}
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+          ]
+        }
       }
     }
 
     await mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero(episode:JEDI)": CacheReference("hero(episode:JEDI)")],
-      "hero(episode:JEDI)": ["__typename": "Droid", "name": "R2-D2"]
+      "hero(episode:JEDI)": ["__typename": "Droid", "name": "R2-D2"],
     ])
 
     // when
     let query = MockQuery<GivenSelectionSet>()
     query.__variables = ["episode": "JEDI"]
-    
-    loadFromStore(operation: query) { result in
-      // then
-      try XCTAssertSuccessResult(result) { graphQLResult in
-        XCTAssertEqual(graphQLResult.source, .cache)
-        XCTAssertNil(graphQLResult.errors)
-        
-        let data = try XCTUnwrap(graphQLResult.data)
-        XCTAssertEqual(data.hero?.name, "R2-D2")
-      }
-    }
-  }
-  
-  func testLoadingHeroNameQueryWithMissingName_throwsMissingValueError() async throws {
-    // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self)
-      ]}
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self)
-        ]}
+    let response = try await store.load(query)
+    let data = try XCTUnwrap(response?.data)
+
+    // then
+    XCTAssertEqual(data.hero?.name, "R2-D2")
+  }
+
+  func testLoadingHeroNameQueryWithMissingName_returnsNil() async throws {
+    // given
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self)
+        ]
+      }
+
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+          ]
+        }
       }
     }
 
     await mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero": CacheReference("hero")],
-      "hero": ["__typename": "Droid"]
+      "hero": ["__typename": "Droid"],
     ])
 
     // when
     let query = MockQuery<GivenSelectionSet>()
-    
-    loadFromStore(operation: query) { result in
-      // then
-      XCTAssertThrowsError(try result.get()) { error in
-        if let error = error as? GraphQLExecutionError {
-          XCTAssertEqual(error.path, ["hero", "name"])
-          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
-        } else {
-          XCTFail("Unexpected error: \(error)")
-        }
-      }
-    }
+
+    let response = try await store.load(query)
+
+    // then
+    expect(response).to(beNil())
   }
-  
+
   func testLoadingHeroNameQueryWithNullName_throwsNullValueError() async throws {
     // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self)
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self)
+        ]
+      }
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self)
-        ]}
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+          ]
+        }
       }
     }
 
     await mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero": CacheReference("hero")],
-      "hero": ["__typename": "Droid", "name": NSNull()]
+      "hero": ["__typename": "Droid", "name": NSNull()],
     ])
-    
+
     // when
     let query = MockQuery<GivenSelectionSet>()
-    
-    loadFromStore(operation: query) { result in
-      // then
-      XCTAssertThrowsError(try result.get()) { error in
-        if let error = error as? GraphQLExecutionError {
-          XCTAssertEqual(error.path, ["hero", "name"])
-          XCTAssertMatch(error.underlying, JSONDecodingError.nullValue)
-        } else {
-          XCTFail("Unexpected error: \(error)")
-        }
-      }
-    }
+
+    await expect { try await self.store.load(query) }
+      .to(
+        throwError(
+          errorType: GraphQLExecutionError.self,
+          closure: { error in
+            XCTAssertEqual(error.path, ["hero", "name"])
+            XCTAssertMatch(error.underlying, JSONDecodingError.nullValue)
+          }
+        )
+      )
   }
-  
+
   func testLoadingHeroAndFriendsNamesQueryWithoutIDs() async throws {
     // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self)
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self)
+        ]
+      }
       var hero: Hero { __data["hero"] }
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self),
-          .field("friends", [Friend].self)
-        ]}
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+            .field("friends", [Friend].self),
+          ]
+        }
         var friends: [Friend] { __data["friends"] }
 
-        class Friend: MockSelectionSet {
-          override class var __selections: [Selection] {[
-            .field("__typename", String.self),
-            .field("name", String.self)
-          ]}
+        class Friend: MockSelectionSet, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("__typename", String.self),
+              .field("name", String.self),
+            ]
+          }
           var name: String { __data["name"] }
         }
       }
@@ -208,8 +215,8 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
         "friends": [
           CacheReference("hero.friends.0"),
           CacheReference("hero.friends.1"),
-          CacheReference("hero.friends.2")
-        ]
+          CacheReference("hero.friends.2"),
+        ],
       ],
       "hero.friends.0": ["__typename": "Human", "name": "Luke Skywalker"],
       "hero.friends.1": ["__typename": "Human", "name": "Han Solo"],
@@ -218,42 +225,42 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
 
     // when
     let query = MockQuery<GivenSelectionSet>()
+    let response = try await store.load(query)
+    let data = try XCTUnwrap(response?.data)
 
-    loadFromStore(operation: query) { result in
-      // then
-      try XCTAssertSuccessResult(result) { graphQLResult in
-        XCTAssertEqual(graphQLResult.source, .cache)
-        XCTAssertNil(graphQLResult.errors)
-        
-        let data = try XCTUnwrap(graphQLResult.data)
-        XCTAssertEqual(data.hero.name, "R2-D2")
-        let friendsNames = data.hero.friends.compactMap { $0.name }
-        XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
-      }
-    }
+    // then
+    XCTAssertEqual(data.hero.name, "R2-D2")
+    let friendsNames = data.hero.friends.compactMap { $0.name }
+    XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
   }
-  
+
   func testLoadingHeroAndFriendsNamesQueryWithIDs() async throws {
     // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self)
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self)
+        ]
+      }
       var hero: Hero { __data["hero"] }
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self),
-          .field("friends", [Friend].self)
-        ]}
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+            .field("friends", [Friend].self),
+          ]
+        }
         var friends: [Friend] { __data["friends"] }
 
-        class Friend: MockSelectionSet {
-          override class var __selections: [Selection] {[
-            .field("__typename", String.self),
-            .field("name", String.self)
-          ]}
+        class Friend: MockSelectionSet, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("__typename", String.self),
+              .field("name", String.self),
+            ]
+          }
           var name: String { __data["name"] }
         }
       }
@@ -268,51 +275,52 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
           CacheReference("1000"),
           CacheReference("1002"),
           CacheReference("1003"),
-        ]
+        ],
       ],
       "1000": ["__typename": "Human", "name": "Luke Skywalker"],
       "1002": ["__typename": "Human", "name": "Han Solo"],
       "1003": ["__typename": "Human", "name": "Leia Organa"],
     ])
-    
+
     // when
     let query = MockQuery<GivenSelectionSet>()
 
-    loadFromStore(operation: query) { result in
-      // then
-      try XCTAssertSuccessResult(result) { graphQLResult in
-        XCTAssertEqual(graphQLResult.source, .cache)
-        XCTAssertNil(graphQLResult.errors)
-        
-        let data = try XCTUnwrap(graphQLResult.data)
-        XCTAssertEqual(data.hero.name, "R2-D2")
-        let friendsNames = data.hero.friends.compactMap { $0.name }
-        XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
-      }
-    }
+    let response = try await store.load(query)
+    let data = try XCTUnwrap(response?.data)
+
+    // then
+    XCTAssertEqual(data.hero.name, "R2-D2")
+    let friendsNames = data.hero.friends.compactMap { $0.name }
+    XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
   }
-  
+
   func testLoadingHeroAndFriendsNamesQuery_withOptionalFriendsSelection_withNullFriends() async throws {
     // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self)
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self)
+        ]
+      }
       var hero: Hero { __data["hero"] }
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self),
-          .field("friends", [Friend]?.self)
-        ]}
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+            .field("friends", [Friend]?.self),
+          ]
+        }
         var friends: [Friend]? { __data["friends"] }
 
-        class Friend: MockSelectionSet {
-          override class var __selections: [Selection] {[
-            .field("__typename", String.self),
-            .field("name", String.self)
-          ]}
+        class Friend: MockSelectionSet, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("__typename", String.self),
+              .field("name", String.self),
+            ]
+          }
           var name: String { __data["name"] }
         }
       }
@@ -324,46 +332,47 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
         "name": "R2-D2",
         "__typename": "Droid",
         "friends": NSNull(),
-      ]
+      ],
     ])
-    
+
     // when
     let query = MockQuery<GivenSelectionSet>()
-    
-    loadFromStore(operation: query) { result in
-      // then
-      try XCTAssertSuccessResult(result) { graphQLResult in
-        XCTAssertEqual(graphQLResult.source, .cache)
-        XCTAssertNil(graphQLResult.errors)
-        
-        let data = try XCTUnwrap(graphQLResult.data)
-        XCTAssertEqual(data.hero.name, "R2-D2")
-        XCTAssertNil(data.hero.friends)
-      }
-    }
+
+    let response = try await store.load(query)
+    let data = try XCTUnwrap(response?.data)
+
+    // then
+    XCTAssertEqual(data.hero.name, "R2-D2")
+    XCTAssertNil(data.hero.friends)
   }
 
   func testLoadingHeroAndFriendsNamesQuery_withOptionalFriendsSelection_withNullFriendListItem() async throws {
     // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self)
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self)
+        ]
+      }
       var hero: Hero { __data["hero"] }
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self),
-          .field("friends", [Friend?]?.self)
-        ]}
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+            .field("friends", [Friend?]?.self),
+          ]
+        }
         var friends: [Friend?]? { __data["friends"] }
 
-        class Friend: MockSelectionSet {
-          override class var __selections: [Selection] {[
-            .field("__typename", String.self),
-            .field("name", String.self)
-          ]}
+        class Friend: MockSelectionSet, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("__typename", String.self),
+              .field("name", String.self),
+            ]
+          }
           var name: String { __data["name"] }
         }
       }
@@ -377,7 +386,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
         "friends": [
           CacheReference("hero.friends.0"),
           NSNull(),
-        ] as JSONValue
+        ] as JSONValue,
       ],
       "hero.friends.0": ["__typename": "Human", "name": "Luke Skywalker"],
     ])
@@ -385,43 +394,46 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
     // when
     let query = MockQuery<GivenSelectionSet>()
 
-    loadFromStore(operation: query) { result in
-      // then
-      try XCTAssertSuccessResult(result) { graphQLResult in
-        XCTAssertEqual(graphQLResult.source, .cache)
-        XCTAssertNil(graphQLResult.errors)
+    let response = try await store.load(query)
+    let data = try XCTUnwrap(response?.data)
 
-        let data = try XCTUnwrap(graphQLResult.data)
-        XCTAssertEqual(data.hero.name, "R2-D2")
+    // then
+    XCTAssertEqual(data.hero.name, "R2-D2")
 
-        XCTAssertEqual(data.hero.friends?.count, 2)
-        XCTAssertEqual(data.hero.friends![0]!.name, "Luke Skywalker")
-        XCTAssertNil(data.hero.friends![1]) // Null friend at position 2
-      }
-    }
+    XCTAssertEqual(data.hero.friends?.count, 2)
+    XCTAssertEqual(data.hero.friends![0]!.name, "Luke Skywalker")
+    XCTAssertNil(data.hero.friends![1])  // Null friend at position 2
   }
-  
-  func testLoadingHeroAndFriendsNamesQuery_withOptionalFriendsSelection_withFriendsNotInCache_throwsMissingValueError() async throws {
+
+  func testLoadingHeroAndFriendsNamesQuery_withOptionalFriendsSelection_withFriendsNotInCache_returnsNil()
+    async throws
+  {
     // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self)
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self)
+        ]
+      }
       var hero: Hero { __data["hero"] }
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self),
-          .field("friends", [Friend]?.self)
-        ]}
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+            .field("friends", [Friend]?.self),
+          ]
+        }
         var friends: [Friend]? { __data["friends"] }
 
-        class Friend: MockSelectionSet {
-          override class var __selections: [Selection] {[
-            .field("__typename", String.self),
-            .field("name", String.self)
-          ]}
+        class Friend: MockSelectionSet, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("__typename", String.self),
+              .field("name", String.self),
+            ]
+          }
           var name: String { __data["name"] }
         }
       }
@@ -429,46 +441,43 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
 
     await mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero": CacheReference("hero")],
-      "hero": ["__typename": "Droid", "name": "R2-D2"]
+      "hero": ["__typename": "Droid", "name": "R2-D2"],
     ])
-    
+
     // when
     let query = MockQuery<GivenSelectionSet>()
-    
-    loadFromStore(operation: query) { result in
-      // then
-      XCTAssertThrowsError(try result.get()) { error in
-        if let error = error as? GraphQLExecutionError {
-          XCTAssertEqual(error.path, ["hero", "friends"])
-          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
-        } else {
-          XCTFail("Unexpected error: \(error)")
-        }
-      }
-    }
+
+    let response = try await store.load(query)
+    expect(response).to(beNil())
   }
-  
+
   func testLoadingWithBadCacheSerialization() async throws {
     // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("hero", Hero.self)
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("hero", Hero.self)
+        ]
+      }
       var hero: Hero { __data["hero"] }
 
-      class Hero: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self),
-          .field("friends", [Friend]?.self)
-        ]}
+      class Hero: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+            .field("friends", [Friend]?.self),
+          ]
+        }
         var friends: [Friend]? { __data["friends"] }
 
-        class Friend: MockSelectionSet {
-          override class var __selections: [Selection] {[
-            .field("__typename", String.self),
-            .field("name", String.self)
-          ]}
+        class Friend: MockSelectionSet, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("__typename", String.self),
+              .field("name", String.self),
+            ]
+          }
           var name: String { __data["name"] }
         }
       }
@@ -482,79 +491,85 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
         "friends": [
           CacheReference("1000"),
           CacheReference("1002"),
-          CacheReference("1003")
-        ]
+          CacheReference("1003"),
+        ],
       ],
-      "1000": ["__typename": "Human", "name": ["dictionary": "badValues", "nested bad val": ["subdictionary": "some value"] ] as JSONValue
+      "1000": [
+        "__typename": "Human",
+        "name": ["dictionary": "badValues", "nested bad val": ["subdictionary": "some value"]] as JSONValue,
       ],
       "1002": ["__typename": "Human", "name": "Han Solo"],
       "1003": ["__typename": "Human", "name": "Leia Organa"],
     ])
-    
+
     // when
     let query = MockQuery<GivenSelectionSet>()
-    
-    loadFromStore(operation: query) { result in
-      XCTAssertThrowsError(try result.get()) { error in
-        // then
-        if let error = error as? GraphQLExecutionError,
-           case JSONDecodingError.couldNotConvert(_, let expectedType) = error.underlying {
-          XCTAssertEqual(error.path, ["hero", "friends", "0", "name"])
+
+    await expect { try await self.store.load(query) }
+      .to(
+        throwError(errorType: GraphQLExecutionError.self) { error in
+          guard case let JSONDecodingError.couldNotConvert(_, expectedType) = error.underlying else {
+            fail()
+            return
+          }
           XCTAssertTrue(expectedType == String.self)
-        } else {
-          XCTFail("Unexpected error: \(error)")
+          XCTAssertEqual(error.path, ["hero", "friends", "0", "name"])
         }
-      }
-    }
+      )
   }
-  
+
   func testLoadingQueryWithFloats() async throws {
     // given
     let starshipLength: Float = 1234.5
     let coordinates: [[Double]] = [[38.857150, -94.798464]]
 
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("starshipCoordinates", Starship.self)
-      ]}
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
+      override class var __selections: [Selection] {
+        [
+          .field("starshipCoordinates", Starship.self)
+        ]
+      }
 
-      class Starship: MockSelectionSet {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self),
-          .field("length", Float.self),
-          .field("coordinates", [[Double]].self)
-        ]}
+      class Starship: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+            .field("length", Float.self),
+            .field("coordinates", [[Double]].self),
+          ]
+        }
       }
     }
-    
+
     await mergeRecordsIntoCache([
       "QUERY_ROOT": ["starshipCoordinates": CacheReference("starshipCoordinates")],
-      "starshipCoordinates": ["__typename": "Starship",
-                              "name": "Millennium Falcon",
-                              "length": starshipLength,
-                              "coordinates": coordinates]
+      "starshipCoordinates": [
+        "__typename": "Starship",
+        "name": "Millennium Falcon",
+        "length": starshipLength,
+        "coordinates": coordinates,
+      ],
     ])
-    
+
     // when
     let query = MockQuery<GivenSelectionSet>()
-    
-    loadFromStore(operation: query) { result in
-      // then
-      try XCTAssertSuccessResult(result) { graphQLResult in
-        XCTAssertEqual(graphQLResult.source, .cache)
-        XCTAssertNil(graphQLResult.errors)
-        
-        let data = try XCTUnwrap(graphQLResult.data)
-        let coordinateData: GivenSelectionSet.Starship? = data.starshipCoordinates
-        XCTAssertEqual(coordinateData?.name, "Millennium Falcon")
-        XCTAssertEqual(coordinateData?.length, starshipLength)
-        XCTAssertEqual(coordinateData?.coordinates, coordinates)
-      }
-    }
+
+    let response = try await store.load(query)
+    let data = try XCTUnwrap(response?.data)
+
+    // then
+    let coordinateData: GivenSelectionSet.Starship? = data.starshipCoordinates
+    XCTAssertEqual(coordinateData?.name, "Millennium Falcon")
+    XCTAssertEqual(coordinateData?.length, starshipLength)
+    XCTAssertEqual(coordinateData?.coordinates, coordinates)
   }
 
-  @MainActor func testLoadingHeroAndFriendsNamesQuery_withOptionalFriendsSelection_withNullFriendListItem_usingRequestChain_loadsDataFromNetworkAndWritesToStore() async throws {
+  @MainActor
+  func
+    testLoadingHeroAndFriendsNamesQuery_withOptionalFriendsSelection_withNullFriendListItem_usingRequestChain_loadsDataFromNetworkAndWritesToStore()
+    async throws
+  {
     // given
     struct Types {
       static let Hero = Object(typename: "Hero", implementedInterfaces: [])
@@ -577,11 +592,13 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
       typealias Schema = MockSchemaMetadata
 
       override class var __parentType: any ParentType { Types.Hero }
-      override class var __selections: [Selection] {[
-        .field("__typename", String.self),
-        .field("name", String.self),
-        .field("friends", [Friend?]?.self)
-      ]}
+      override class var __selections: [Selection] {
+        [
+          .field("__typename", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend?]?.self),
+        ]
+      }
 
       public var name: String? { __data["name"] }
       public var friends: [Friend?]? { __data["friends"] }
@@ -590,21 +607,25 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
         name: String? = nil,
         friends: [Friend?]? = nil
       ) {
-        self.init(_dataDict: DataDict(
-          data: [
-            "__typename": Types.Hero.typename,
-            "name": name,
-            "friends": friends
-          ],
-          fulfilledFragments: [ObjectIdentifier(Self.self)]
-        ))
+        self.init(
+          _dataDict: DataDict(
+            data: [
+              "__typename": Types.Hero.typename,
+              "name": name,
+              "friends": friends,
+            ],
+            fulfilledFragments: [ObjectIdentifier(Self.self)]
+          )
+        )
       }
 
       class Friend: MockSelectionSet, @unchecked Sendable {
-        override class var __selections: [Selection] {[
-          .field("__typename", String.self),
-          .field("name", String.self)
-        ]}
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("name", String.self),
+          ]
+        }
         var name: String { __data["name"] }
       }
     }
@@ -618,25 +639,25 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
           httpVersion: nil,
           headerFields: nil
         ),
-      """
-      {
-        "data": {
-          "__typename": "Hero",
-          "name": "R2-D2",
-          "friends": [
-            {
-              "__typename": "Friend",
-              "name": "Luke Skywalker"
-            },
-            null,
-            {
-              "__typename": "Friend",
-              "name": "Obi-Wan Kenobi"
-            }
-          ]
+        """
+        {
+          "data": {
+            "__typename": "Hero",
+            "name": "R2-D2",
+            "friends": [
+              {
+                "__typename": "Friend",
+                "name": "Luke Skywalker"
+              },
+              null,
+              {
+                "__typename": "Friend",
+                "name": "Obi-Wan Kenobi"
+              }
+            ]
+          }
         }
-      }
-      """.data(using: .utf8)
+        """.data(using: .utf8)
       )
     }
 
@@ -653,27 +674,25 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading, 
       operation: operation,
       fetchBehavior: .NetworkOnly,
       graphQLEndpoint: TestURL.mockServer.url
-    )    
+    )
 
     // when
     let resultStream = requestChain.kickoff(request: request)
 
     _ = try await resultStream.getAllValues()
 
-    loadFromStore(operation: MockQuery<Hero>()) { result in
-      // then
-      try XCTAssertSuccessResult(result) { graphQLResult in
-        XCTAssertEqual(graphQLResult.source, .cache)
-        XCTAssertNil(graphQLResult.errors)
+    let response = try await store.load(MockQuery<Hero>())
+    let data = try XCTUnwrap(response?.data)
 
-        let data = try XCTUnwrap(graphQLResult.data)
-        XCTAssertEqual(data.name, "R2-D2")
+    // then
+    XCTAssertEqual(response?.source, .cache)
+    XCTAssertNil(response?.errors)
 
-        XCTAssertEqual(data.friends?.count, 3)
-        XCTAssertEqual(data.friends![0]!.name, "Luke Skywalker")
-        XCTAssertNil(data.friends![1]) // Null friend at position 2
-        XCTAssertEqual(data.friends![2]!.name, "Obi-Wan Kenobi")
-      }
-    }
+    XCTAssertEqual(data.name, "R2-D2")
+
+    XCTAssertEqual(data.friends?.count, 3)
+    XCTAssertEqual(data.friends![0]!.name, "Luke Skywalker")
+    XCTAssertNil(data.friends![1])  // Null friend at position 2
+    XCTAssertEqual(data.friends![2]!.name, "Obi-Wan Kenobi")
   }
 }

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -32,12 +32,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   // MARK: - Read Query Tests
 
   func test_readQuery_givenQueryDataInCache_returnsData() async throws {
-    class HeroNameSelectionSet: MockSelectionSet {
+    class HeroNameSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
@@ -62,7 +62,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   func test_readQuery_givenQueryDataDoesNotExist_throwsMissingValueError() async throws {
     // given
-    class GivenSelectionSet: MockSelectionSet {
+    class GivenSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("name", String.self)
       ]}
@@ -90,12 +90,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       case JEDI
     }
 
-    class HeroNameSelectionSet: MockSelectionSet {
+    class HeroNameSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
@@ -129,12 +129,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       case PHANTOM_MENACE
     }
 
-    class HeroNameSelectionSet: MockSelectionSet {
+    class HeroNameSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
@@ -162,14 +162,14 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   func test_readQuery_withCacheReferencesByCustomKey_resolvesReferences() async throws {
     // given
-    class HeroFriendsSelectionSet: MockSelectionSet {
+    class HeroFriendsSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       var hero: Hero { __data["hero"] }
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
@@ -179,7 +179,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
         var friends: [Friend] { __data["friends"] }
 
-        class Friend: MockSelectionSet {
+        class Friend: MockSelectionSet, @unchecked Sendable {
           override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
@@ -231,7 +231,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     })
 
-    class GivenSelectionSet: MockFragment {
+    class GivenSelectionSet: MockFragment, @unchecked Sendable {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] { [
@@ -242,7 +242,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       var asDroid: AsDroid? { _asInlineFragment() }
 
-      class AsDroid: MockTypeCase {
+      class AsDroid: MockTypeCase, @unchecked Sendable {
         typealias Schema = MockSchemaMetadata
         override class var __parentType: any ParentType { Types.Droid }
 
@@ -282,7 +282,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     })
 
-    class GivenSelectionSet: MockFragment {
+    class GivenSelectionSet: MockFragment, @unchecked Sendable {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] { [
@@ -293,7 +293,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       var asDroid: AsDroid? { _asInlineFragment() }
 
-      class AsDroid: MockTypeCase {
+      class AsDroid: MockTypeCase, @unchecked Sendable {
         typealias Schema = MockSchemaMetadata
         override class var __parentType: any ParentType { Types.Droid }
 
@@ -373,10 +373,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let graphQLResult = try await store.load(query)
 
     // then
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.name, "Artoo")
   }
 
@@ -506,8 +506,8 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   /// to successfully mutate the 'name' field, but the 'nickname' field should still be a cache miss.
   /// While reading an optional field to execute a cache mutation, this is fine, but while reading the
   /// omitted optional field to execute a fetch from the cache onto a immutable selection set for a
-  /// operation, this should throw a missing value error, indicating the cache miss.
-  func test_updateCacheMutationWithOptionalField_omittingOptionalField_updateNestedField_updatesObjectsMaintainingNilValue_throwsMissingValueErrorOnRead() async throws {
+  /// operation, this return nil, indicating the cache miss.
+  func test_updateCacheMutationWithOptionalField_omittingOptionalField_updateNestedField_updatesObjectsMaintainingNilValue_returnsNilOnRead() async throws {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
@@ -561,9 +561,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     await expect {
       try await self.store.load(query)
-    }.to(throwError(
-      GraphQLExecutionError(path: ["hero", "nickname"], underlying: JSONDecodingError.missingValue)
-    ))
+    }.to(beNil())
   }
 
   func test_updateCacheMutationWithNonNullField_withNilValue_updateNestedField_throwsMissingValueOnInitialReadForUpdate() async throws {
@@ -669,10 +667,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let mutation = MockMutation<GivenSelectionSet>()
 
     let graphQLResult = try await self.store.load(mutation)
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.name, "Artoo")
   }
 
@@ -736,19 +734,19 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     let graphQLResult1 = try await self.store.load(query)
 
-    XCTAssertEqual(graphQLResult1.source, .cache)
-    XCTAssertNil(graphQLResult1.errors)
+    XCTAssertEqual(graphQLResult1?.source, .cache)
+    XCTAssertNil(graphQLResult1?.errors)
 
-    let data1 = try XCTUnwrap(graphQLResult1.data)
+    let data1 = try XCTUnwrap(graphQLResult1?.data)
     XCTAssertEqual(data1.hero.name, "Artoo")
 
     query.__variables = ["episode": Episode.PHANTOM_MENACE]
     let graphQLResult2 = try await self.store.load(query)
 
-    XCTAssertEqual(graphQLResult2.source, .cache)
-    XCTAssertNil(graphQLResult2.errors)
+    XCTAssertEqual(graphQLResult2?.source, .cache)
+    XCTAssertNil(graphQLResult2?.errors)
 
-    let data2 = try XCTUnwrap(graphQLResult2.data)
+    let data2 = try XCTUnwrap(graphQLResult2?.data)
     XCTAssertEqual(data2.hero.name, "Qui-Gon Jinn")
   }
 
@@ -836,10 +834,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let query = MockQuery<GivenSelectionSet>()
 
     let graphQLResult = try await self.store.load(query)
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.asDroid?.primaryFunction, "Combat")
   }
 
@@ -956,10 +954,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let query = MockQuery<GivenSelectionSet>()
 
     let graphQLResult = try await self.store.load(query)
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.name, "Artoo")
     XCTAssertEqual(data.hero.fragments.givenFragment.asDroid?.primaryFunction, "Combat")
   }
@@ -1099,10 +1097,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     let graphQLResult = try await self.store.load(query)
 
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.name, "Artoo")
     XCTAssertEqual(data.hero.fragments.givenFragment?.asDroid?.primaryFunction, "Combat")
   }
@@ -1200,10 +1198,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     let graphQLResult = try await self.store.load(query)
 
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.name, "R2-D2")
     let friendsNames = data.hero.friends.compactMap { $0.name }
     XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa", "C-3PO"])
@@ -1260,10 +1258,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let query = MockQuery<GivenSelectionSet>()
 
     let graphQLResult = try await self.store.load(query)
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.type, .case(.droid))
   }
 
@@ -1315,10 +1313,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let mutation = MockMutation<GivenSelectionSet>()
     let graphQLResult = try await self.store.load(mutation)
 
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.name, "Artoo")
   }
 
@@ -1476,10 +1474,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let query = MockQuery<GivenFragment>()
     let graphQLResult = try await self.store.load(query)
 
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.name, "Artoo")
   }
 
@@ -1498,7 +1496,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     })
 
-    class Data: MockSelectionSet {
+    class Data: MockSelectionSet, @unchecked Sendable {
       typealias Schema = MockSchemaMetadata
 
       override class var __parentType: any ParentType { Types.Query }
@@ -1548,7 +1546,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     })
 
-    class Data: MockSelectionSet {
+    class Data: MockSelectionSet, @unchecked Sendable {
       typealias Schema = MockSchemaMetadata
 
       override class var __parentType: any ParentType { Types.Query }
@@ -1567,7 +1565,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         ], fulfilledFragments: [ObjectIdentifier(Self.self)]))
       }
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: any ParentType { Types.Human }
@@ -1580,7 +1578,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         var ifA: IfA? { _asInlineFragment() }
         var ifB: IfB? { _asInlineFragment() }
 
-        class IfA: ConcreteMockTypeCase<Hero> {
+        class IfA: ConcreteMockTypeCase<Hero>, @unchecked Sendable {
           typealias Schema = MockSchemaMetadata
           override class var __parentType: any ParentType { Types.Human }
           override class var __selections: [Selection] {[
@@ -1608,7 +1606,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
             ]))
           }
 
-          class Friend: MockSelectionSet {
+          class Friend: MockSelectionSet, @unchecked Sendable {
             typealias Schema = MockSchemaMetadata
 
             override class var __parentType: any ParentType { Types.Human }
@@ -1631,7 +1629,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
           }
         }
 
-        class IfB: ConcreteMockTypeCase<Hero> {
+        class IfB: ConcreteMockTypeCase<Hero>, @unchecked Sendable {
           typealias Schema = MockSchemaMetadata
           override class var __parentType: any ParentType { Types.Human }
           override class var __selections: [Selection] {[
@@ -1688,7 +1686,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     })
 
-    class GivenQuery: MockSelectionSet {
+    class GivenQuery: MockSelectionSet, @unchecked Sendable {
       typealias Schema = MockSchemaMetadata
 
       override class var __parentType: any ParentType { Types.Query }
@@ -1707,7 +1705,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         ], fulfilledFragments: [ObjectIdentifier(Self.self)]))
       }
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: any ParentType { Types.Human }
@@ -1717,7 +1715,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
         var asCharacter: AsCharacter? { _asInlineFragment() }
 
-        class AsCharacter: ConcreteMockTypeCase<Hero> {
+        class AsCharacter: ConcreteMockTypeCase<Hero>, @unchecked Sendable {
           typealias Schema = MockSchemaMetadata
           override class var __parentType: any ParentType { Types.Character }
           override class var __selections: [Selection] {[
@@ -1827,7 +1825,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     }
 
-    class GivenQuery: MockSelectionSet {
+    class GivenQuery: MockSelectionSet, @unchecked Sendable {
       typealias Schema = MockSchemaMetadata
 
       override class var __parentType: any ParentType { Types.Query }
@@ -1843,7 +1841,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         ], fulfilledFragments: [ObjectIdentifier(Self.self)]))
       }
 
-      class IfA: ConcreteMockTypeCase<GivenQuery> {
+      class IfA: ConcreteMockTypeCase<GivenQuery>, @unchecked Sendable {
         typealias Schema = MockSchemaMetadata
         override class var __parentType: any ParentType { Types.Query }
         override class var __selections: [Selection] {[
@@ -1950,7 +1948,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     }
 
-    class GivenQuery: MockSelectionSet {
+    class GivenQuery: MockSelectionSet, @unchecked Sendable {
       typealias Schema = MockSchemaMetadata
 
       override class var __parentType: any ParentType { Types.Query }
@@ -1966,7 +1964,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         ], fulfilledFragments: [ObjectIdentifier(Self.self)]))
       }
 
-      class IfA: ConcreteMockTypeCase<GivenQuery> {
+      class IfA: ConcreteMockTypeCase<GivenQuery>, @unchecked Sendable {
         typealias Schema = MockSchemaMetadata
         override class var __parentType: any ParentType { Types.Query }
         override class var __selections: [Selection] {[
@@ -2124,14 +2122,14 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     }
 
-    class HeroFriendsSelectionSet: MockSelectionSet {
+    class HeroFriendsSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       var hero: Hero { __data["hero"] }
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
@@ -2141,7 +2139,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
         var friends: [Friend] { __data["friends"] }
 
-        class Friend: MockSelectionSet {
+        class Friend: MockSelectionSet, @unchecked Sendable {
           override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
@@ -2153,10 +2151,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     let query = MockQuery<HeroFriendsSelectionSet>()
     let graphQLResult = try await self.store.load(query)
-    XCTAssertEqual(graphQLResult.source, .cache)
-    XCTAssertNil(graphQLResult.errors)
+    XCTAssertEqual(graphQLResult?.source, .cache)
+    XCTAssertNil(graphQLResult?.errors)
 
-    let data = try XCTUnwrap(graphQLResult.data)
+    let data = try XCTUnwrap(graphQLResult?.data)
     XCTAssertEqual(data.hero.name, "R2-D2")
     let friendsNames: [String] = data.hero.friends.compactMap { $0.name }
     XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa", "C-3PO"])
@@ -2252,12 +2250,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   func test_removeObjectsMatchingPattern_givenPatternNotMatchingKeyCase_deletesCaseInsensitiveMatchingRecords() async throws {
     // given
-    class HeroNameSelectionSet: MockSelectionSet {
+    class HeroNameSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
@@ -2309,14 +2307,14 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       case EMPIRE
     }
 
-    class HeroFriendsSelectionSet: MockSelectionSet {
+    class HeroFriendsSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
       var hero: Hero { __data["hero"] }
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
@@ -2326,7 +2324,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
         var friends: [Friend] { __data["friends"] }
 
-        class Friend: MockSelectionSet {
+        class Friend: MockSelectionSet, @unchecked Sendable {
           override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
@@ -2419,12 +2417,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   func test_readTransaction_readQuery_afterTransaction_releasesReadTransaction() async throws {
     // given
-    class HeroNameSelectionSet: MockSelectionSet {
+    class HeroNameSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
-      class Hero: MockSelectionSet {
+      class Hero: MockSelectionSet, @unchecked Sendable {
         override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)

--- a/Tests/ApolloTests/Interceptors/MaxRetryInterceptorTests.swift
+++ b/Tests/ApolloTests/Interceptors/MaxRetryInterceptorTests.swift
@@ -97,7 +97,7 @@ class MaxRetryInterceptorTests: XCTestCase {
       requestConfiguration: RequestConfiguration()
     )
 
-    await expect { try await results.getAllValues() }.to(throwError(RequestChainError.noResults))
+    await expect { try await results.getAllValues() }.to(throwError(ApolloClient.Error.noResults))
     expect(testInterceptor.timesRetryHasBeenCalled).to(equal(testInterceptor.timesToCallRetry))    
   }
 }

--- a/Tests/ApolloTests/RequestChainNetworkTransportTests.swift
+++ b/Tests/ApolloTests/RequestChainNetworkTransportTests.swift
@@ -100,7 +100,7 @@ class RequestChainNetworkTransportTests: XCTestCase, MockResponseProvider {
 
     await expect {
       try await resultStream.getAllValues()
-    }.to(throwError(RequestChainError.noResults))
+    }.to(throwError(ApolloClient.Error.noResults))
   }
 
   // MARK: - Cancellation tests

--- a/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
+++ b/apollo-ios/Sources/Apollo/ApolloClientProtocol.swift
@@ -27,34 +27,42 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
     query: Query,
     fetchBehavior: FetchBehavior,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Swift.Error>
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Swift.Error>
   where Query.ResponseFormat == SingleResponseFormat
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.SingleResponse,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Swift.Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat
 
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.CacheAndNetwork,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Query>, any Swift.Error>
   where Query.ResponseFormat == IncrementalDeferredResponseFormat
 
+  /// Fetches a query from the local cache. Does not attempt to fetch results from the server.
+  ///
+  /// - Parameters:
+  ///   - query: The query to fetch.
+  ///   - cachePolicy: The `CacheOnly` cache policy.
+  ///   - requestConfiguration: A configuration used to configure per-request behaviors for this request
+  ///
+  ///   - Returns: The response loaded from the cache. On a cache miss, this will return `nil`.
   func fetch<Query: GraphQLQuery>(
     query: Query,
     cachePolicy: CachePolicy.Query.CacheOnly,
     requestConfiguration: RequestConfiguration?
-  ) async throws -> GraphQLResponse<Query>
+  ) async throws -> GraphQLResponse<Query>?
 
   // MARK: - Watch Functions
 
@@ -125,7 +133,7 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
   func perform<Mutation: GraphQLMutation>(
     mutation: Mutation,
     requestConfiguration: RequestConfiguration?
-  ) throws -> AsyncThrowingStream<GraphQLResponse<Mutation>, any Error>
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Mutation>, any Swift.Error>
   where Mutation.ResponseFormat == IncrementalDeferredResponseFormat
 
   // MARK: - Upload Functions
@@ -158,6 +166,6 @@ public protocol ApolloClientProtocol: AnyObject, Sendable {
     subscription: Subscription,
     cachePolicy: CachePolicy.Subscription,
     requestConfiguration: RequestConfiguration?
-  ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription>, any Error>
+  ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription>, any Swift.Error>
 
 }

--- a/apollo-ios/Sources/Apollo/CachePolicy.swift
+++ b/apollo-ios/Sources/Apollo/CachePolicy.swift
@@ -16,6 +16,8 @@ public enum CachePolicy: Sendable, Hashable {
       case networkOnly
     }
 
+    /// A cache policy that returns data from the cache if available,
+    /// Does not attempt to fetch results from the server.
     public enum CacheOnly: Sendable, Hashable {
       /// Return data from the cache if available, do not attempt to fetch results from the server.
       case cacheOnly

--- a/apollo-ios/Sources/Apollo/RequestBodyCreator.swift
+++ b/apollo-ios/Sources/Apollo/RequestBodyCreator.swift
@@ -2,7 +2,6 @@
 import ApolloAPI
 #endif
 
-#warning("TODO: Do we really need this? Should it be part of RequestChainNetworkTransport, or just on JSONRequest")
 public protocol JSONRequestBodyCreator: Sendable {
 
   /// Creates a `JSONEncodableDictionary` out of the passed-in operation

--- a/apollo-ios/Sources/Apollo/RequestChain.swift
+++ b/apollo-ios/Sources/Apollo/RequestChain.swift
@@ -4,19 +4,6 @@ import Foundation
   import ApolloAPI
 #endif
 
-public enum RequestChainError: Swift.Error, LocalizedError {
-  case noResults
-
-  public var errorDescription: String? {
-    switch self {
-    case .noResults:
-      return
-        "Request chain completed request with no results emitted. This can occur if the network returns a success response with no body content, or if an interceptor fails to pass on the emitted results"
-    }
-  }
-
-}
-
 public struct RequestChain<Request: GraphQLRequest>: Sendable {
 
   public struct Retry: Swift.Error {
@@ -132,7 +119,7 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
     }
 
     guard didEmitResult else {
-      throw RequestChainError.noResults
+      throw ApolloClient.Error.noResults
     }
   }
 
@@ -158,16 +145,7 @@ public struct RequestChain<Request: GraphQLRequest>: Sendable {
 
             // Cache miss
 
-          } catch {
-            #warning(
-              """
-              TODO: If we are making cache miss return nil (instead of throwing error), then should
-              this just always be throwing the error? What's the point of differentiating cache miss 
-              from thrown error if we are still supressing it here?
-
-              An error interceptor can still catch on the error and run a retry with a fetch behavior that doesn't do a cache read on the cache failure
-              """
-            )
+          } catch {            
             // Cache read failure
             if !fetchBehavior.shouldFetchFromNetwork(hadSuccessfulCacheRead: false) {
               throw error

--- a/apollo-ios/Sources/Apollo/SplitNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/SplitNetworkTransport.swift
@@ -28,7 +28,7 @@ public final class SplitNetworkTransport<
     queryTransport: QueryTransport,
     mutationTransport: MutationTransport,
     subscriptionTransport: SubscriptionTransport = Void(),
-    uploadTransport: UploadTransport = Void(),
+    uploadTransport: UploadTransport = Void()
   ) {
     self.queryTransport = queryTransport
     self.mutationTransport = mutationTransport

--- a/apollo-ios/Sources/ApolloAPI/JSONDecodingError.swift
+++ b/apollo-ios/Sources/ApolloAPI/JSONDecodingError.swift
@@ -7,7 +7,7 @@ import Foundation
 public enum JSONDecodingError: Error, LocalizedError, Hashable {
   /// A value that is expected to be present is missing from the ``JSONObject``.
   case missingValue
-  /// A value that is non-null has a `null`value.
+  /// A value that is non-null has a `null` value.
   case nullValue
   /// A value in a ``JSONObject`` was not of the expected `JSON` type.
   /// (eg. An object instead of a list)

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -198,7 +198,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
 
   public func setJournalMode(mode: JournalMode) throws {
     try performSync {
-      try exec("PRAGMA journal_mode = \(mode.rawValue);", errorMessage: "Failed to set journal mode")
+      _ = try exec("PRAGMA journal_mode = \(mode.rawValue);", errorMessage: "Failed to set journal mode")
     }
   }
 }


### PR DESCRIPTION
This PR changes the behavior of a cache miss to return `nil` rather than throwing a `JSONDecodingError.missingValue`. A cache miss is an expected possibility, not necessarily an error, and this can cause confusion for users. Now the cache loading mechanisms only throw an error if there is a problem with the cache, such as corrupt or invalid data.