### PR TITLE
fix: Move to `macos-14` for actions image platform

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,7 +40,7 @@ jobs:
               - '.tuist-version'
 
   tuist-generation:
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: [changes]
     if: ${{ needs.changes.outputs.ios == 'true' || needs.changes.outputs.codegen  == 'true' || needs.changes.outputs.pagination  == 'true' || needs.changes.outputs.tuist == 'true' }}
     timeout-minutes: 8
@@ -63,7 +63,7 @@ jobs:
         key: ${{ github.run_id }}-dependencies
 
   run-swift-builds:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -85,7 +85,7 @@ jobs:
         cd ${{ matrix.package }} && swift build
 
   build-and-unit-test:
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: [tuist-generation, changes]
     timeout-minutes: 20
     strategy:
@@ -189,7 +189,7 @@ jobs:
           TestResults/ResultBundle.zip
 
   run-codegen-test-configurations:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 20
     name: Codegen Test Configurations - macOS
     steps:
@@ -204,7 +204,7 @@ jobs:
         ./scripts/run-test-codegen-configurations.sh -t
   
   verify-frontend-bundle-latest:
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: [changes]
     if: ${{ needs.changes.outputs.codegen  == 'true' }}
     timeout-minutes: 5
@@ -222,7 +222,7 @@ jobs:
         git diff --exit-code
 
   verify-cli-binary-archive:
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: [changes]
     if: ${{ needs.changes.outputs.codegen  == 'true' }}
     timeout-minutes: 5
@@ -240,7 +240,7 @@ jobs:
       run: ./cli-version-check.sh
 
   run-cocoapods-integration-tests:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 20
     name: Cocoapods Integration Tests - macOS
     steps:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   tuist-generation:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 8
     name: Run Tuist Generation
     steps:
@@ -31,7 +31,7 @@ jobs:
         key: ${{ github.run_id }}-dependencies
 
   run-swift-builds:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
         cd ${{ matrix.package }} && swift build
 
   build-and-unit-test:
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: tuist-generation
     timeout-minutes: 20
     strategy:
@@ -153,7 +153,7 @@ jobs:
           TestResults/ResultBundle.zip
 
   run-codegen-test-configurations:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 20
     name: Codegen Test Configurations - macOS
     steps:
@@ -168,7 +168,7 @@ jobs:
         ./scripts/run-test-codegen-configurations.sh -t
 
   run-cocoapods-integration-tests:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 20
     name: Cocoapods Integration Tests - macOS
     steps:
@@ -188,7 +188,7 @@ jobs:
       uses: ./.github/actions/run-cocoapods-integration-tests
   
   send-slack-status-notification:
-    runs-on: macos-latest
+    runs-on: macos-14
     if: ${{ always() }}
     timeout-minutes: 5
     needs: [tuist-generation, run-swift-builds, build-and-unit-test, run-codegen-test-configurations, run-cocoapods-integration-tests]


### PR DESCRIPTION
Nightly health builds are [failing](https://github.com/apollographql/apollo-ios-dev/actions/workflows/release-check.yml) because `macos-15` no longer has Xcode 15 installed so we need to move back to `macos-14` for this branch. When 2.0 is merged into `main` we'll get back on the `macos-15` image platform.