### PR TITLE
fix: Use correct default value when enum has deprecated case - v2

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -27,12 +27,17 @@ class MockObjectTemplateTests: XCTestCase {
     schemaNamespace: String = "TestSchema",
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackage(),
     testMocks: ApolloCodegenConfiguration.TestMockFileOutput = .swiftPackage(),
+    deprecatedEnumCases: ApolloCodegenConfiguration.Composition = .include,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = .exclude
   ) {
     let config = ApolloCodegenConfiguration.mock(
       schemaNamespace: schemaNamespace,
       output: .mock(moduleType: moduleType, testMocks: testMocks),
-      options: .init(warningsOnDeprecatedUsage: warningsOnDeprecatedUsage, markTypesNonisolated: false)
+      options: .init(
+        deprecatedEnumCases: deprecatedEnumCases,
+        warningsOnDeprecatedUsage: warningsOnDeprecatedUsage,
+        markTypesNonisolated: false
+      )
     )
     ir = IRBuilder.mock(compilationResult: .mock())
 
@@ -1053,6 +1058,45 @@ class MockObjectTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  // MARK: - Deprecated Enum Cases in Default Mock Values
+
+  func test__render_convenienceInitializer__givenDeprecatedEnumCases_exclude_firstCaseDeprecated_shouldUseFirstNonDeprecatedCase() throws {
+    // given
+    let enumType = GraphQLEnumType.mock(
+      name: "Priority",
+      values: [
+        .mock(name: "critical", deprecationReason: "No longer supported"),
+        .mock(name: "high"),
+        .mock(name: "low"),
+      ]
+    )
+
+    buildSubject(
+      fields: [
+        "priority": .mock("priority", type: .nonNull(.enum(enumType))),
+      ],
+      moduleType: .swiftPackage(),
+      deprecatedEnumCases: .exclude
+    )
+
+    let expected = """
+    public extension Mock where O == Dog {
+      convenience init(
+        priority: GraphQLEnum<TestSchema.Priority> = .case(.high)
+      ) {
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(
+      expected,
+      atLine: 10 + self.subject.fields.count,
+      ignoringExtraLines: true)
+    )
   }
 
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/DefaultMockValueProviding.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/DefaultMockValueProviding.swift
@@ -45,7 +45,13 @@ extension GraphQLScalarType: DefaultMockValueProviding {
 
 extension GraphQLEnumType: DefaultMockValueProviding {
   func defaultMockValue(config: ApolloCodegen.ConfigurationContext) -> String {
-    guard let first = values.first else {
+    let filteredValues: [GraphQLEnumValue]
+    if config.options.deprecatedEnumCases == .exclude {
+      filteredValues = values.filter { !$0.isDeprecated }
+    } else {
+      filteredValues = values
+    }
+    guard let first = filteredValues.first else {
       fatalError("Cannot provide a default value for caseless enum \(name)")
     }
     return ".case(.\(first.render(as: .enumCase, config: config)))"


### PR DESCRIPTION
## Summary
- This fix targets the v2 release branch.
- When `deprecatedEnumCases` is set to `.exclude`, the mock codegen incorrectly used the first enum case as the default value in convenience initializers — even if that case was deprecated and excluded from the generated enum type, causing a compile error.
- Filters enum values by deprecation status in `GraphQLEnumType.defaultMockValue()` before selecting the default, matching the existing filtering in `EnumTemplate`.
- Adds a test verifying the mock default uses the first non-deprecated case.

Port of the 1.x fix from #948 to the 2.x branch.

Fixes https://github.com/apollographql/apollo-ios/issues/3634

## Test plan
- [x] New test `test__render_convenienceInitializer__givenDeprecatedEnumCases_exclude_firstCaseDeprecated_shouldUseFirstNonDeprecatedCase` passes
- [x] All 25 MockObjectTemplateTests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)