### PR TITLE
Add isOneOf to inspection query in ApolloSchemaDownloader

### DIFF
--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
@@ -271,6 +271,7 @@ public struct ApolloSchemaDownloader {
           kind
           name
           description
+          isOneOf
           fields(includeDeprecated: true) {
             name
             description


### PR DESCRIPTION
In https://github.com/apollographql/apollo-ios-dev/pull/537 the `@oneOf` directive was introduced. However, I noticed that the directive was not included in my schema when I did an introspection, and so the additional types were not generated. 

I had a look at the source code, and noticed that the `isOneOf` was missing from the inspection query done in `ApolloSchemaDownloader`. I've added it, but I wasn't really able to test this, so I was hoping if somebody can point me in the right direction or help me out with this 🙏 