### PR TITLE
[v2] Only input variables use Int32 in generated models

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -152,18 +152,18 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
     public static var __selections: [ApolloAPI.Selection] { [
-      .field("bodyTemperature", Int32.self),
+      .field("bodyTemperature", Int.self),
       .field("isJellicle", Bool.self),
     ] }
 
-    public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+    public var bodyTemperature: Int { __data["bodyTemperature"] }
     public var isJellicle: Bool { __data["isJellicle"] }
     public var species: String { __data["species"] }
     public var humanName: String? { __data["humanName"] }
     public var laysEggs: Bool { __data["laysEggs"] }
 
     public init(
-      bodyTemperature: Int32,
+      bodyTemperature: Int,
       isJellicle: Bool,
       species: String,
       humanName: String? = nil,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/CrocodileFragment.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/CrocodileFragment.graphql.swift
@@ -15,17 +15,17 @@ public struct CrocodileFragment: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var __selections: [ApolloAPI.Selection] { [
     .field("__typename", String.self),
     .field("species", String.self),
-    .field("age", Int32.self),
+    .field("age", Int.self),
     .field("tag", String?.self, arguments: ["id": "albino"]),
   ] }
 
   public var species: String { __data["species"] }
-  public var age: Int32 { __data["age"] }
+  public var age: Int { __data["age"] }
   public var tag: String? { __data["tag"] }
 
   public init(
     species: String,
-    age: Int32,
+    age: Int,
     tag: String? = nil
   ) {
     self.init(_dataDict: DataDict(

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
@@ -44,13 +44,13 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
     public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("__typename", String.self),
-      .field("meters", Int32.self),
+      .field("meters", Int.self),
     ] }
 
-    public var meters: Int32 { __data["meters"] }
+    public var meters: Int { __data["meters"] }
 
     public init(
-      meters: Int32
+      meters: Int
     ) {
       self.init(_dataDict: DataDict(
         data: [

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -14,11 +14,11 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
   public static var __selections: [ApolloAPI.Selection] { [
     .field("__typename", String.self),
-    .field("bodyTemperature", Int32.self),
+    .field("bodyTemperature", Int.self),
     .fragment(HeightInMeters.self),
   ] }
 
-  public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+  public var bodyTemperature: Int { __data["bodyTemperature"] }
   public var height: Height { __data["height"] }
 
   public struct Fragments: FragmentContainer {
@@ -30,7 +30,7 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public init(
     __typename: String,
-    bodyTemperature: Int32,
+    bodyTemperature: Int,
     height: Height
   ) {
     self.init(_dataDict: DataDict(

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsDeferQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsDeferQuery.graphql.swift
@@ -113,18 +113,18 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
         public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("__typename", String.self),
-          .field("feet", Int32.self),
-          .field("inches", Int32?.self),
+          .field("feet", Int.self),
+          .field("inches", Int?.self),
         ] }
 
-        public var feet: Int32 { __data["feet"] }
-        public var inches: Int32? { __data["inches"] }
-        public var meters: Int32 { __data["meters"] }
+        public var feet: Int { __data["feet"] }
+        public var inches: Int? { __data["inches"] }
+        public var meters: Int { __data["meters"] }
 
         public init(
-          feet: Int32,
-          inches: Int32? = nil,
-          meters: Int32
+          feet: Int,
+          inches: Int? = nil,
+          meters: Int
         ) {
           self.init(_dataDict: DataDict(
             data: [
@@ -192,7 +192,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
           public var predators: [Predator] { __data["predators"] }
           public var laysEggs: Bool { __data["laysEggs"] }
           public var species: String { __data["species"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var height: Height { __data["height"] }
 
           public struct Fragments: FragmentContainer {
@@ -208,7 +208,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
             predators: [Predator],
             laysEggs: Bool,
             species: String,
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             height: Height
           ) {
             self.init(_dataDict: DataDict(
@@ -282,7 +282,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
-        public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+        public var bodyTemperature: Int { __data["bodyTemperature"] }
 
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
@@ -299,7 +299,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           predators: [Predator],
-          bodyTemperature: Int32
+          bodyTemperature: Int
         ) {
           self.init(_dataDict: DataDict(
             data: [
@@ -329,14 +329,14 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -438,14 +438,14 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -483,7 +483,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
           public var species: String { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
           public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var humanName: String? { __data["humanName"] }
           public var favoriteToy: String { __data["favoriteToy"] }
           public var owner: Owner? { __data["owner"] }
@@ -504,7 +504,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
             species: String,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
             predators: [Predator],
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             humanName: String? = nil,
             favoriteToy: String,
             owner: Owner? = nil
@@ -542,14 +542,14 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
             public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-            public var feet: Int32 { __data["feet"] }
-            public var inches: Int32? { __data["inches"] }
-            public var meters: Int32 { __data["meters"] }
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
+            public var meters: Int { __data["meters"] }
 
             public init(
-              feet: Int32,
-              inches: Int32? = nil,
-              meters: Int32
+              feet: Int,
+              inches: Int? = nil,
+              meters: Int
             ) {
               self.init(_dataDict: DataDict(
                 data: [
@@ -648,16 +648,16 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
             public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize> { __data["relativeSize"] }
             public var centimeters: Double { __data["centimeters"] }
-            public var feet: Int32 { __data["feet"] }
-            public var inches: Int32? { __data["inches"] }
-            public var meters: Int32 { __data["meters"] }
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
+            public var meters: Int { __data["meters"] }
 
             public init(
               relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>,
               centimeters: Double,
-              feet: Int32,
-              inches: Int32? = nil,
-              meters: Int32
+              feet: Int,
+              inches: Int? = nil,
+              meters: Int
             ) {
               self.init(_dataDict: DataDict(
                 data: [
@@ -699,7 +699,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
-        public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+        public var bodyTemperature: Int { __data["bodyTemperature"] }
         public var humanName: String? { __data["humanName"] }
         public var favoriteToy: String { __data["favoriteToy"] }
         public var owner: Owner? { __data["owner"] }
@@ -723,7 +723,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           predators: [Predator],
-          bodyTemperature: Int32,
+          bodyTemperature: Int,
           humanName: String? = nil,
           favoriteToy: String,
           owner: Owner? = nil
@@ -766,14 +766,14 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -812,7 +812,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
           public var species: String { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
           public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var humanName: String? { __data["humanName"] }
           public var favoriteToy: String { __data["favoriteToy"] }
           public var owner: Owner? { __data["owner"] }
@@ -833,7 +833,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
             species: String,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
             predators: [Predator],
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             humanName: String? = nil,
             favoriteToy: String,
             owner: Owner? = nil
@@ -875,14 +875,14 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
             public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-            public var feet: Int32 { __data["feet"] }
-            public var inches: Int32? { __data["inches"] }
-            public var meters: Int32 { __data["meters"] }
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
+            public var meters: Int { __data["meters"] }
 
             public init(
-              feet: Int32,
-              inches: Int32? = nil,
-              meters: Int32
+              feet: Int,
+              inches: Int? = nil,
+              meters: Int
             ) {
               self.init(_dataDict: DataDict(
                 data: [
@@ -966,14 +966,14 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -1010,7 +1010,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
           public var species: String { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
           public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var humanName: String? { __data["humanName"] }
           public var favoriteToy: String { __data["favoriteToy"] }
           public var owner: Owner? { __data["owner"] }
@@ -1031,7 +1031,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
             species: String,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
             predators: [Predator],
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             humanName: String? = nil,
             favoriteToy: String,
             owner: Owner? = nil
@@ -1073,14 +1073,14 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
             public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-            public var feet: Int32 { __data["feet"] }
-            public var inches: Int32? { __data["inches"] }
-            public var meters: Int32 { __data["meters"] }
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
+            public var meters: Int { __data["meters"] }
 
             public init(
-              feet: Int32,
-              inches: Int32? = nil,
-              meters: Int32
+              feet: Int,
+              inches: Int? = nil,
+              meters: Int
             ) {
               self.init(_dataDict: DataDict(
                 data: [
@@ -1120,7 +1120,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
-        public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+        public var bodyTemperature: Int { __data["bodyTemperature"] }
         public var humanName: String? { __data["humanName"] }
         public var favoriteToy: String { __data["favoriteToy"] }
         public var owner: Owner? { __data["owner"] }
@@ -1144,7 +1144,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           predators: [Predator],
-          bodyTemperature: Int32,
+          bodyTemperature: Int,
           humanName: String? = nil,
           favoriteToy: String,
           owner: Owner? = nil
@@ -1187,14 +1187,14 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -1235,7 +1235,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
           public var species: String { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
           public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var humanName: String? { __data["humanName"] }
           public var owner: Owner? { __data["owner"] }
 
@@ -1256,7 +1256,7 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
             species: String,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
             predators: [Predator],
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             humanName: String? = nil,
             owner: Owner? = nil
           ) {
@@ -1297,14 +1297,14 @@ public struct AllAnimalsDeferQuery: GraphQLQuery {
 
             public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-            public var feet: Int32 { __data["feet"] }
-            public var inches: Int32? { __data["inches"] }
-            public var meters: Int32 { __data["meters"] }
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
+            public var meters: Int { __data["meters"] }
 
             public init(
-              feet: Int32,
-              inches: Int32? = nil,
-              meters: Int32
+              feet: Int,
+              inches: Int? = nil,
+              meters: Int
             ) {
               self.init(_dataDict: DataDict(
                 data: [

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -134,16 +134,16 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("__typename", String.self),
-          .field("feet", Int32.self),
-          .field("inches", Int32?.self),
+          .field("feet", Int.self),
+          .field("inches", Int?.self),
         ] }
 
-        public var feet: Int32 { __data["feet"] }
-        public var inches: Int32? { __data["inches"] }
+        public var feet: Int { __data["feet"] }
+        public var inches: Int? { __data["inches"] }
 
         public init(
-          feet: Int32,
-          inches: Int32? = nil
+          feet: Int,
+          inches: Int? = nil
         ) {
           self.init(_dataDict: DataDict(
             data: [
@@ -208,7 +208,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public var species: String { __data["species"] }
           public var laysEggs: Bool { __data["laysEggs"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var height: Height { __data["height"] }
 
           public struct Fragments: FragmentContainer {
@@ -223,7 +223,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
             __typename: String,
             species: String,
             laysEggs: Bool,
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             height: Height
           ) {
             self.init(_dataDict: DataDict(
@@ -304,14 +304,14 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -347,7 +347,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public var species: String? { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
-        public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+        public var bodyTemperature: Int { __data["bodyTemperature"] }
 
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
@@ -363,7 +363,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
           species: String? = nil,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           predators: [Predator],
-          bodyTemperature: Int32
+          bodyTemperature: Int
         ) {
           self.init(_dataDict: DataDict(
             data: [
@@ -392,14 +392,14 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -501,14 +501,14 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
           public var centimeters: Double? { __data["centimeters"] }
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
 
           public init(
             relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? = nil,
             centimeters: Double? = nil,
-            feet: Int32,
-            inches: Int32? = nil
+            feet: Int,
+            inches: Int? = nil
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -545,7 +545,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var species: String? { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
           public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var id: AnimalKingdomAPI.ID { __data["id"] }
           public var humanName: String? { __data["humanName"] }
           public var favoriteToy: String { __data["favoriteToy"] }
@@ -566,7 +566,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
             species: String? = nil,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
             predators: [Predator],
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             id: AnimalKingdomAPI.ID,
             humanName: String? = nil,
             favoriteToy: String,
@@ -605,18 +605,18 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-            public var feet: Int32 { __data["feet"] }
-            public var inches: Int32? { __data["inches"] }
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
             public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
-            public var meters: Int32 { __data["meters"] }
+            public var meters: Int { __data["meters"] }
 
             public init(
-              feet: Int32,
-              inches: Int32? = nil,
+              feet: Int,
+              inches: Int? = nil,
               relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? = nil,
               centimeters: Double? = nil,
-              meters: Int32
+              meters: Int
             ) {
               self.init(_dataDict: DataDict(
                 data: [
@@ -659,7 +659,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public var species: String? { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
-        public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+        public var bodyTemperature: Int { __data["bodyTemperature"] }
         public var id: AnimalKingdomAPI.ID { __data["id"] }
         public var humanName: String? { __data["humanName"] }
         public var favoriteToy: String { __data["favoriteToy"] }
@@ -680,7 +680,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
           species: String? = nil,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           predators: [Predator],
-          bodyTemperature: Int32,
+          bodyTemperature: Int,
           id: AnimalKingdomAPI.ID,
           humanName: String? = nil,
           favoriteToy: String,
@@ -721,18 +721,18 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
           public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
           public var centimeters: Double? { __data["centimeters"] }
-          public var meters: Int32 { __data["meters"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
+            feet: Int,
+            inches: Int? = nil,
             relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? = nil,
             centimeters: Double? = nil,
-            meters: Int32
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -823,7 +823,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var species: String? { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
           public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var id: AnimalKingdomAPI.ID { __data["id"] }
           public var humanName: String? { __data["humanName"] }
           public var favoriteToy: String { __data["favoriteToy"] }
@@ -844,7 +844,7 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
             species: String? = nil,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
             predators: [Predator],
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             id: AnimalKingdomAPI.ID,
             humanName: String? = nil,
             favoriteToy: String,
@@ -886,18 +886,18 @@ public struct AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-            public var feet: Int32 { __data["feet"] }
-            public var inches: Int32? { __data["inches"] }
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
             public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
-            public var meters: Int32 { __data["meters"] }
+            public var meters: Int { __data["meters"] }
 
             public init(
-              feet: Int32,
-              inches: Int32? = nil,
+              feet: Int,
+              inches: Int? = nil,
               relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? = nil,
               centimeters: Double? = nil,
-              meters: Int32
+              meters: Int
             ) {
               self.init(_dataDict: DataDict(
                 data: [

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -113,18 +113,18 @@ public struct AllAnimalsQuery: GraphQLQuery {
         public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("__typename", String.self),
-          .field("feet", Int32.self),
-          .field("inches", Int32?.self),
+          .field("feet", Int.self),
+          .field("inches", Int?.self),
         ] }
 
-        public var feet: Int32 { __data["feet"] }
-        public var inches: Int32? { __data["inches"] }
-        public var meters: Int32 { __data["meters"] }
+        public var feet: Int { __data["feet"] }
+        public var inches: Int? { __data["inches"] }
+        public var meters: Int { __data["meters"] }
 
         public init(
-          feet: Int32,
-          inches: Int32? = nil,
-          meters: Int32
+          feet: Int,
+          inches: Int? = nil,
+          meters: Int
         ) {
           self.init(_dataDict: DataDict(
             data: [
@@ -192,7 +192,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
           public var predators: [Predator] { __data["predators"] }
           public var laysEggs: Bool { __data["laysEggs"] }
           public var species: String { __data["species"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var height: Height { __data["height"] }
 
           public struct Fragments: FragmentContainer {
@@ -208,7 +208,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
             predators: [Predator],
             laysEggs: Bool,
             species: String,
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             height: Height
           ) {
             self.init(_dataDict: DataDict(
@@ -282,7 +282,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
-        public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+        public var bodyTemperature: Int { __data["bodyTemperature"] }
 
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
@@ -299,7 +299,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           predators: [Predator],
-          bodyTemperature: Int32
+          bodyTemperature: Int
         ) {
           self.init(_dataDict: DataDict(
             data: [
@@ -329,14 +329,14 @@ public struct AllAnimalsQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -436,16 +436,16 @@ public struct AllAnimalsQuery: GraphQLQuery {
 
           public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize> { __data["relativeSize"] }
           public var centimeters: Double { __data["centimeters"] }
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
             relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>,
             centimeters: Double,
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -485,7 +485,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
           public var species: String { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
           public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var humanName: String? { __data["humanName"] }
           public var favoriteToy: String { __data["favoriteToy"] }
           public var owner: Owner? { __data["owner"] }
@@ -506,7 +506,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
             species: String,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
             predators: [Predator],
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             humanName: String? = nil,
             favoriteToy: String,
             owner: Owner? = nil
@@ -544,16 +544,16 @@ public struct AllAnimalsQuery: GraphQLQuery {
 
             public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-            public var feet: Int32 { __data["feet"] }
-            public var inches: Int32? { __data["inches"] }
-            public var meters: Int32 { __data["meters"] }
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
+            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize> { __data["relativeSize"] }
             public var centimeters: Double { __data["centimeters"] }
 
             public init(
-              feet: Int32,
-              inches: Int32? = nil,
-              meters: Int32,
+              feet: Int,
+              inches: Int? = nil,
+              meters: Int,
               relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>,
               centimeters: Double
             ) {
@@ -599,7 +599,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
-        public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+        public var bodyTemperature: Int { __data["bodyTemperature"] }
         public var humanName: String? { __data["humanName"] }
         public var favoriteToy: String { __data["favoriteToy"] }
         public var owner: Owner? { __data["owner"] }
@@ -620,7 +620,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           predators: [Predator],
-          bodyTemperature: Int32,
+          bodyTemperature: Int,
           humanName: String? = nil,
           favoriteToy: String,
           owner: Owner? = nil
@@ -661,16 +661,16 @@ public struct AllAnimalsQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
           public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize> { __data["relativeSize"] }
           public var centimeters: Double { __data["centimeters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32,
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int,
             relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>,
             centimeters: Double
           ) {
@@ -758,14 +758,14 @@ public struct AllAnimalsQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -802,7 +802,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
           public var species: String { __data["species"] }
           public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
           public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+          public var bodyTemperature: Int { __data["bodyTemperature"] }
           public var humanName: String? { __data["humanName"] }
           public var favoriteToy: String { __data["favoriteToy"] }
           public var owner: Owner? { __data["owner"] }
@@ -823,7 +823,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
             species: String,
             skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
             predators: [Predator],
-            bodyTemperature: Int32,
+            bodyTemperature: Int,
             humanName: String? = nil,
             favoriteToy: String,
             owner: Owner? = nil
@@ -865,16 +865,16 @@ public struct AllAnimalsQuery: GraphQLQuery {
 
             public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-            public var feet: Int32 { __data["feet"] }
-            public var inches: Int32? { __data["inches"] }
-            public var meters: Int32 { __data["meters"] }
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
+            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize> { __data["relativeSize"] }
             public var centimeters: Double { __data["centimeters"] }
 
             public init(
-              feet: Int32,
-              inches: Int32? = nil,
-              meters: Int32,
+              feet: Int,
+              inches: Int? = nil,
+              meters: Int,
               relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>,
               centimeters: Double
             ) {
@@ -922,7 +922,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
-        public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+        public var bodyTemperature: Int { __data["bodyTemperature"] }
         public var humanName: String? { __data["humanName"] }
         public var owner: Owner? { __data["owner"] }
 
@@ -943,7 +943,7 @@ public struct AllAnimalsQuery: GraphQLQuery {
           species: String,
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
           predators: [Predator],
-          bodyTemperature: Int32,
+          bodyTemperature: Int,
           humanName: String? = nil,
           owner: Owner? = nil
         ) {
@@ -983,16 +983,16 @@ public struct AllAnimalsQuery: GraphQLQuery {
 
           public static var __parentType: any ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
-          public var feet: Int32 { __data["feet"] }
-          public var inches: Int32? { __data["inches"] }
-          public var meters: Int32 { __data["meters"] }
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
           public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize> { __data["relativeSize"] }
           public var centimeters: Double { __data["centimeters"] }
 
           public init(
-            feet: Int32,
-            inches: Int32? = nil,
-            meters: Int32,
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int,
             relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>,
             centimeters: Double
           ) {

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -229,7 +229,7 @@ public struct ClassroomPetsQuery: GraphQLQuery {
         public var species: String { __data["species"] }
         public var humanName: String? { __data["humanName"] }
         public var laysEggs: Bool { __data["laysEggs"] }
-        public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+        public var bodyTemperature: Int { __data["bodyTemperature"] }
         public var isJellicle: Bool { __data["isJellicle"] }
 
         public struct Fragments: FragmentContainer {
@@ -243,7 +243,7 @@ public struct ClassroomPetsQuery: GraphQLQuery {
           species: String,
           humanName: String? = nil,
           laysEggs: Bool,
-          bodyTemperature: Int32,
+          bodyTemperature: Int,
           isJellicle: Bool
         ) {
           self.init(_dataDict: DataDict(

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Bird+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Bird+Mock.graphql.swift
@@ -10,7 +10,7 @@ public final class Bird: MockObject {
   public typealias MockValueCollectionType = Array<Mock<Bird>>
 
   public struct MockFields: Sendable {
-    @Field<Int32>("bodyTemperature") public var bodyTemperature
+    @Field<Int>("bodyTemperature") public var bodyTemperature
     @Field<String>("favoriteToy") public var favoriteToy
     @Field<Height>("height") public var height
     @Field<String>("humanName") public var humanName
@@ -26,7 +26,7 @@ public final class Bird: MockObject {
 
 public extension Mock where O == Bird {
   convenience init(
-    bodyTemperature: Int32 = 0,
+    bodyTemperature: Int = 0,
     favoriteToy: String = "",
     height: Mock<Height> = Mock<Height>(),
     humanName: String? = nil,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Cat+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Cat+Mock.graphql.swift
@@ -10,7 +10,7 @@ public final class Cat: MockObject {
   public typealias MockValueCollectionType = Array<Mock<Cat>>
 
   public struct MockFields: Sendable {
-    @Field<Int32>("bodyTemperature") public var bodyTemperature
+    @Field<Int>("bodyTemperature") public var bodyTemperature
     @Field<String>("favoriteToy") public var favoriteToy
     @Field<Height>("height") public var height
     @Field<String>("humanName") public var humanName
@@ -26,7 +26,7 @@ public final class Cat: MockObject {
 
 public extension Mock where O == Cat {
   convenience init(
-    bodyTemperature: Int32 = 0,
+    bodyTemperature: Int = 0,
     favoriteToy: String = "",
     height: Mock<Height> = Mock<Height>(),
     humanName: String? = nil,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Crocodile+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Crocodile+Mock.graphql.swift
@@ -10,7 +10,7 @@ public final class Crocodile: MockObject {
   public typealias MockValueCollectionType = Array<Mock<Crocodile>>
 
   public struct MockFields: Sendable {
-    @Field<Int32>("age") public var age
+    @Field<Int>("age") public var age
     @Field<Height>("height") public var height
     @Field<AnimalKingdomAPI.ID>("id") public var id
     @Field<[Animal]>("predators") public var predators
@@ -22,7 +22,7 @@ public final class Crocodile: MockObject {
 
 public extension Mock where O == Crocodile {
   convenience init(
-    age: Int32 = 0,
+    age: Int = 0,
     height: Mock<Height> = Mock<Height>(),
     id: AnimalKingdomAPI.ID = "",
     predators: [(any AnyMock)] = [],

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Dog+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Dog+Mock.graphql.swift
@@ -11,7 +11,7 @@ public final class Dog: MockObject {
 
   public struct MockFields: Sendable {
     @Field<AnimalKingdomAPI.CustomDate>("birthdate") public var birthdate
-    @Field<Int32>("bodyTemperature") public var bodyTemperature
+    @Field<Int>("bodyTemperature") public var bodyTemperature
     @Field<String>("favoriteToy") public var favoriteToy
     @Field<Height>("height") public var height
     @Field<AnimalKingdomAPI.Object>("houseDetails") public var houseDetails
@@ -28,7 +28,7 @@ public final class Dog: MockObject {
 public extension Mock where O == Dog {
   convenience init(
     birthdate: AnimalKingdomAPI.CustomDate? = nil,
-    bodyTemperature: Int32 = 0,
+    bodyTemperature: Int = 0,
     favoriteToy: String = "",
     height: Mock<Height> = Mock<Height>(),
     houseDetails: AnimalKingdomAPI.Object? = nil,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Height+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Height+Mock.graphql.swift
@@ -11,9 +11,9 @@ public final class Height: MockObject {
 
   public struct MockFields: Sendable {
     @Field<Double>("centimeters") public var centimeters
-    @Field<Int32>("feet") public var feet
-    @Field<Int32>("inches") public var inches
-    @Field<Int32>("meters") public var meters
+    @Field<Int>("feet") public var feet
+    @Field<Int>("inches") public var inches
+    @Field<Int>("meters") public var meters
     @Field<GraphQLEnum<AnimalKingdomAPI.RelativeSize>>("relativeSize") public var relativeSize
   }
 }
@@ -21,9 +21,9 @@ public final class Height: MockObject {
 public extension Mock where O == Height {
   convenience init(
     centimeters: Double = 0.0,
-    feet: Int32 = 0,
-    inches: Int32? = nil,
-    meters: Int32 = 0,
+    feet: Int = 0,
+    inches: Int? = nil,
+    meters: Int = 0,
     relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize> = .case(.large)
   ) {
     self.init()

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Human+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Human+Mock.graphql.swift
@@ -10,7 +10,7 @@ public final class Human: MockObject {
   public typealias MockValueCollectionType = Array<Mock<Human>>
 
   public struct MockFields: Sendable {
-    @Field<Int32>("bodyTemperature") public var bodyTemperature
+    @Field<Int>("bodyTemperature") public var bodyTemperature
     @Field<String>("firstName") public var firstName
     @Field<Height>("height") public var height
     @Field<AnimalKingdomAPI.ID>("id") public var id
@@ -23,7 +23,7 @@ public final class Human: MockObject {
 
 public extension Mock where O == Human {
   convenience init(
-    bodyTemperature: Int32 = 0,
+    bodyTemperature: Int = 0,
     firstName: String = "",
     height: Mock<Height> = Mock<Height>(),
     id: AnimalKingdomAPI.ID = "",

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
@@ -54,17 +54,17 @@ public struct CreateAwesomeReviewMutation: GraphQLMutation {
       public static var __parentType: any ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
-        .field("stars", Int32.self),
+        .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }
 
       /// The number of stars this review gave, 1-5
-      public var stars: Int32 { __data["stars"] }
+      public var stars: Int { __data["stars"] }
       /// Comment about the movie
       public var commentary: String? { __data["commentary"] }
 
       public init(
-        stars: Int32,
+        stars: Int,
         commentary: String? = nil
       ) {
         self.init(_dataDict: DataDict(

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -65,17 +65,17 @@ public struct CreateReviewForEpisodeMutation: GraphQLMutation {
       public static var __parentType: any ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
-        .field("stars", Int32.self),
+        .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }
 
       /// The number of stars this review gave, 1-5
-      public var stars: Int32 { __data["stars"] }
+      public var stars: Int { __data["stars"] }
       /// Comment about the movie
       public var commentary: String? { __data["commentary"] }
 
       public init(
-        stars: Int32,
+        stars: Int,
         commentary: String? = nil
       ) {
         self.init(_dataDict: DataDict(

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
@@ -54,17 +54,17 @@ public struct CreateReviewWithNullFieldMutation: GraphQLMutation {
       public static var __parentType: any ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
-        .field("stars", Int32.self),
+        .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }
 
       /// The number of stars this review gave, 1-5
-      public var stars: Int32 { __data["stars"] }
+      public var stars: Int { __data["stars"] }
       /// Comment about the movie
       public var commentary: String? { __data["commentary"] }
 
       public init(
-        stars: Int32,
+        stars: Int,
         commentary: String? = nil
       ) {
         self.init(_dataDict: DataDict(

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -55,20 +55,20 @@ public struct ReviewAddedSubscription: GraphQLSubscription {
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
         .field("episode", GraphQLEnum<StarWarsAPI.Episode>?.self),
-        .field("stars", Int32.self),
+        .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }
 
       /// The movie
       public var episode: GraphQLEnum<StarWarsAPI.Episode>? { __data["episode"] }
       /// The number of stars this review gave, 1-5
-      public var stars: Int32 { __data["stars"] }
+      public var stars: Int { __data["stars"] }
       /// Comment about the movie
       public var commentary: String? { __data["commentary"] }
 
       public init(
         episode: GraphQLEnum<StarWarsAPI.Episode>? = nil,
-        stars: Int32,
+        stars: Int,
         commentary: String? = nil
       ) {
         self.init(_dataDict: DataDict(

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
@@ -18,9 +18,9 @@ public struct IncrementingSubscription: GraphQLSubscription {
 
     public static var __parentType: any ApolloAPI.ParentType { SubscriptionAPI.Objects.Subscription }
     public static var __selections: [ApolloAPI.Selection] { [
-      .field("numberIncremented", Int32?.self),
+      .field("numberIncremented", Int?.self),
     ] }
 
-    public var numberIncremented: Int32? { __data["numberIncremented"] }
+    public var numberIncremented: Int? { __data["numberIncremented"] }
   }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -434,7 +434,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let expected = """
       public static var __parentType: any ApolloAPI.ParentType { TestSchema.Objects.Nested }
 
-      public var a: Int32 { __data["a"] }
+      public var a: Int { __data["a"] }
     """
 
     // when
@@ -571,8 +571,8 @@ class SelectionSetTemplateTests: XCTestCase {
         .field("__typename", String.self),
         .field("string", String.self),
         .field("string_optional", String?.self),
-        .field("int", Int32.self),
-        .field("int_optional", Int32?.self),
+        .field("int", Int.self),
+        .field("int_optional", Int?.self),
         .field("float", Double.self),
         .field("float_optional", Double?.self),
         .field("boolean", Bool.self),
@@ -4774,8 +4774,8 @@ class SelectionSetTemplateTests: XCTestCase {
     let expected = """
       public var string: String { __data["string"] }
       public var string_optional: String? { __data["string_optional"] }
-      public var int: Int32 { __data["int"] }
-      public var int_optional: Int32? { __data["int_optional"] }
+      public var int: Int { __data["int"] }
+      public var int_optional: Int? { __data["int_optional"] }
       public var float: Double { __data["float"] }
       public var float_optional: Double? { __data["float_optional"] }
       public var boolean: Bool { __data["boolean"] }
@@ -10762,7 +10762,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expectedTypeAlias = """
       public var comments: [Comment]? { __data["comments"] }
-      public var total: Int32 { __data["total"] }
+      public var total: Int { __data["total"] }
 
       public typealias Comment = PostsInfoById.Awarding.Comment
     """
@@ -10874,7 +10874,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     public var name: String { __data["name"] }
     public var comments: [Comment]? { __data["comments"] }
-    public var total: Int32 { __data["total"] }
+    public var total: Int { __data["total"] }
 
     public typealias Comment = PostsInfoById.Awarding.Comment
   """

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_FieldMerging_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_FieldMerging_Tests.swift
@@ -164,7 +164,7 @@ class SelectionSetTemplate_FieldMerging_Tests: XCTestCase {
     let expected = """
 
       public var petName: String { __data["petName"] }
-      public var bodyTemperature: Int32 { __data["bodyTemperature"] }
+      public var bodyTemperature: Int { __data["bodyTemperature"] }
     }
     """
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -630,8 +630,8 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
         public init(
           string: String,
           string_optional: String? = nil,
-          int: Int32,
-          int_optional: Int32? = nil,
+          int: Int,
+          int_optional: Int? = nil,
           float: Double,
           float_optional: Double? = nil,
           boolean: Bool,
@@ -1211,7 +1211,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
       public init(
         __typename: String,
         species: String,
-        age: Int32
+        age: Int
       ) {
         self.init(_dataDict: DataDict(
           data: [
@@ -1288,8 +1288,8 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let expected =
     """
       public init(
-        inches: Int32? = nil,
-        feet: Int32? = nil
+        inches: Int? = nil,
+        feet: Int? = nil
       ) {
         self.init(_dataDict: DataDict(
           data: [

--- a/Tests/ApolloCodegenTests/Extensions/GraphQLNamedType+SwiftTests.swift
+++ b/Tests/ApolloCodegenTests/Extensions/GraphQLNamedType+SwiftTests.swift
@@ -4,28 +4,39 @@ import Nimble
 import ApolloCodegenInternalTestHelpers
 import GraphQLCompiler
 
-class GraphQLNamedType_SwiftTests: XCTestCase {
-  func test_swiftName_givenGraphQLScalar_boolean_providesCompatibleSwiftName() {
-    let graphqlNamedType = GraphQLType.scalar(.boolean())
+class GraphQLNamedType_RenderContext_Tests: XCTestCase {
+  func test_renderAs_typeName_givenGraphQLScalar_boolean_providesCompatibleSwiftName() {
+    let graphqlNamedType = GraphQLType.scalar(.boolean()).namedType
 
-    expect(graphqlNamedType.namedType.name.swiftName).to(equal("Bool"))
+    let rendered = graphqlNamedType.render(as: .typename())
+    expect(rendered).to(equal("Bool"))
   }
 
-  func test_swiftName_givenGraphQLScalar_int_providesCompatibleSwiftName() {
-    let graphqlNamedType = GraphQLType.scalar(.integer())
+  func test_renderAs_typeName_givenGraphQLScalar_float_providesCompatibleSwiftName() {
+    let graphqlNamedType = GraphQLType.scalar(.float()).namedType
 
-    expect(graphqlNamedType.namedType.name.swiftName).to(equal("Int32"))
+    let rendered = graphqlNamedType.render(as: .typename())
+    expect(rendered).to(equal("Double"))
   }
 
-  func test_swiftName_givenGraphQLScalar_float_providesCompatibleSwiftName() {
-    let graphqlNamedType = GraphQLType.scalar(.float())
+  func test_renderAs_typeName_givenGraphQLScalar_string_providesCompatibleSwiftName() {
+    let graphqlNamedType = GraphQLType.scalar(.string()).namedType
 
-    expect(graphqlNamedType.namedType.name.swiftName).to(equal("Double"))
+    let rendered = graphqlNamedType.render(as: .typename())
+    expect(rendered).to(equal("String"))
   }
 
-  func test_swiftName_givenGraphQLScalar_string_providesCompatibleSwiftName() {
-    let graphqlNamedType = GraphQLType.scalar(.string())
+  func test_renderAs_typeName_givenGraphQLScalar_int_providesCompatibleSwiftName() {
+    let graphqlNamedType = GraphQLType.scalar(.integer()).namedType
 
-    expect(graphqlNamedType.namedType.name.swiftName).to(equal("String"))
+    let rendered = graphqlNamedType.render(as: .typename())
+    expect(rendered).to(equal("Int"))
+  }
+
+  func test_renderAs_typeName_inInputValue_givenGraphQLScalar_int_providesCompatibleSwiftName() {
+    let graphqlNamedType = GraphQLType.scalar(.integer()).namedType
+
+    let rendered = graphqlNamedType.render(as: .typename(isInputValue: true))
+    expect(rendered).to(equal("Int32"))
   }
 }

--- a/Tests/ApolloPaginationTests/Mocks.swift
+++ b/Tests/ApolloPaginationTests/Mocks.swift
@@ -31,7 +31,7 @@ enum Mocks {
         class FriendsConnection: MockSelectionSet, @unchecked Sendable {
           override class var __selections: [Selection] {[
             .field("__typename", String.self),
-            .field("totalCount", Int32.self),
+            .field("totalCount", Int.self),
             .field("friends", [Character].self),
             .field("pageInfo", PageInfo.self),
           ]}
@@ -93,7 +93,7 @@ enum Mocks {
         class FriendsConnection: MockSelectionSet, @unchecked Sendable {
           override class var __selections: [Selection] {[
             .field("__typename", String.self),
-            .field("totalCount", Int32.self),
+            .field("totalCount", Int.self),
             .field("friends", [Character].self),
             .field("pageInfo", PageInfo.self),
           ]}
@@ -151,7 +151,7 @@ enum Mocks {
         class FriendsConnection: MockSelectionSet, @unchecked Sendable {
           override class var __selections: [Selection] {[
             .field("__typename", String.self),
-            .field("totalCount", Int32.self),
+            .field("totalCount", Int.self),
             .field("friends", [Character].self),
             .field("pageInfo", PageInfo.self),
           ]}

--- a/Tests/ApolloTests/ApolloClientOperationTests.swift
+++ b/Tests/ApolloTests/ApolloClientOperationTests.swift
@@ -52,7 +52,7 @@ final class ApolloClientOperationTests: XCTestCase {
       override class var __selections: [Selection] {
         [
           .field("__typename", String.self),
-          .field("stars", Int32.self),
+          .field("stars", Int.self),
           .field("commentary", String?.self),
         ]
       }

--- a/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptor_MultipartResponseSubscriptionParser_Tests.swift
+++ b/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptor_MultipartResponseSubscriptionParser_Tests.swift
@@ -292,11 +292,11 @@ final class JSONResponseParsingInterceptor_MultipartResponseSubscriptionParser_T
     override class var __selections: [Selection] {
       [
         .field("__typename", String.self),
-        .field("ticker", Int32.self),
+        .field("ticker", Int.self),
       ]
     }
 
-    var ticker: Int32 { __data["ticker"] }
+    var ticker: Int { __data["ticker"] }
   }
 
   func test__parsing__givenHeartbeat_shouldIgnore() async throws {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ConfigurationValidation.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ConfigurationValidation.swift
@@ -68,7 +68,7 @@ extension ApolloCodegen.ConfigurationContext {
   func validate(_ compilationResult: CompilationResult) throws {
     guard
       !compilationResult.referencedTypes.contains(where: { namedType in
-        namedType.name.swiftName == self.schemaNamespace.firstUppercased
+        namedType.name.schemaName == self.schemaNamespace.firstUppercased
       }),
       !compilationResult.fragments.contains(where: { fragmentDefinition in
         fragmentDefinition.name == self.schemaNamespace.firstUppercased

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/DefaultMockValueProviding.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/DefaultMockValueProviding.swift
@@ -54,7 +54,7 @@ extension GraphQLEnumType: DefaultMockValueProviding {
 
 extension GraphQLObjectType: DefaultMockValueProviding {
   func defaultMockValue(config: ApolloCodegen.ConfigurationContext) -> String {
-    return "Mock<\(self.render(as: .typename))>()"
+    return "Mock<\(self.render(as: .typename()))>()"
   }
 }
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/CustomScalarTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/CustomScalarTemplate.swift
@@ -28,7 +28,7 @@ struct CustomScalarTemplate: TemplateRenderer {
     \(documentation: documentationTemplate, config: config)
     \(graphqlScalar.name.typeNameDocumentation)
     \(accessControlModifier(for: .parent))\
-    typealias \(graphqlScalar.render(as: .typename)) = String
+    typealias \(graphqlScalar.render(as: .typename())) = String
     
     """
     )

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -20,7 +20,7 @@ struct EnumTemplate: TemplateRenderer {
     \(documentation: graphqlEnum.documentation, config: config)
     \(graphqlEnum.name.typeNameDocumentation)
     \(accessControlModifier(for: .parent))\
-    enum \(graphqlEnum.render(as: .typename)): String, EnumType {
+    enum \(graphqlEnum.render(as: .typename())): String, EnumType {
       \(graphqlEnum.values.compactMap({
         enumCase(for: $0)
       }), separator: "\n")

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -23,7 +23,7 @@ struct InputObjectTemplate: TemplateRenderer {
     \(documentation: graphqlInputObject.documentation, config: config)
     \(graphqlInputObject.name.typeNameDocumentation)
     \(accessControlModifier(for: .parent))\
-    struct \(graphqlInputObject.render(as: .typename)): InputObject {
+    struct \(graphqlInputObject.render(as: .typename())): InputObject {
       \(memberAccessControl)private(set) var __data: InputDict
     
       \(memberAccessControl)init(_ data: InputDict) {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
@@ -18,7 +18,7 @@ struct InterfaceTemplate: TemplateRenderer {
     """
     \(documentation: graphqlInterface.documentation, config: config)
     \(graphqlInterface.name.typeNameDocumentation)
-    static let \(graphqlInterface.render(as: .typename)) = \(TemplateConstants.ApolloAPITargetName).Interface(
+    static let \(graphqlInterface.render(as: .typename())) = \(TemplateConstants.ApolloAPITargetName).Interface(
       name: "\(graphqlInterface.name.schemaName)",
       keyFields: \(KeyFieldsTemplate()),
       implementingObjects: \(ImplementingObjectsTemplate())
@@ -38,7 +38,7 @@ struct InterfaceTemplate: TemplateRenderer {
     return """
     [\(list: graphqlInterface.implementingObjects.map({ object in
           TemplateString("""
-          "\(object.render(as: .typename))"
+          "\(object.render(as: .typename()))"
           """)
       }))]
     """

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockInterfacesTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockInterfacesTemplate.swift
@@ -17,7 +17,7 @@ struct MockInterfacesTemplate: TemplateRenderer {
     TemplateString("""
     \(accessControlModifier(for: .parent))extension MockObject {
       \(graphqlInterfaces.map {
-      "typealias \($0.render(as: .typename)) = Interface"
+      "typealias \($0.render(as: .typename())) = Interface"
       }, separator: "\n")
     }
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -36,7 +36,7 @@ struct MockObjectTemplate: TemplateRenderer {
   func renderBodyTemplate(
     nonFatalErrorRecorder: ApolloCodegen.NonFatalError.Recorder
   ) -> TemplateString {
-    let objectName = graphqlObject.render(as: .typename)
+    let objectName = graphqlObject.render(as: .typename())
     let fields: [TemplateField] = fields
       .sorted { $0.0 < $1.0 }
       .map {
@@ -138,7 +138,7 @@ struct MockObjectTemplate: TemplateRenderer {
         case is GraphQLInterfaceType, is GraphQLUnionType:
           mockType = "(any AnyMock)"
         default:
-          mockType = "Mock<\(graphQLCompositeType.render(as: .typename))>"
+          mockType = "Mock<\(graphQLCompositeType.render(as: .typename()))>"
         }
         return TemplateString("\(mockType)\(if: !forceNonNull, "?")").description
       case .scalar,

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockUnionsTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/MockUnionsTemplate.swift
@@ -17,7 +17,7 @@ struct MockUnionsTemplate: TemplateRenderer {
     TemplateString("""
     \(accessControlModifier(for: .parent))extension MockObject {
       \(graphqlUnions.map {
-      "typealias \($0.render(as: .typename)) = Union"
+      "typealias \($0.render(as: .typename())) = Union"
       }, separator: "\n")
     }
     

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
@@ -18,7 +18,7 @@ struct ObjectTemplate: TemplateRenderer {
     """
     \(documentation: graphqlObject.documentation, config: config)
     \(graphqlObject.name.typeNameDocumentation)
-    static let \(graphqlObject.render(as: .typename)) = \(TemplateConstants.ApolloAPITargetName).Object(
+    static let \(graphqlObject.render(as: .typename())) = \(TemplateConstants.ApolloAPITargetName).Object(
       typename: "\(graphqlObject.name.schemaName)\",
       implementedInterfaces: \(ImplementedInterfacesTemplate()),
       keyFields: \(KeyFieldsTemplate())
@@ -39,7 +39,7 @@ struct ObjectTemplate: TemplateRenderer {
     [\(list: graphqlObject.interfaces.map({ interface in
           TemplateString("""
           \(if: !config.output.schemaTypes.isInModule, "\(config.schemaNamespace.firstUppercased).")\
-          Interfaces.\(interface.render(as: .typename)).self
+          Interfaces.\(interface.render(as: .typename())).self
           """)
       }))]
     """

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OneOfInputObjectTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OneOfInputObjectTemplate.swift
@@ -20,7 +20,7 @@ struct OneOfInputObjectTemplate: TemplateRenderer {
     \(documentation: graphqlInputObject.documentation, config: config)
     \(graphqlInputObject.name.typeNameDocumentation)
     \(accessControlModifier(for: .parent))\
-    enum \(graphqlInputObject.render(as: .typename)): OneOfInputObject {
+    enum \(graphqlInputObject.render(as: .typename())): OneOfInputObject {
       \(graphqlInputObject.fields.map({ "\(FieldCaseTemplate($1))" }), separator: "\n")
     
       \(memberAccessControl)var __data: InputDict {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -2,7 +2,7 @@ import GraphQLCompiler
 
 extension GraphQLType {
 
-  enum RenderContext {
+  enum RenderContext: Equatable {
     /// Renders the type for use in an operation selection set.
     case selectionSetField(forceNonNull: Bool = false)
     /// Renders the type for use in a test mock object.
@@ -140,7 +140,7 @@ extension GraphQLNamedType {
   func testMockFieldTypeName(
     _ config: ApolloCodegenConfiguration
   ) -> String {
-    let typename = render(as: .typename)
+    let typename = render(as: .typename())
     if SwiftKeywords.TestMockFieldAbstractTypeNamesToNamespace.contains(typename) &&
         self is GraphQLAbstractType {
       return "MockObject.\(typename)"
@@ -159,7 +159,7 @@ extension GraphQLNamedType {
       if case .testMockField = context {
         return newTypeName ?? testMockFieldTypeName(config)
       } else {
-        return newTypeName ?? self.render(as: .typename)
+        return newTypeName ?? self.render(as: .typename(isInputValue: context == .inputValue))
       }
     }()
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
@@ -88,7 +88,7 @@ fileprivate extension GraphQLInputObjectType {
     }
 
     return """
-    \(if: !config.output.operations.isInModule, "\(config.schemaNamespace.firstUppercased).")\(render(as: .typename))(\(list: entries))
+    \(if: !config.output.operations.isInModule, "\(config.schemaNamespace.firstUppercased).")\(render(as: .typename()))(\(list: entries))
     """
   }
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
@@ -56,7 +56,7 @@ struct SchemaMetadataTemplate: TemplateRenderer {
     static func objectType(forTypename typename: String) -> \(TemplateConstants.ApolloAPITargetName).Object? {
       switch typename {
       \(schema.referencedTypes.objects.map {
-        "case \"\($0.name.schemaName)\": return \(schemaNamespace).Objects.\($0.render(as: .typename))"
+        "case \"\($0.name.schemaName)\": return \(schemaNamespace).Objects.\($0.render(as: .typename()))"
       }, separator: "\n")
       default: return nil
       }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -154,7 +154,7 @@ struct SelectionSetTemplate {
           pluralizer: config.pluralizer))
     \(if: config.options.schemaDocumentation == .include, """
       ///
-      /// Parent Type: `\(selectionSet.typeInfo.parentType.render(as: .typename))`
+      /// Parent Type: `\(selectionSet.typeInfo.parentType.render(as: .typename()))`
       """)
     """
   }
@@ -257,7 +257,7 @@ struct SelectionSetTemplate {
   }
 
   private func GeneratedSchemaTypeReference(_ type: GraphQLCompositeType) -> TemplateString {
-    "\(config.schemaNamespace.firstUppercased).\(type.schemaTypesNamespace).\(type.render(as: .typename))"
+    "\(config.schemaNamespace.firstUppercased).\(type.schemaTypesNamespace).\(type.render(as: .typename()))"
   }
 
   // MARK: - Selections
@@ -1182,7 +1182,7 @@ extension IR.ScopeCondition {
     } else {
       return TemplateString(
         """
-        \(ifLet: type, { "As\($0.render(as: .typename))" })\
+        \(ifLet: type, { "As\($0.render(as: .typename()))" })\
         \(ifLet: conditions, { "If\($0.typeNameComponents)"})
         """
       ).description

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
@@ -19,7 +19,7 @@ struct UnionTemplate: TemplateRenderer {
     """
     \(documentation: graphqlUnion.documentation, config: config)
     \(graphqlUnion.name.typeNameDocumentation)
-    static let \(graphqlUnion.render(as: .typename)) = Union(
+    static let \(graphqlUnion.render(as: .typename())) = Union(
       name: "\(graphqlUnion.name.schemaName)",
       possibleTypes: \(PossibleTypesTemplate())
     )
@@ -36,7 +36,7 @@ struct UnionTemplate: TemplateRenderer {
   ) -> TemplateString {
     """
     \(if: !config.output.schemaTypes.isInModule, "\(config.schemaNamespace.firstUppercased).")\
-    Objects.\(type.render(as: .typename)).self
+    Objects.\(type.render(as: .typename())).self
     """
   }
 

--- a/apollo-ios/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/apollo-ios/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -31,6 +31,19 @@ extension String: JSONDecodable, JSONEncodable {
   }
 }
 
+extension Int: JSONDecodable, JSONEncodable {
+  @inlinable public init(_jsonValue value: JSONValue) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Int.self)
+    }
+    self = number.intValue
+  }
+
+  @inlinable public var _jsonValue: JSONValue {
+    return self
+  }
+}
+
 extension Int32: JSONDecodable, JSONEncodable {
   @inlinable public init(_jsonValue value: JSONValue) throws {
     guard let number = value as? NSNumber else {

--- a/apollo-ios/Sources/ApolloAPI/OutputTypeConvertible.swift
+++ b/apollo-ios/Sources/ApolloAPI/OutputTypeConvertible.swift
@@ -5,8 +5,8 @@ public protocol OutputTypeConvertible {
 extension String: OutputTypeConvertible {
   public static let _asOutputType: Selection.Field.OutputType = .nonNull(.scalar(String.self))
 }
-extension Int32: OutputTypeConvertible {
-  public static let _asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Int32.self))
+extension Int: OutputTypeConvertible {
+  public static let _asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Int.self))
 }
 extension Bool: OutputTypeConvertible {
   public static let _asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Bool.self))

--- a/apollo-ios/Sources/ApolloAPI/ScalarTypes.swift
+++ b/apollo-ios/Sources/ApolloAPI/ScalarTypes.swift
@@ -21,6 +21,7 @@ public protocol ScalarType:
   GraphQLOperationVariableValue {}
 
 extension String: ScalarType {}
+extension Int: ScalarType {}
 extension Int32: ScalarType {}
 extension Bool: ScalarType {}
 extension Float: ScalarType {}


### PR DESCRIPTION
In #722 we turned generated `Int` values into `Int32`. After disccusion [here](https://github.com/apollographql/apollo-ios/issues/3411#issuecomment-3189547073) we've decided that `Int32` should only be used for input values that will be sent to the server.

This PR adds an `isInputType` parameter to `GraphQLNamedType.RenderContext` which is used when rendering to determine if we should use `Int` or `Int32`.