### PR TITLE
Add RootSelectionSet convenience initializer from inline fragment

### DIFF
--- a/apollo-ios/Sources/ApolloAPI/SelectionSet.swift
+++ b/apollo-ios/Sources/ApolloAPI/SelectionSet.swift
@@ -128,8 +128,16 @@ extension SelectionSet where Fragments: FragmentContainer {
   public var fragments: Fragments { Fragments(_dataDict: __data) }
 }
 
+// MARK: - Root Entity Type Conversion Helpers
+
 extension InlineFragment {
   @inlinable public var asRootEntityType: RootEntityType {
     RootEntityType.init(_dataDict: __data)
+  }
+}
+
+extension RootSelectionSet {
+  public init<T: InlineFragment>(_ inlineFragment: T) where T.RootEntityType == Self {
+    self = inlineFragment.asRootEntityType
   }
 }


### PR DESCRIPTION
[Discussion on the reasoning for this PR is here.](https://community.apollographql.com/t/initializing-selection-set-manually-without-using-datadict-initializer/9395/8) 

Added a convenience initializer to `RootSelectionSet` that allows it to be initialized directly from an `InlineFragment`, simplifying the conversion process between fragments and root entity types.