### PR TITLE
Fix _asInlineFragment returning nil for types omitted by reduceGeneratedSchemaTypes

### DIFF
--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -752,6 +752,60 @@ class SelectionSetTests: XCTestCase {
   }
 
   @MainActor
+  func test__asInlineFragment_givenInterfaceType_typeNotInSchemaMetadata_butListedInImplementingObjects_returnsType() async {
+    // given
+    // This simulates `reduceGeneratedSchemaTypes: true` where "CloudinaryImage" implements
+    // the interface but has no generated Object type in SchemaMetadata.
+    struct Types {
+      static let ImageInterface = Interface(
+        name: "UrlTemplateBackedImage_Interface",
+        implementingObjects: ["CloudinaryImage"]
+      )
+    }
+
+    MockSchemaMetadata.stub_objectTypeForTypeName({ _ in
+      // All types return nil — simulating reduceGeneratedSchemaTypes filtering them out
+      return nil
+    })
+
+    class Image: MockSelectionSet, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {[
+        .field("__typename", String.self),
+        .field("url", String.self),
+        .inlineFragment(AsUrlTemplateBackedImage.self),
+      ]}
+
+      var asUrlTemplateBackedImage: AsUrlTemplateBackedImage? { _asInlineFragment() }
+
+      class AsUrlTemplateBackedImage: MockTypeCase, @unchecked Sendable {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: any ParentType { Types.ImageInterface }
+        override class var __selections: [Selection] {[
+          .field("urlTemplate", String.self)
+        ]}
+      }
+    }
+
+    let object: JSONObject = [
+      "__typename": "CloudinaryImage",
+      "url": "https://example.com/image.jpg",
+      "urlTemplate": "https://example.com/{width}/{height}/image.jpg"
+    ]
+
+    // when
+    let actual = try! await Image(data: object)
+
+    // then
+    expect(actual.asUrlTemplateBackedImage).toNot(beNil())
+    expect(actual.asUrlTemplateBackedImage?.urlTemplate).to(equal(
+      "https://example.com/{width}/{height}/image.jpg"
+    ))
+  }
+
+  @MainActor
   func test__asInlineFragment_givenUnionType_typeNameIsTypeInUnionPossibleTypes_returnsType() async {
     // given
     enum Types {

--- a/apollo-ios/Sources/Apollo/Execution/GraphQLExecutor.swift
+++ b/apollo-ios/Sources/Apollo/Execution/GraphQLExecutor.swift
@@ -51,6 +51,7 @@ public class ObjectExecutionInfo {
       return schema.objectType(forTypename: objectType.typename)
     }
     return schema.objectType(forTypename: __typename)
+      ?? Object(typename: __typename, implementedInterfaces: [])
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes `_asInlineFragment()` silently returning `nil` at runtime when `reduceGeneratedSchemaTypes` is enabled and the concrete type implementing an interface is not registered in `SchemaMetadata`
- Adds a lightweight `Object` fallback in `runtimeObjectType(for:)` (matching the existing pattern in `SchemaMetadata.graphQLType(for:)`) so inline fragment type conditions can resolve via the interface's `implementingObjects` list, which is always fully populated

Fixes https://github.com/apollographql/apollo-ios/issues/3632

## Test plan
- [x] Added `test__asInlineFragment_givenInterfaceType_typeNotInSchemaMetadata_butListedInImplementingObjects_returnsType` to `SelectionSetTests`
- [x] All 52 existing `SelectionSetTests` pass with zero errors
- [x] Apollo library builds cleanly via `swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)