### PR TITLE
Make dependentKeys in GraphQLResult public.

### DIFF
--- a/apollo-ios/Sources/Apollo/GraphQLResult.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLResult.swift
@@ -20,7 +20,7 @@ public struct GraphQLResult<Data: RootSelectionSet> {
   /// Source of data
   public let source: Source
 
-  let dependentKeys: Set<CacheKey>?
+  public let dependentKeys: Set<CacheKey>?
 
   public init(
     data: Data?,


### PR DESCRIPTION
## Summary
Making `dependentKeys` public allows for implementing custom `ApolloStoreSubscribers` similar to `GraphQLQueryWatcher`. Without this it's extremely to know when to react to cache changes for a query.