### PR TITLE
Fix: Xcode version for nightly health check

### DIFF
--- a/.github/workflows/nightly-health-check.yml
+++ b/.github/workflows/nightly-health-check.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 7 * * *"
 
 env:
-  XCODE_VERSION: "15.4"
+  XCODE_VERSION: "16.4"
 
 jobs:
   tuist-generation:

--- a/.github/workflows/nightly-health-check.yml
+++ b/.github/workflows/nightly-health-check.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         include:
           # macOS_current
-          - destination: platform=macOS,arch=x86_64
+          - destination: platform=macOS,arch=arm64
             scheme: ApolloTests
             test-plan: Apollo-CITestPlan
             name: Apollo Unit Tests - macOS
@@ -79,19 +79,19 @@ jobs:
             name: Apollo Unit Tests - tvOS ${{ vars.TVOS_VERSION }}
             run-js-tests: false
           # Codegen CLI Test
-          - destination: platform=macOS,arch=x86_64
+          - destination: platform=macOS,arch=arm64
             scheme: CodegenCLITests
             test-plan: CodegenCLITestPlan
             name: Codegen CLI Unit Tests - macOS
             run-js-tests: false
           # CodegenLib Test
-          - destination: platform=macOS,arch=x86_64
+          - destination: platform=macOS,arch=arm64
             scheme: ApolloCodegenTests
             test-plan: Apollo-Codegen-CITestPlan
             name: Codegen Lib Unit Tests - macOS
             run-js-tests: true
           # ApolloPagination Tests
-          - destination: platform=macOS,arch=x86_64
+          - destination: platform=macOS,arch=arm64
             scheme: ApolloPaginationTests
             test-plan: Apollo-PaginationTestPlan
             name: ApolloPagination Unit Tests - macOS


### PR DESCRIPTION
* Changed the Xcode version used for the nightly health check; `16.4`
* Updated test architecture to match CI test; `arm64`.
* Renamed the action file to reflect it's purpose.