### PR TITLE
Fix generated default mock initializer for lowercase type names

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -547,6 +547,7 @@ class MockObjectTemplateTests: XCTestCase {
 
   func test__render__givenSchemaTypeAndDefaultParameterFlagOn_generatesDefaultValueForRequiredFields() {
     // given
+    let aardvark: GraphQLType = .entity(GraphQLObjectType.mock("aardvark"))
     let Cat: GraphQLType = .entity(GraphQLObjectType.mock("Cat"))
     let Animal: GraphQLType = .entity(GraphQLInterfaceType.mock("Animal", implementingObjects: [GraphQLObjectType.mock("Duck")]))
     let Pet: GraphQLType = .entity(GraphQLUnionType.mock("Pet", types: [GraphQLObjectType.mock("Goldfish"), GraphQLObjectType.mock("Hamster")]))
@@ -558,6 +559,7 @@ class MockObjectTemplateTests: XCTestCase {
         "stringNestedList": .mock("stringNestedList", type: .nonNull(.list(.nonNull(.list(.nonNull(.string())))))),
         "customScalar": .mock("customScalar", type: .nonNull(.scalar(.mock(name: "CustomScalar")))),
         "customScalarList": .mock("customScalarList", type: .nonNull(.list(.nonNull(.scalar(.mock(name: "CustomScalar")))))),
+        "lowercaseObject": .mock("object", type: .nonNull(aardvark)),
         "object": .mock("object", type: .nonNull(Cat)),
         "objectList": .mock("objectList", type: .nonNull(.list(.nonNull(Cat)))),
         "objectNestedList": .mock("objectNestedList", type: .nonNull(.list(.nonNull(.list(.nonNull(Cat)))))),
@@ -585,6 +587,7 @@ class MockObjectTemplateTests: XCTestCase {
         interface: (any AnyMock) = Mock<Duck>(),
         interfaceList: [(any AnyMock)] = [],
         interfaceNestedList: [[(any AnyMock)]] = [],
+        lowercaseObject: Mock<Aardvark> = Mock<Aardvark>(),
         object: Mock<Cat> = Mock<Cat>(),
         objectList: [Mock<Cat>] = [],
         objectNestedList: [[Mock<Cat>]] = [],
@@ -603,6 +606,7 @@ class MockObjectTemplateTests: XCTestCase {
         _setEntity(interface, for: \\.interface)
         _setList(interfaceList, for: \\.interfaceList)
         _setList(interfaceNestedList, for: \\.interfaceNestedList)
+        _setEntity(lowercaseObject, for: \\.lowercaseObject)
         _setEntity(object, for: \\.object)
         _setList(objectList, for: \\.objectList)
         _setList(objectNestedList, for: \\.objectNestedList)

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/DefaultMockValueProviding.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/DefaultMockValueProviding.swift
@@ -54,7 +54,7 @@ extension GraphQLEnumType: DefaultMockValueProviding {
 
 extension GraphQLObjectType: DefaultMockValueProviding {
   func defaultMockValue(config: ApolloCodegen.ConfigurationContext) -> String {
-    return "Mock<\(name)>()"
+    return "Mock<\(self.render(as: .typename))>()"
   }
 }
 


### PR DESCRIPTION
I was previously using the GraphQLNamedType's `name` field to create the default mock initializer for entity types, but it looks like the declared type gets capitalized when generating the mocks.  The fix was to use the same function that is generating the mock type (`render(as: .typename)`) to generate the default initializer type.

I also added a new case to the test for this functionality that confirms that a lowercased type ("aardvark") will produce a template with matching declared and initialized types.