### PR TITLE
[v2] Fix Input Object

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -798,7 +798,7 @@ class InputObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
   }
 
-  func test__render__given_NonNullableField_WithDefault__generates_OptionalParameter_InitializerNilDefault() throws {
+  func test__render__given_nonNullableField_WithDefault__generates_OptionalParameter_InitializerNilDefault() throws {
     // given
     buildSubject(fields: [
       GraphQLInputField.mock("nonNullableWithDefault", type: .nonNull(.scalar(.integer())), defaultValue: .int(3))
@@ -809,7 +809,7 @@ class InputObjectTemplateTests: XCTestCase {
         nonNullableWithDefault: Int? = nil
       ) {
         __data = InputDict([
-          "nonNullableWithDefault": nonNullableWithDefault
+          "nonNullableWithDefault": nonNullableWithDefault ?? GraphQLNullable.none
         ])
       }
 
@@ -966,7 +966,7 @@ class InputObjectTemplateTests: XCTestCase {
         nonNullableListNullableItemWithDefault: [String?]? = nil
       ) {
         __data = InputDict([
-          "nonNullableListNullableItemWithDefault": nonNullableListNullableItemWithDefault
+          "nonNullableListNullableItemWithDefault": nonNullableListNullableItemWithDefault ?? GraphQLNullable.none
         ])
       }
 
@@ -1018,7 +1018,7 @@ class InputObjectTemplateTests: XCTestCase {
         nonNullableListNonNullableItemWithDefault: [String]? = nil
       ) {
         __data = InputDict([
-          "nonNullableListNonNullableItemWithDefault": nonNullableListNonNullableItemWithDefault
+          "nonNullableListNonNullableItemWithDefault": nonNullableListNonNullableItemWithDefault ?? GraphQLNullable.none
         ])
       }
 

--- a/Tests/ApolloTests/InputDictTests.swift
+++ b/Tests/ApolloTests/InputDictTests.swift
@@ -1,9 +1,17 @@
-import XCTest
-import Nimble
 import ApolloAPI
+import Nimble
+import XCTest
 
 final class InputDictTests: XCTestCase {
 
+  /// ```graphql
+  /// input OperationInput {
+  ///   stringField: String!
+  ///   nullableField: String
+  ///   requiredFieldWithDefaultValue: String! = "Default"
+  ///   nullableFieldWithDefaultValue: String = "Default"
+  /// }
+  /// ```
   private struct OperationInput: InputObject {
     public private(set) var __data: InputDict
 
@@ -13,11 +21,15 @@ final class InputDictTests: XCTestCase {
 
     public init(
       stringField: String,
-      nullableField: GraphQLNullable<String> = nil
+      nullableField: GraphQLNullable<String> = nil,
+      requiredFieldWithDefaultValue: String? = nil,
+      nullableFieldWithDefaultValue: GraphQLNullable<String> = nil
     ) {
       __data = InputDict([
         "stringField": stringField,
-        "nullableField": nullableField
+        "nullableField": nullableField,
+        "requiredFieldWithDefaultValue": requiredFieldWithDefaultValue ?? GraphQLNullable.none,
+        "nullableFieldWithDefaultValue": nullableFieldWithDefaultValue,
       ])
     }
 
@@ -30,9 +42,25 @@ final class InputDictTests: XCTestCase {
       get { __data["nullableField"] }
       set { __data["nullableField"] = newValue }
     }
+
+    public var requiredFieldWithDefaultValue: String? {
+      get { __data["requiredFieldWithDefaultValue"] }
+      set { __data["requiredFieldWithDefaultValue"] = newValue }
+    }
+
+    public var nullableFieldWithDefaultValue: GraphQLNullable<String> {
+      get { __data["nullableFieldWithDefaultValue"] }
+      set { __data["nullableFieldWithDefaultValue"] = newValue }
+    }
+
   }
 
-  func test__accessor__givenInputObjectNullableFieldInitializedWithDefaultValue_whenAccessingField_shouldEqualNilOrGraphQLNullableNone() throws {
+  // MARK: - Field Accessor Tests
+
+  func
+    test__accessor__given_nullableField_initializedWithDefaultValue_whenAccessingField_shouldEqualNilOrGraphQLNullableNone()
+    throws
+  {
     // given
     let input = OperationInput(stringField: "Something")
 
@@ -48,7 +76,7 @@ final class InputDictTests: XCTestCase {
     XCTAssertEqual(nullableValue, nil)
   }
 
-  func test__accessor__givenInputObjectNullableFieldInitializedWithValue_whenAccessingField_shouldEqualnitializedValue() throws {
+  func test__accessor__given_nullableField_initializedWithValue_whenAccessingField_shouldEqualnitializedValue() throws {
     // given
     let input = OperationInput(stringField: "Something", nullableField: "AnotherThing")
 
@@ -64,7 +92,9 @@ final class InputDictTests: XCTestCase {
     expect(nullableValue.unwrapped).to(equal("AnotherThing"))
   }
 
-  func test__accessor__givenInputObjectNullableFieldInitializedWithNullValue_whenAccessingField_shouldEqualGraphQLNullableNull() throws {
+  func test__accessor__given_nullableField_initializedWithNullValue_whenAccessingField_shouldEqualGraphQLNullableNull()
+    throws
+  {
     // given
     let input = OperationInput(stringField: "Something", nullableField: .null)
 
@@ -76,6 +106,347 @@ final class InputDictTests: XCTestCase {
     expect(stringValue).to(equal("Something"))
 
     expect(nullableValue).to(equal(GraphQLNullable<String>.null))
+  }
+
+  func
+    test__accessor__given_requiredFieldWithDefaultValue_using_defaultValue_whenAccessingField_should_beNil()
+    throws
+  {
+    // given
+    let input = OperationInput(
+      stringField: "Something"
+    )
+
+    // when
+    let value = input.requiredFieldWithDefaultValue
+
+    // then
+    expect(value).to(beNil())
+  }
+
+  func
+    test__accessor__given_requiredFieldWithDefaultValue_initializedWith_nil_whenAccessingField_should_beNil()
+    throws
+  {
+    // given
+    let input = OperationInput(
+      stringField: "Something",
+      requiredFieldWithDefaultValue: nil
+    )
+
+    // when
+    let value = input.requiredFieldWithDefaultValue
+
+    // then
+    expect(value).to(beNil())
+  }
+
+  func
+    test__accessor__given_requiredFieldWithDefaultValue_initializedWith_newValue_whenAccessingField_should_haveNewValue()
+    throws
+  {
+    // given
+    let expected = "TestValue"
+
+    let input = OperationInput(
+      stringField: "Something",
+      requiredFieldWithDefaultValue: expected
+    )
+
+    // when
+    let value = input.requiredFieldWithDefaultValue
+
+    // then
+    expect(value).to(equal(expected))
+  }
+
+  func
+    test__accessor__given_nullableFieldWithDefaultValue_using_defaultValue_whenAccessingField_should_be_none()
+    throws
+  {
+    // given
+    let input = OperationInput(
+      stringField: "Something"
+    )
+
+    // when
+    let value = input.nullableFieldWithDefaultValue
+
+    // then
+    expect(value).to(equal(GraphQLNullable.none))
+  }
+
+  func
+    test__accessor__given_nullableFieldWithDefaultValue_initializedWith_nil_whenAccessingField_should_be_none()
+    throws
+  {
+    // given
+    let input = OperationInput(
+      stringField: "Something",
+      nullableFieldWithDefaultValue: nil
+    )
+
+    // when
+    let value = input.nullableFieldWithDefaultValue
+
+    // then
+    expect(value).to(equal(GraphQLNullable.none))
+  }
+
+  func
+    test__accessor__given_nullableFieldWithDefaultValue_initializedWith_newValue_whenAccessingField_should_haveNewValue()
+    throws
+  {
+    // given
+    let expected = "TestValue"
+
+    let input = OperationInput(
+      stringField: "Something",
+      nullableFieldWithDefaultValue: .some(expected)
+    )
+
+    // when
+    let value = input.nullableFieldWithDefaultValue
+
+    // then
+    expect(value.unwrapped).to(equal(expected))
+  }
+
+  // MARK: - Setter Tests
+
+  func
+    test__setter__given_nullableField_setTo_value_whenAccessingField_shouldEqualValue()
+    throws
+  {
+    // given
+    let expected = "TestValue"
+    var input = OperationInput(stringField: "Something")
+
+    // when
+    input.stringField = expected
+    input.nullableField = .some(expected)
+
+    // then
+    expect(input.stringField).to(equal(expected))
+    expect(input.nullableField.unwrapped).to(equal(expected))
+  }
+
+  func test__setter__given_nullableField_setTo_null_whenAccessingField_shouldEqual_null() throws {
+    // given
+    var input = OperationInput(stringField: "Something", nullableField: "AnotherThing")
+
+    // when
+    input.nullableField = .null
+
+    // then
+    expect(input.nullableField).to(equal(GraphQLNullable.null))
+  }
+
+  func test__setter__given_nullableField_setTo_none_whenAccessingField_shouldEqual_none() throws {
+    // given
+    var input = OperationInput(stringField: "Something", nullableField: "AnotherThing")
+
+    // when
+    input.nullableField = .none
+
+    // then
+    expect(input.nullableField).to(equal(GraphQLNullable.none))
+  }
+
+  func
+    test__setter__given_requiredFieldWithDefaultValue_setTo_nil_whenAccessingField_should_beNil()
+    throws
+  {
+    // given
+    var input = OperationInput(
+      stringField: "Something"
+    )
+
+    // when
+    input.requiredFieldWithDefaultValue = nil
+
+    // then
+    expect(input.requiredFieldWithDefaultValue).to(beNil())
+  }
+
+  func
+    test__setter__given_requiredFieldWithDefaultValue_setTo_newValue_whenAccessingField_should_haveNewValue()
+    throws
+  {
+    // given
+    let expected = "TestValue"
+
+    var input = OperationInput(
+      stringField: "Something"
+    )
+
+    // when
+    input.requiredFieldWithDefaultValue = expected
+
+    // then
+    expect(input.requiredFieldWithDefaultValue).to(equal(expected))
+  }
+
+  func
+    test__setter__given_nullableFieldWithDefaultValue_setTo_nil_whenAccessingField_should_beNil()
+    throws
+  {
+    // given
+    var input = OperationInput(
+      stringField: "Something"
+    )
+
+    // when
+    input.nullableFieldWithDefaultValue = nil
+
+    // then
+    expect(input.nullableFieldWithDefaultValue).to(equal(GraphQLNullable.none))
+  }
+
+  func
+    test__setter__given_nullableFieldWithDefaultValue_setTo_null_whenAccessingField_should_beNil()
+    throws
+  {
+    // given
+    var input = OperationInput(
+      stringField: "Something"
+    )
+
+    // when
+    input.nullableFieldWithDefaultValue = .null
+
+    // then
+    expect(input.nullableFieldWithDefaultValue).to(equal(.null))
+  }
+
+  func
+    test__setter__given_nullableFieldWithDefaultValue_setTo_newValue_whenAccessingField_should_haveNewValue()
+    throws
+  {
+    // given
+    let expected = "TestValue"
+
+    var input = OperationInput(
+      stringField: "Something"
+    )
+
+    // when
+    input.nullableFieldWithDefaultValue = .some(expected)
+
+    // then
+    expect(input.nullableFieldWithDefaultValue.unwrapped).to(equal(expected))
+  }
+
+  // MARK: - jsonEncodableValue Tests
+
+  func
+    test__jsonEncodableValue__given_requiredFieldWithDefaultValue_using_defaultValue_whenAccessingField_shouldEqualGraphQLNullable_none()
+    throws
+  {
+    // given
+    let input = OperationInput(
+      stringField: "Something"
+    )
+
+    // when
+    let jsonObject = input._jsonEncodableValue as? JSONObject
+    let value: Any? = jsonObject?["requiredFieldWithDefaultValue"]
+
+    // then
+    expect(value).to(beNil())
+  }
+
+  func
+    test__jsonEncodableValue__given_requiredFieldWithDefaultValue_initializedWith_nil_whenAccessingField_shouldEqualGraphQLNullable_none()
+    throws
+  {
+    // given
+    let input = OperationInput(
+      stringField: "Something",
+      requiredFieldWithDefaultValue: nil
+    )
+
+    // when
+    let jsonObject = input._jsonEncodableValue as? JSONObject
+    let value: Any? = jsonObject?["requiredFieldWithDefaultValue"]
+
+    // then
+    expect(value).to(beNil())
+  }
+
+  func
+    test__jsonEncodableValue__given_requiredFieldWithDefaultValue_initializedWith_newValue_whenAccessingField_should_haveNewValue()
+    throws
+  {
+    // given
+    let expected = "TestValue"
+
+    let input = OperationInput(
+      stringField: "Something",
+      requiredFieldWithDefaultValue: expected
+    )
+
+    // when
+    let jsonObject = input._jsonEncodableValue?._jsonValue as? JSONObject
+    let value: Any? = jsonObject?["requiredFieldWithDefaultValue"]
+
+    // then
+    expect(value as? String).to(equal(expected))
+  }
+
+  func
+    test__jsonEncodableValue__given_nullableFieldWithDefaultValue_using_defaultValue_whenAccessingField_shouldEqualGraphQLNullable_none()
+    throws
+  {
+    // given
+    let input = OperationInput(
+      stringField: "Something"
+    )
+
+    // when
+    let jsonObject = input._jsonEncodableValue as? JSONObject
+    let value: Any? = jsonObject?["nullableFieldWithDefaultValue"]
+
+    // then
+    expect(value).to(beNil())
+  }
+
+  func
+    test__jsonEncodableValue__given_nullableFieldWithDefaultValue_initializedWith_nil_whenAccessingField_shouldEqualGraphQLNullable_none()
+    throws
+  {
+    // given
+    let input = OperationInput(
+      stringField: "Something",
+      nullableFieldWithDefaultValue: nil
+    )
+
+    // when
+    let jsonObject = input._jsonEncodableValue as? JSONObject
+    let value: Any? = jsonObject?["nullableFieldWithDefaultValue"]
+
+    // then
+    expect(value).to(beNil())
+  }
+
+  func
+    test__jsonEncodableValue__given_nullableFieldWithDefaultValue_initializedWith_newValue_whenAccessingField_should_haveNewValue()
+    throws
+  {
+    // given
+    let expected = "TestValue"
+
+    let input = OperationInput(
+      stringField: "Something",
+      nullableFieldWithDefaultValue: .some(expected)
+    )
+
+    // when
+    let jsonObject = input._jsonEncodableValue?._jsonValue as? JSONObject
+    let value: Any? = jsonObject?["nullableFieldWithDefaultValue"]
+
+    // then
+    expect(value as? String).to(equal(expected))
   }
 
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -89,7 +89,13 @@ struct InputObjectTemplate: TemplateRenderer {
     _ fields: GraphQLInputFieldDictionary
   ) -> TemplateString {
     TemplateString("""
-    \(fields.map({ "\"\($1.name.schemaName)\": \($1.render(config: config))" }), separator: ",\n")
+    \(fields.map({
+      TemplateString("""
+      "\($1.name.schemaName)": \($1.render(config: config))\(
+          if: !$1.type.isNullable && $1.hasDefaultValue, " ?? GraphQLNullable.none"
+        )
+      """)
+    }), separator: ",\n")
     """)
   }
 

--- a/apollo-ios/Sources/ApolloAPI/SchemaTypes/InputObject.swift
+++ b/apollo-ios/Sources/ApolloAPI/SchemaTypes/InputObject.swift
@@ -30,12 +30,6 @@ public struct InputDict: GraphQLOperationVariableValue, Hashable {
 
   public var _jsonEncodableValue: (any JSONEncodable)? { data._jsonEncodableObject }
 
-  @_disfavoredOverload
-  public subscript<T: GraphQLOperationVariableValue>(key: String) -> T {
-    get { data[key] as! T }
-    set { data[key] = newValue }
-  }
-
   public subscript<T: GraphQLOperationVariableValue>(key: String) -> GraphQLNullable<T> {
     get {
       if let value = data[key] {
@@ -45,6 +39,27 @@ public struct InputDict: GraphQLOperationVariableValue, Hashable {
       return .none
     }
     set { data[key] = newValue }
+  }
+
+  @_disfavoredOverload
+  public subscript<T: GraphQLOperationVariableValue>(key: String) -> T {
+    get { data[key] as! T }
+    set { data[key] = newValue }
+  }
+
+  @_disfavoredOverload
+  public subscript<T: GraphQLOperationVariableValue>(key: String) -> T? {
+    get {
+      switch data[key] {
+      case let .some(value) as GraphQLNullable<T>,
+        let value as T:
+        return value
+        
+      default:
+        return nil
+      }
+    }
+    set { data[key] = newValue ?? GraphQLNullable.none }
   }
 
   public static func == (lhs: InputDict, rhs: InputDict) -> Bool {


### PR DESCRIPTION
In 2.0 we remove conformance of `Optional` to `GraphQLOperationVariableValue` because it should always be stored as a `GraphQLNullable`.

This caused a few issues addressed by this PR:

On a generated InputObject, non-null fields with a schema defined default value are generated as `Optional`. Because they either are a value or `nil` (using the default value of the schema) they can't be `.null` like a nullable field. Since `Optional` cannot be stored as a variable any more, the generated input object failed to compile.

This PR:

1. Adds a new subscript to `InputDict` that converts the `GraphQLNullable` to the `Optional` field value (and vice versa for the setter).

2. Converts the `Optional` value in the input objects initializer to `GraphQLNullable` in the code generation template.