### PR TITLE
[v2] Input List Fixes

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -11,14 +11,15 @@ public struct PetSearchLocalCacheMutation: LocalCacheMutation {
 
   public init(filters: GraphQLNullable<PetSearchFilters> = .init(
     PetSearchFilters(
-      species: ["Dog", "Cat"],
+      species: [
+        "Dog",
+        "Cat"
+      ],
       size: .init(.small),
-      measurements: .init(
-        MeasurementsInput(
-          height: 10.5,
-          weight: 5.0
-        )
-      )
+      measurements: [MeasurementsInput(
+        height: 10.5,
+        weight: 5.0
+      )]
     )
   )) {
     self.filters = filters

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -8,21 +8,28 @@ public struct PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"query PetSearch($filters: PetSearchFilters = { species: ["Dog", "Cat"] size: SMALL measurements: { height: 10.5, weight: 5.0 } }) { pets(filters: $filters) { __typename id humanName } }"#
+      #"query PetSearch($filters: PetSearchFilters = { species: ["Dog", "Cat"] size: SMALL measurements: [{ height: 10.5, weight: 5.0 }, { height: 10.5, weight: 5.0 }] }) { pets(filters: $filters) { __typename id humanName } }"#
     ))
 
   public var filters: GraphQLNullable<PetSearchFilters>
 
   public init(filters: GraphQLNullable<PetSearchFilters> = .init(
     PetSearchFilters(
-      species: ["Dog", "Cat"],
+      species: [
+        "Dog",
+        "Cat"
+      ],
       size: .init(.small),
-      measurements: .init(
+      measurements: [
+        MeasurementsInput(
+          height: 10.5,
+          weight: 5.0
+        ),
         MeasurementsInput(
           height: 10.5,
           weight: 5.0
         )
-      )
+      ]
     )
   )) {
     self.filters = filters

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/CustomScalars/Object.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/CustomScalars/Object.swift
@@ -5,6 +5,17 @@
 // Any changes to this file will not be overwritten by future
 // code generation execution.
 
-import ApolloAPI
+@_spi(Internal) @_spi(Execution) import ApolloAPI
 
-public typealias Object = String
+public struct Object: CustomScalarType {
+  let value: String
+
+  public init(_jsonValue value: ApolloAPI.JSONValue) throws {
+    self.value = value as? String ?? ""
+  }
+
+  public var _jsonValue: ApolloAPI.JSONValue {
+    return value
+  }
+
+}

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/InputObjects/PetSearchFilters.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/InputObjects/PetSearchFilters.graphql.swift
@@ -13,7 +13,7 @@ public struct PetSearchFilters: InputObject {
   public init(
     species: GraphQLNullable<[String?]> = nil,
     size: GraphQLNullable<GraphQLEnum<RelativeSize>> = nil,
-    measurements: GraphQLNullable<MeasurementsInput> = nil
+    measurements: GraphQLNullable<[MeasurementsInput?]> = nil
   ) {
     __data = InputDict([
       "species": species,
@@ -32,7 +32,7 @@ public struct PetSearchFilters: InputObject {
     set { __data["size"] = newValue }
   }
 
-  public var measurements: GraphQLNullable<MeasurementsInput> {
+  public var measurements: GraphQLNullable<[MeasurementsInput?]> {
     get { __data["measurements"] }
     set { __data["measurements"] = newValue }
   }

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
@@ -38,7 +38,7 @@ input MeasurementsInput {
 input PetSearchFilters {
   species: [String]
   size: RelativeSize
-  measurements: MeasurementsInput
+  measurements: [MeasurementsInput]
 }
 
 interface Animal @typePolicy(keyFields: "id") {

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/PetSearchLocalCacheMutation.graphql
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/PetSearchLocalCacheMutation.graphql
@@ -1,10 +1,11 @@
 query PetSearchLocalCacheMutation($filters: PetSearchFilters = {
   species: ["Dog", "Cat"],
   size: SMALL,
-  measurements: {
+  measurements: [{
     height: 10.5,
     weight: 5.0
     }
+  ]
   }
 ) @apollo_client_ios_localCacheMutation {
   pets(filters: $filters) {

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/PetSearchQuery.graphql
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/PetSearchQuery.graphql
@@ -1,10 +1,17 @@
-query PetSearch($filters: PetSearchFilters = {
-  species: ["Dog", "Cat"],
-  size: SMALL,
-  measurements: {
-    height: 10.5,
-    weight: 5.0
-    }
+query PetSearch(
+  $filters: PetSearchFilters = {
+    species: ["Dog", "Cat"],
+    size: SMALL,
+    measurements: [
+      {
+        height: 10.5,
+        weight: 5.0
+      },
+      {
+        height: 10.5,
+        weight: 5.0
+      }
+    ]
   }
 ) {
   pets(filters: $filters) {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/CustomScalarTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/CustomScalarTemplateTests.swift
@@ -45,6 +45,21 @@ class CustomScalarTemplateTests: XCTestCase {
     subject.renderBodyTemplate(nonFatalErrorRecorder: .init()).description
   }
 
+  func test__render__shouldGenerateImportStatement() throws {
+    // given
+    buildSubject(name: "aCustomScalar")
+
+    let expected = """
+    @_spi(Internal) @_spi(Execution) import ApolloAPI
+    """
+
+    // when
+    let rendered = subject.render()
+
+    // then
+    expect(rendered.body).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
   // MARK: Casing Tests
 
   func test__render__givenCustomScalar_shouldGenerateTypealiasNameFirstUppercased() throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
@@ -274,7 +274,10 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           defaultValue: .list([.string("1"), .string("2")])
         ),
         """
-        listField: GraphQLNullable<[String?]> = ["1", "2"]
+        listField: GraphQLNullable<[String?]> = [
+          "1",
+          "2"
+        ]
         """
       ),
       (
@@ -302,11 +305,11 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
       let actual = template.VariableParameter(test.variable).description
 
       // then
-      expect(actual).to(equal(test.expected))
+      expect(actual).to(equalLineByLine(test.expected))
     }
   }
 
-  func test__renderOperationVariableParameter__givenInputFieldType_withDefaultValue__generatesCorrectParametersWithInitializer_withNamespaceWhenRequired() throws {
+  func test__renderOperationVariableParameter__givenInputObjectField_withDefaultValue__generatesCorrectParametersWithInitializer_withNamespaceWhenRequired() throws {
     // given
     let variable: CompilationResult.VariableDefinition = .mock(
       "inputField",
@@ -350,6 +353,105 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
 
       // then
       expect(actual).to(equal(test.expected))
+    }
+  }
+
+  func test__renderOperationVariableParameter__givenListOfInputObjectsField_withSingleDefaultValue__generatesCorrectParametersWithInitializer_withNamespaceWhenRequired() throws {
+    // given
+    let variable: CompilationResult.VariableDefinition = .mock(
+      "inputField",
+      type: .list(
+        .inputObject(.mock(
+          "InnerInputObject",
+          fields: [
+            .mock("innerStringField", type: .scalar(.string()), defaultValue: nil)
+          ]
+        ))
+      ),
+    defaultValue: .list([.object(["innerStringField": .string("Value")])])
+    )
+
+    let expectedWithNamespace = """
+      inputField: GraphQLNullable<[TestSchema.InnerInputObject?]> = [TestSchema.InnerInputObject(innerStringField: "Value")]
+      """
+
+    let expectedNoNamespace = """
+      inputField: GraphQLNullable<[InnerInputObject?]> = [InnerInputObject(innerStringField: "Value")]
+      """
+
+    let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
+      (.mock(moduleType: .swiftPackage(), operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackage(), operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackage(), operations: .inSchemaModule), expectedNoNamespace),
+      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
+    ]
+
+    for test in tests {
+      // when
+      buildTemplate(configOutput: test.config)
+      let actual = template.VariableParameter(variable).description
+
+      // then
+      expect(actual).to(equal(test.expected))
+    }
+  }
+
+  func test__renderOperationVariableParameter__givenListOfInputObjectsField_withMultipleDefaultValue__generatesCorrectParametersWithInitializer_withNamespaceWhenRequired() throws {
+    // given
+    let variable: CompilationResult.VariableDefinition = .mock(
+      "inputField",
+      type: .list(
+        .inputObject(.mock(
+          "InnerInputObject",
+          fields: [
+            .mock("innerStringField", type: .scalar(.string()), defaultValue: nil)
+          ]
+        ))
+      ),
+    defaultValue: .list([
+      .object(["innerStringField": .string("Value 1")]),
+      .object(["innerStringField": .string("Value 2")])
+    ])
+    )
+
+    let expectedWithNamespace = """
+      inputField: GraphQLNullable<[TestSchema.InnerInputObject?]> = [
+        TestSchema.InnerInputObject(innerStringField: "Value 1"),
+        TestSchema.InnerInputObject(innerStringField: "Value 2")
+      ]
+      """
+
+    let expectedNoNamespace = """
+      inputField: GraphQLNullable<[InnerInputObject?]> = [
+        InnerInputObject(innerStringField: "Value 1"),
+        InnerInputObject(innerStringField: "Value 2")
+      ]
+      """
+
+    let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
+      (.mock(moduleType: .swiftPackage(), operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackage(), operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackage(), operations: .inSchemaModule), expectedNoNamespace),
+      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
+    ]
+
+    for test in tests {
+      // when
+      buildTemplate(configOutput: test.config)
+      let actual = template.VariableParameter(variable).description
+
+      // then
+      expect(actual).to(equalLineByLine(test.expected))
     }
   }
 
@@ -401,12 +503,18 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
         innerIntField: 123,
         innerFloatField: 12.3456,
         innerBoolField: true,
-        innerListField: ["A", "B"],
+        innerListField: [
+          "A",
+          "B"
+        ],
         innerEnumField: .init(.caseONE),
         innerInputObject: .init(
           TestSchema.InnerInputObject(
             innerStringField: "EFGH",
-            innerListField: [.init(.caseTwo), .init(.caseThree)]
+            innerListField: [
+              .init(.caseTwo),
+              .init(.caseThree)
+            ]
           )
         )
       )
@@ -468,11 +576,17 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
       innerIntField: 123,
       innerFloatField: 12.3456,
       innerBoolField: true,
-      innerListField: ["A", "B"],
+      innerListField: [
+        "A",
+        "B"
+      ],
       innerEnumField: .init(.caseONE),
       innerInputObject: TestSchema.InnerInputObject(
         innerStringField: "EFGH",
-        innerListField: [.init(.caseTwo), .init(.caseThree)]
+        innerListField: [
+          .init(.caseTwo),
+          .init(.caseThree)
+        ]
       )
     )
     """
@@ -610,7 +724,12 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
                     type: .list(.scalar(.string())),
                     defaultValue: .list([.string("val"), .null]))
 
-    let expected = "nullableListNullableItemWithDefault: GraphQLNullable<[String?]> = [\"val\", nil]"
+    let expected = """
+    nullableListNullableItemWithDefault: GraphQLNullable<[String?]> = [
+      \"val\",
+      nil
+    ]
+    """
 
     // when
     buildTemplate()

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
@@ -41,9 +41,9 @@ extension InputVariableRenderable {
       case let .nonNull(.list(listInnerType)),
         let .list(listInnerType):
         return """
-        [\(list.compactMap {
+        [\(list: list.compactMap {
           InputVariable(type: listInnerType, defaultValue: $0).renderVariableDefaultValue(inList: true, config: config)
-        }, separator: ", ")]
+        })]
         """
 
       default:
@@ -56,11 +56,15 @@ extension InputVariableRenderable {
         return inputObjectType.renderInitializer(values: object, config: config)
 
       case let .inputObject(inputObjectType):
-        return """
-        .init(
-          \(inputObjectType.renderInitializer(values: object, config: config))
-        )
-        """
+        if inList {
+          return inputObjectType.renderInitializer(values: object, config: config)
+        } else {
+          return """
+            .init(
+              \(inputObjectType.renderInitializer(values: object, config: config))
+            )
+            """
+        }
 
       default:
         preconditionFailure("Variable type must be InputObject with value of .object type.")

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -337,6 +337,8 @@ struct ImportStatementTemplate {
       switch type {
       case .inputObject:
         return "@_spi(Internal) @_spi(Unsafe) \(apolloAPIImport)"
+      case .customScalar:
+        return "@_spi(Internal) @_spi(Execution) \(apolloAPIImport)"
       case .enum:
         return "@_spi(Internal) \(apolloAPIImport)"
       default:

--- a/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/apollo-ios/Sources/ApolloAPI/GraphQLOperation.swift
@@ -215,6 +215,7 @@ extension JSONEncodable where Self: GraphQLOperationVariableValue {
 }
 
 extension Optional: GraphQLOperationVariableListElement where Wrapped: GraphQLOperationVariableListElement {
+  @_spi(Internal)
   @inlinable public var _jsonEncodableValue: (any JSONEncodable)? {
      switch self {
      case .none: return nil

--- a/apollo-ios/Sources/ApolloAPI/SchemaTypes/InputObject.swift
+++ b/apollo-ios/Sources/ApolloAPI/SchemaTypes/InputObject.swift
@@ -2,7 +2,7 @@
 ///
 /// # See Also
 /// [GraphQLSpec - Input Objects](https://spec.graphql.org/draft/#sec-Input-Objects)
-public protocol InputObject: GraphQLOperationVariableValue, JSONEncodable, Hashable {
+public protocol InputObject: GraphQLOperationVariableValue, GraphQLOperationVariableListElement, JSONEncodable, Hashable {
   @_spi(Unsafe)
   var __data: InputDict { get }
 }


### PR DESCRIPTION
* Improved code generation for input object lists, ensuring that default values for lists are rendered in a multi-line, readable format, and that initializers for input object lists are correctly generated.
* Changed the import statement for custom scalars to use `@_spi(Internal) @_spi(Execution) import ApolloAPI`.
* Updated the `InputObject` protocol to conform to `GraphQLOperationVariableListElement`, allowing input objects to be used as elements in variable lists.
* Added `@_spi(Internal)` to the `_jsonEncodableValue` property of optional list elements, improving SPI usage for internal encoding.