### PR TITLE
fix: Deferred fragment accessor with nested fragment

### DIFF
--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -526,12 +526,18 @@ struct SelectionSetTemplate {
   private func FragmentInitializerTemplate(
     _ selectionSet: ComputedSelectionSet
   ) -> String {
-    if let directSelections = selectionSet.direct,
-      (directSelections.inlineFragments.containsDeferredFragment
-      || directSelections.namedFragments.containsDeferredFragment)
-    {
-      return DesignatedInitializerTemplate(
-        """
+    guard
+      selectionSet.direct?.inlineFragments.containsDeferredFragment ?? false ||
+      selectionSet.direct?.namedFragments.containsDeferredFragment ?? false ||
+      selectionSet.merged.inlineFragments.containsDeferredFragment ||
+      selectionSet.merged.namedFragments.containsDeferredFragment
+    else {
+      return DesignatedInitializerTemplate()
+    }
+
+    return DesignatedInitializerTemplate(
+      """
+      \(ifLet: selectionSet.direct, { directSelections in """
         \(forEachIn: directSelections.inlineFragments.values, separator: "\n", {
           if let deferCondition = $0.typeInfo.deferCondition {
             return DeferredPropertyInitializationStatement(deferCondition.label)
@@ -546,12 +552,16 @@ struct SelectionSetTemplate {
 
           return ""
         })
-        """
-      )
+        """})
+      \(forEachIn: selectionSet.merged.namedFragments.values, separator: "\n", {
+        if let _ = $0.typeInfo.deferCondition {
+          return DeferredPropertyInitializationStatement($0.definition.name.firstLowercased)
+        }
 
-    } else {
-      return DesignatedInitializerTemplate()
-    }
+        return ""
+      })
+      """
+    )
   }
 
   private func DeferredPropertyInitializationStatement(_ propertyName: String) -> TemplateString {


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3567

The selection set template would correctly produce a fragment accessor property for merged deferred fragments but the initializer was missing.