### PR TITLE
Remove cocoapods check

### DIFF
--- a/apollo-ios/Sources/Apollo/FieldPolicyDirectiveEvaluator.swift
+++ b/apollo-ios/Sources/Apollo/FieldPolicyDirectiveEvaluator.swift
@@ -1,7 +1,5 @@
 import Foundation
-#if !COCOAPODS
 @_spi(Internal) import ApolloAPI
-#endif
 
 enum FieldPolicyResult {
   case single(CacheKeyInfo)


### PR DESCRIPTION
Just a tiny cleanup. Cocoapods is no longer supported. This check is now redundant