### PR TITLE
fix: change clientVersion build delimiter

### DIFF
--- a/apollo-ios/Sources/Apollo/NetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/NetworkTransport.swift
@@ -68,7 +68,7 @@ public extension NetworkTransport {
       if version.isEmpty {
         version.append(buildNumber)
       } else {
-        version.append("-\(buildNumber)")
+        version.append("+\(buildNumber)")
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-ios/issues/3570.

This changes the version/build delimiter from a `-` to a `+`. This now matches [the semver specification of that additional metadata](https://semver.org/#spec-item-10).

> Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version. Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-]. Identifiers MUST NOT be empty. Build metadata MUST be ignored when determining version precedence. Thus two versions that differ only in the build metadata, have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3----117B344092BD.

**Note:** This does not address the metadata difference between [pre-release](https://semver.org/#spec-item-9) and [stable](https://semver.org/#spec-item-10) versions.