### PR TITLE
fix: CLI installation

### DIFF
--- a/apollo-ios/Plugins/InstallCLI/InstallCLIPluginCommand.swift
+++ b/apollo-ios/Plugins/InstallCLI/InstallCLIPluginCommand.swift
@@ -40,7 +40,7 @@ extension InstallCLIPluginCommand: XcodeCommandPlugin {
     process.executableURL = URL(fileURLWithPath: toolURL.absoluteString)
 
     let downloadScriptPath = try downloadScriptPath(context: context)
-    process.arguments = [downloadScriptPath, context.xcodeProject.directoryURL.absoluteString]
+    process.arguments = [downloadScriptPath, context.xcodeProject.directoryURL.standardized.relativePath]
 
     try process.run()
     process.waitUntilExit()
@@ -61,7 +61,7 @@ extension InstallCLIPluginCommand: XcodeCommandPlugin {
       absoluteScriptPath = context.pluginWorkDirectoryURL.appending(path: "../../../../\(relativeScriptPath)")
     }
 
-    return absoluteScriptPath
+    return absoluteScriptPath.standardized.relativePath
   }
 
   /// Used to get a string representation of Xcode in the current toolchain.

--- a/apollo-ios/Plugins/InstallCLI/InstallCLIPluginCommand.swift
+++ b/apollo-ios/Plugins/InstallCLI/InstallCLIPluginCommand.swift
@@ -53,12 +53,12 @@ extension InstallCLIPluginCommand: XcodeCommandPlugin {
   private func downloadScriptPath(context: XcodePluginContext) throws -> String {
     let xcodeVersion = try xcodeVersion(context: context)
     let relativeScriptPath = "SourcePackages/checkouts/apollo-ios/scripts/download-cli.sh"
-    let absoluteScriptPath: String
+    let absoluteScriptPath: URL
 
     if xcodeVersion.lexicographicallyPrecedes("16.3") {
-      absoluteScriptPath = "\(context.pluginWorkDirectoryURL.absoluteString)/../../../\(relativeScriptPath)"
+      absoluteScriptPath = context.pluginWorkDirectoryURL.appending(path: "../../../\(relativeScriptPath)")
     } else {
-      absoluteScriptPath = "\(context.pluginWorkDirectoryURL.absoluteString)/../../../../\(relativeScriptPath)"
+      absoluteScriptPath = context.pluginWorkDirectoryURL.appending(path: "../../../../\(relativeScriptPath)")
     }
 
     return absoluteScriptPath


### PR DESCRIPTION
* Switches to using the `appending(path:)` function provided by `URL`; safer than manually building the path.
* Removes any URL percent-encoded characters with `standardized`.
* Avoids the `file://` scheme being output by using `relativePath`.