### PR TITLE
[v2] Fix nullable list of nullable items in InputObject

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/InputObjects/PetSearchFilters.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/InputObjects/PetSearchFilters.graphql.swift
@@ -11,7 +11,7 @@ public struct PetSearchFilters: InputObject {
   }
 
   public init(
-    species: [String],
+    species: GraphQLNullable<[String?]> = nil,
     size: GraphQLNullable<GraphQLEnum<RelativeSize>> = nil,
     measurements: GraphQLNullable<MeasurementsInput> = nil
   ) {
@@ -22,7 +22,7 @@ public struct PetSearchFilters: InputObject {
     ])
   }
 
-  public var species: [String] {
+  public var species: GraphQLNullable<[String?]> {
     get { __data["species"] }
     set { __data["species"] = newValue }
   }

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
@@ -36,7 +36,7 @@ input MeasurementsInput {
 }
 
 input PetSearchFilters {
-  species: [String!]!
+  species: [String]
   size: RelativeSize
   measurements: MeasurementsInput
 }

--- a/Tests/ApolloTests/GraphQLOperationVariableEncodingTests.swift
+++ b/Tests/ApolloTests/GraphQLOperationVariableEncodingTests.swift
@@ -50,7 +50,12 @@ class GraphQLOperationVariableEncodingTests: XCTestCase {
     let map: GraphQLOperation.Variables = ["appearsIn": [.jedi, .empire] as [Episode]]
     XCTAssertEqual(serializeAndDeserialize(map), ["appearsIn": ["JEDI", "EMPIRE"]])
   }
-  
+
+  func testEncodeListOfOptionalValues() {
+    let map: GraphQLOperation.Variables = ["appearsIn": [.jedi, nil] as [Episode?]]
+    XCTAssertEqual(serializeAndDeserialize(map), ["appearsIn": ["JEDI", NSNull()]])
+  }
+
   func testEncodeOptionalListWithValue() {
     let map: GraphQLOperation.Variables = ["appearsIn": GraphQLNullable<[Episode]>.some([.jedi, .empire])]
     XCTAssertEqual(serializeAndDeserialize(map), ["appearsIn": ["JEDI", "EMPIRE"]])
@@ -60,7 +65,12 @@ class GraphQLOperationVariableEncodingTests: XCTestCase {
     let map: GraphQLOperation.Variables = ["appearsIn": GraphQLNullable<[Episode]>.none]
     XCTAssertEqual(serializeAndDeserialize(map), [:])
   }
-  
+
+  func testEncodeOptionalListOfOptionalValues() {
+    let map: GraphQLOperation.Variables = ["appearsIn": GraphQLNullable<[Episode?]>.some([.jedi, nil])]
+    XCTAssertEqual(serializeAndDeserialize(map), ["appearsIn": ["JEDI", NSNull()]])
+  }
+
   func testEncodeInputObject() {
     let review = ReviewInput(stars: 5, commentary: "This is a great movie!")
     let map: GraphQLOperation.Variables = ["review": review]

--- a/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
@@ -173,11 +173,14 @@ public struct SubscriptionResponseFormat: OperationResponseFormat {}
 public protocol GraphQLOperationVariableValue: Sendable {
   var _jsonEncodableValue: (any JSONEncodable)? { get }
 }
+public protocol GraphQLOperationVariableListElement: Sendable {
+  var _jsonEncodableValue: (any JSONEncodable)? { get }
+}
 
-extension Array: GraphQLOperationVariableValue
-where Element: GraphQLOperationVariableValue & JSONEncodable & Hashable {}
+extension Array: GraphQLOperationVariableValue, GraphQLOperationVariableListElement
+where Element: GraphQLOperationVariableListElement & JSONEncodable & Hashable {}
 
-extension Dictionary: GraphQLOperationVariableValue
+extension Dictionary: GraphQLOperationVariableValue, GraphQLOperationVariableListElement
 where Key == String, Value == any GraphQLOperationVariableValue {
   @inlinable public var _jsonEncodableValue: (any JSONEncodable)? { _jsonEncodableObject }
   @inlinable public var _jsonEncodableObject: JSONEncodableDictionary {
@@ -198,6 +201,15 @@ where Wrapped: GraphQLOperationVariableValue {
 
 extension JSONEncodable where Self: GraphQLOperationVariableValue {
   @inlinable public var _jsonEncodableValue: (any JSONEncodable)? { self }
+}
+
+extension Optional: GraphQLOperationVariableListElement where Wrapped: GraphQLOperationVariableListElement {
+  @inlinable public var _jsonEncodableValue: (any JSONEncodable)? {
+     switch self {
+     case .none: return nil
+     case let .some(value): return value._jsonEncodableValue
+     }
+   }
 }
 
 // MARK: - Deprecations

--- a/apollo-ios/Sources/ApolloAPI/ScalarTypes.swift
+++ b/apollo-ios/Sources/ApolloAPI/ScalarTypes.swift
@@ -18,7 +18,9 @@ public protocol AnyScalarType: Sendable, Hashable, JSONEncodable {}
 public protocol ScalarType:
   AnyScalarType,
   JSONDecodable,
-  GraphQLOperationVariableValue {}
+  GraphQLOperationVariableValue,
+  GraphQLOperationVariableListElement
+{}
 
 extension String: ScalarType {}
 extension Int32: ScalarType {}
@@ -39,7 +41,8 @@ public protocol CustomScalarType:
   AnyScalarType,
   JSONDecodable,
   OutputTypeConvertible,
-  GraphQLOperationVariableValue
+  GraphQLOperationVariableValue,
+  GraphQLOperationVariableListElement
 {}
 
 extension CustomScalarType {

--- a/apollo-ios/Sources/ApolloAPI/SchemaTypes/EnumType.swift
+++ b/apollo-ios/Sources/ApolloAPI/SchemaTypes/EnumType.swift
@@ -11,5 +11,6 @@ public protocol EnumType:
   RawRepresentable,
   CaseIterable,
   JSONEncodable,
-  GraphQLOperationVariableValue
+  GraphQLOperationVariableValue,
+  GraphQLOperationVariableListElement
 where RawValue == String {}


### PR DESCRIPTION
https://github.com/apollographql/apollo-ios/commit/2832c18e485d1b9f6b76f64b919c31a2b0268a9a prevented optional values from being used in inputs. Because all nullable values should use `GraphQLNullable` not `Optional` in inputs. But when you have a list of optional elements, you should still use `Optional`. Inside of the list `Optional.none` is treated as `null`, there is no need for discerning between `.none` and `.null`.

This PR adds a new `GraphQLOperationVariableListElement` protocol to differentiate between values that can be a top-level variable value and those that can only be list elements. It also adjusts the conformances of types to these protocols to represent the desired intent accurately.