### PR TITLE
docs: fix Apollo iOS README API Reference link, add AI Skill resource

### DIFF
--- a/apollo-ios/README.md
+++ b/apollo-ios/README.md
@@ -73,8 +73,9 @@ Any targets in your application that will use `ApolloClient` need to have a depe
 | ----- | ----- | ----- |
 | **Getting Started Guide** | Complete setup and first query | [Start Here →](https://www.apollographql.com/docs/ios/get-started?utm_source=github&utm_medium=apollographql_apollo-client&utm_campaign=readme) |
 | **Full Documentation** | Comprehensive guides and examples | [Read Docs →](https://www.apollographql.com/docs/ios?utm_source=github&utm_medium=apollographql_apollo-client&utm_campaign=readme) |
-| **API Reference** | Complete API documentation | [Browse API →](https://www.apollographql.com/docs/react/api/apollo-client?utm_source=github&utm_medium=apollographql_apollo-client&utm_campaign=readme) |
+| **API Reference** | Complete API documentation | [Browse API →](https://www.apollographql.com/docs/ios/docc/documentation) |
 | **VS Code Extension** | Enhanced development experience | [Install Extension →](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) |
+| **AI Skill** | Apollo iOS agent skill for AI assistants | [View Skill →](https://github.com/apollographql/skills/tree/main#apollo-ios) |
 | **DevTools** | Debug your GraphQL apps | [Chrome](https://chrome.google.com/webstore/detail/apollo-client-devtools/jdkknkkbebbapilgoeccciglkfbmbnfm) \| [Firefox](https://addons.mozilla.org/en-US/firefox/addon/apollo-developer-tools/) |
 | **Free Course** | Apollo iOS and Swift: Codegen and Queries | [Take Course →](https://www.apollographql.com/tutorials/apollo-ios-swift-part1?utm_source=github&utm_medium=apollographql_apollo-client&utm_campaign=readme) |
 


### PR DESCRIPTION
## Summary

Two small fixes/additions to the Apollo iOS `README.md` (in the `apollo-ios/` subtree, so this will be pushed upstream on merge):

- **API Reference link**: was pointing at the React (web client) docs (`/docs/react/api/apollo-client`). Repointed to the Apollo iOS DocC documentation: https://www.apollographql.com/docs/ios/docc/documentation
- **AI Skill row**: added a new row in the Resources table linking to the Apollo iOS agent skill in [apollographql/skills](https://github.com/apollographql/skills/tree/main#apollo-ios), so users can discover it for use with Claude and other AI assistants.

## Test plan

- [x] Verified the new API Reference URL returns 200
- [x] Verified the AI Skill anchor link points to the Apollo iOS section of the skills repo README
- [ ] Reviewer to confirm the wording ("AI Skill") and table placement read well

🤖 Generated with [Claude Code](https://claude.com/claude-code)