### PR TITLE
Add subscription support to request chain network transport

### DIFF
--- a/Tests/ApolloTests/RequestChainNetworkTransportTests.swift
+++ b/Tests/ApolloTests/RequestChainNetworkTransportTests.swift
@@ -13,6 +13,7 @@ import XCTest
   - Cache reads and writes based on cache policy (and if source is cache)
   - cache only request gets sent through interceptors still
   - cache read after failed network fetch
+  - Tests for subscriptions over HTTP
   """
 )
 class RequestChainNetworkTransportTests: XCTestCase, MockResponseProvider {

--- a/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/apollo-ios/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -1,5 +1,5 @@
-import Foundation
 import ApolloAPI
+import Foundation
 
 /// An implementation of `NetworkTransport` which creates a `RequestChain` object
 /// for each item sent through it.
@@ -142,6 +142,25 @@ public final class RequestChainNetworkTransport: NetworkTransport, Sendable {
     )
   }
 
+}
+
+extension RequestChainNetworkTransport: SubscriptionNetworkTransport {
+
+  public func send<Subscription>(
+    subscription: Subscription,
+    fetchBehavior: FetchBehavior,
+    requestConfiguration: RequestConfiguration
+  ) throws -> AsyncThrowingStream<GraphQLResponse<Subscription>, any Error> where Subscription: GraphQLSubscription {
+    let request = self.constructRequest(
+      for: subscription,
+      fetchBehavior: fetchBehavior,
+      requestConfiguration: requestConfiguration
+    )
+
+    let chain = makeChain(for: request)
+    
+    return chain.kickoff(request: request)
+  }
 }
 
 extension RequestChainNetworkTransport: UploadingNetworkTransport {

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -5,8 +5,8 @@ import ApolloAPI
 public final class WebSocketTransport: SubscriptionNetworkTransport {
 
   public enum Error: Swift.Error {
-    /// WebSocketTransport has not yet been implemented for Apollo iOS 2.0. This will be implemented prior to
-    /// Beta release.
+    /// WebSocketTransport has not yet been implemented for Apollo iOS 2.0. This will be implemented in a future
+    /// release.
     case notImplemented
   }
 


### PR DESCRIPTION
I forgot to make `RequestChainNetworkTransport` conform to `SubscriptionNetworkTransport` protocol. All of the underlying mechanisms to support this already exist.

We will need to add more tests for this functionality in the near future, but just need this enabled for the 2.0 release.