### PR TITLE
Fix \r\n in GraphQL descriptions generating invalid Swift comments

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateString_Documentation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateString_Documentation_Tests.swift
@@ -176,4 +176,110 @@ class TemplateString_Documentation_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
+  func test__appendInterpolation_documentation__givenStringWithWindowsCRLF_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\r\nLine2\r\nLine3"
+
+    let expected = """
+    /// Line1
+    /// Line2
+    /// Line3
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+    \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__appendInterpolation_documentation__givenStringWithBareCR_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\rLine2\rLine3"
+
+    let expected = """
+    /// Line1
+    /// Line2
+    /// Line3
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+    \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__appendInterpolation_documentation__givenStringWithMixedLineEndings_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\r\nLine2\nLine3\rLine4"
+
+    let expected = """
+    /// Line1
+    /// Line2
+    /// Line3
+    /// Line4
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+    \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__appendInterpolation_documentation__givenStringWithWindowsCRLFAndIndentation_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\r\nLine2\r\nLine3"
+
+    let expected = """
+      /// Line1
+      /// Line2
+      /// Line3
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+      \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__appendInterpolation_documentation__givenStringWithWindowsCRLFAndEmptyLine_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\r\n\r\nLine3"
+
+    let expected = """
+    /// Line1
+    ///
+    /// Line3
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+    \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
 }

--- a/apollo-ios-codegen/Sources/TemplateString/TemplateString.swift
+++ b/apollo-ios-codegen/Sources/TemplateString/TemplateString.swift
@@ -325,7 +325,7 @@ public struct TemplateString: ExpressibleByStringInterpolation, CustomStringConv
       }
 
       let components = comment
-        .split(separator: "\n", omittingEmptySubsequences: false)
+        .splitLines()
         .joinedAsCommentLines(withLinePrefix: prefix)
 
       appendInterpolation(components)
@@ -369,6 +369,40 @@ public func +(lhs: String, rhs: TemplateString) -> TemplateString {
 
 // MARK: - Extensions
 
+extension String {
+  /// Splits the string into lines, treating `\r\n`, `\r`, and all other
+  /// Unicode newline characters as single line separators. This ensures
+  /// correct behaviour regardless of the line-ending convention used in
+  /// GraphQL schema descriptions (e.g. Windows CRLF, legacy Mac CR, Unix LF).
+  fileprivate func splitLines() -> [Substring] {
+    var lines: [Substring] = []
+    var lineStart = startIndex
+    var index = startIndex
+
+    while index < endIndex {
+      let char = self[index]
+      let next = self.index(after: index)
+
+      if char == "\r" && next < endIndex && self[next] == "\n" {
+        // \r\n — treat as a single separator
+        lines.append(self[lineStart..<index])
+        index = self.index(after: next)
+        lineStart = index
+      } else if char.isNewline {
+        // \n, \r, \u{0085}, \u{2028}, \u{2029}, etc.
+        lines.append(self[lineStart..<index])
+        index = next
+        lineStart = index
+      } else {
+        index = next
+      }
+    }
+
+    lines.append(self[lineStart...])
+    return lines
+  }
+}
+
 extension Array where Element == Substring {
   func joinedAsLines(withIndent indent: String) -> String {
     var iterator = self.makeIterator()
@@ -383,11 +417,13 @@ extension Array where Element == Substring {
 
     return string
   }
+}
 
+extension Array where Element: StringProtocol {
   fileprivate func joinedAsCommentLines(withLinePrefix prefix: String) -> String {
     var string = ""
 
-    func add(line: Substring) {
+    func add(line: Element) {
       string += prefix
       if !line.isEmpty {
         string += " "


### PR DESCRIPTION
## Summary

Fixes apollographql/apollo-ios#3553

GraphQL field descriptions containing `\r\n` (Windows CRLF) caused invalid Swift to be generated — only the first line received the `///` doc comment prefix, and subsequent lines were emitted as raw uncommented text, breaking compilation.

**Example — before fix:**
```swift
/// Test
Test       ← missing ///
Test       ← missing ///
Test       ← missing ///
public var test: String? { __data["test"] }
```

**Example — after fix:**
```swift
/// Test
/// Test
/// Test
/// Test
public var test: String? { __data["test"] }
```

## Root Cause

`appendInterpolation(comment:withLinePrefix:)` in `TemplateString.swift` split the description string on `"\n"` only, leaving `\r` attached to the end of each line. When `TemplateString` applied indentation it re-split on `"\n"`, so `\r` ended up in the written file and caused a carriage-return that overwrote the `///` prefix.

## Fix

Replaced the plain `split(separator: "\n")` with a new `String.splitLines()` helper that:
- Treats `\r\n` as a **single** separator (the key fix)
- Handles all other Unicode newline characters via `Character.isNewline` (`\r`, `\n`, `\u{0085}` NEL, `\u{2028}` Line Separator, `\u{2029}` Paragraph Separator)
- Requires no minimum OS version beyond the existing macOS 12 deployment target

## Tests

5 new test cases added to `TemplateString_Documentation_Tests`:

| Test | Input |
|---|---|
| `givenStringWithWindowsCRLF` | `"Line1\r\nLine2\r\nLine3"` |
| `givenStringWithBareCR` | `"Line1\rLine2\rLine3"` |
| `givenStringWithMixedLineEndings` | `"Line1\r\nLine2\nLine3\rLine4"` |
| `givenStringWithWindowsCRLFAndIndentation` | CRLF in indented context |
| `givenStringWithWindowsCRLFAndEmptyLine` | `"Line1\r\n\r\nLine3"` |

All 13 tests in `TemplateString_Documentation_Tests` pass. Full `ApolloCodegenTests` suite passes.