### PR TITLE
Use WebSocketError instead of raw error in disconnection handling

### DIFF
--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -556,10 +556,11 @@ extension WebSocketTransport: WebSocketClientDelegate {
       return previousState
     }
     // report any error to all subscribers
-    self.$error.mutate { $0 = WebSocketError(payload: nil,
-                                            error: error,
-                                            kind: .networkError) }
-    self.notifyErrorAllHandlers(error)
+    let webSocketError = WebSocketError(payload: nil,
+                                        error: error,
+                                        kind: .networkError)
+    self.$error.mutate { $0 = webSocketError }
+    self.notifyErrorAllHandlers(webSocketError)
 
     switch previousState {
     case .connected, .disconnected:


### PR DESCRIPTION
## What

This PR introduces the forwarding of `WebSocketError` to all handlers.

## Why

This allows handlers to more easily inspect the error type and react accordingly.  
In my specific use case, errors related to the WebSocket are already handled by the `WebSocketTransportDelegate`, so I want to be able to filter out those errors from the `.failure` case of the subscription.

## How

In the `handleDisconnection` method, the code previously forwarded the raw underlying error to the handlers.  
This PR changes that behavior by wrapping the error into a `WebSocketError`, ensuring consistency with the other code paths where `WebSocketError` is used instead of the raw error.

## Copilot summary
This pull request introduces a new test for handling WebSocket disconnection errors and refines the error reporting mechanism in the `WebSocketTransport` class. The changes improve test coverage and ensure better error propagation to subscribers.

### New Test for WebSocket Disconnection:

* Added a new test method `testWebSocketDidDisconnect` in `WebSocketTransportTests` to verify that a `WebSocketError` is correctly reported when the WebSocket disconnects unexpectedly. The test uses a mock WebSocket and a mock operation to simulate the scenario and validate the behavior. (`Tests/ApolloTests/WebSocket/WebSocketTransportTests.swift`, [Tests/ApolloTests/WebSocket/WebSocketTransportTests.swiftR111-R140](diffhunk://#diff-c2d57d1f3e013bc8e8c83b6b45f8f3df98b61006a1b44b9677b6020444968ad2R111-R140))

### Improved Error Reporting:

* Refactored error handling in the `WebSocketTransport` class to ensure that the `WebSocketError` is consistently passed to all subscribers. The error is now created as a local variable (`webSocketError`) and passed to both the `$error` property and the `notifyErrorAllHandlers` method, improving code clarity and consistency. (`apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift`, [apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swiftL559-R563](diffhunk://#diff-4ddf08c9f607a1380e81b0f0039befdf9de7f4fecc20c690325fc9b8d0c058ffL559-R563))