### PR TITLE
Enable Swift 6 Language Mode

### DIFF
--- a/apollo-ios-codegen/Package.swift
+++ b/apollo-ios-codegen/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .product(name: "InflectorKit", package: "InflectorKit"),
         .product(name: "OrderedCollections", package: "swift-collections")
       ],
-      swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [.swiftLanguageMode(.v6)]
     ),
     .target(
       name: "GraphQLCompiler",
@@ -44,7 +44,7 @@ let package = Package(
       exclude: [
         "JavaScript"
       ],
-      swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [.swiftLanguageMode(.v6)]
     ),
     .target(
       name: "IR",
@@ -54,17 +54,17 @@ let package = Package(
         "Utilities",
         .product(name: "OrderedCollections", package: "swift-collections")        
       ],
-      swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [.swiftLanguageMode(.v6)]
     ),
     .target(
       name: "TemplateString",
       dependencies: [],
-      swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [.swiftLanguageMode(.v6)]
     ),
     .target(
       name: "Utilities",
       dependencies: [],
-      swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [.swiftLanguageMode(.v6)]
     ),
     .executableTarget(
       name: "apollo-ios-cli",
@@ -74,7 +74,7 @@ let package = Package(
       exclude: [
         "README.md",
       ],
-      swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [.swiftLanguageMode(.v6)]
     ),
     .target(
       name: "CodegenCLI",
@@ -82,7 +82,7 @@ let package = Package(
         "ApolloCodegenLib",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
-      swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [.swiftLanguageMode(.v6)]
     ),
   ],
   swiftLanguageModes: [.v6, .v5]

--- a/apollo-ios-pagination/Package.swift
+++ b/apollo-ios-pagination/Package.swift
@@ -33,8 +33,7 @@ let package = Package(
         .product(name: "OrderedCollections", package: "swift-collections"),
       ],
       swiftSettings: [
-        .enableUpcomingFeature("ExistentialAny"),
-        .enableExperimentalFeature("StrictConcurrency")
+        .swiftLanguageMode(.v6)
       ]
     ),
   ],

--- a/apollo-ios/Package.swift
+++ b/apollo-ios/Package.swift
@@ -31,8 +31,7 @@ let package = Package(
         .copy("Resources/PrivacyInfo.xcprivacy")
       ],
       swiftSettings: [
-        .enableUpcomingFeature("ExistentialAny"),
-        .enableExperimentalFeature("StrictConcurrency")
+        .swiftLanguageMode(.v6)
       ]
     ),
     .target(
@@ -42,8 +41,7 @@ let package = Package(
         .copy("Resources/PrivacyInfo.xcprivacy")
       ],
       swiftSettings: [
-        .enableUpcomingFeature("ExistentialAny"),
-        .enableExperimentalFeature("StrictConcurrency")
+        .swiftLanguageMode(.v6)
       ]
     ),
     .target(
@@ -55,8 +53,7 @@ let package = Package(
         .copy("Resources/PrivacyInfo.xcprivacy")
       ],
       swiftSettings: [
-        .enableUpcomingFeature("ExistentialAny"),
-        .enableExperimentalFeature("StrictConcurrency")
+        .swiftLanguageMode(.v6)
       ]
     ),
     .target(
@@ -68,8 +65,7 @@ let package = Package(
         .copy("Resources/PrivacyInfo.xcprivacy")
       ],
       swiftSettings: [
-        .enableUpcomingFeature("ExistentialAny"),
-        .enableExperimentalFeature("StrictConcurrency")
+        .swiftLanguageMode(.v6)
       ]
     ),
     .target(
@@ -79,8 +75,7 @@ let package = Package(
         "ApolloAPI"
       ],
       swiftSettings: [
-        .enableUpcomingFeature("ExistentialAny"),
-        .enableExperimentalFeature("StrictConcurrency")
+        .swiftLanguageMode(.v6)
       ]
     ),
     .plugin(


### PR DESCRIPTION
Apollo V2 is currently `enableExperimentalFeature` swift settings that are meant for Swift 5.9/5.10. This PR enables Swift 6 Language Mode.

Per [Enabling Complete Concurrency Checking](https://www.swift.org/documentation/concurrency/):

<img width="889" height="565" alt="When using Swift 6.0 tools or later, use [SwiftSetting.enableUpcomingFeature](https://developer.apple.com/documentation/packagedescription/swiftsetting/enableupcomingfeature(_:_:)) in the Swift settings for the given target" src="https://github.com/user-attachments/assets/1d832b52-8b2a-4b5c-826d-d587285d936e" />

We _could_ change `enableExperimentalFeature` to `enableUpcomingFeature`, as suggested by the above. But based on local testing, the targets in the `Package.swift` files in this repo already builds in Swift 6 Language Mode.

Feel free to close this out if it's not what you want just yet – I know I'm jumping the gun going straight to a PR here.