### PR TITLE
fix: Cherry-pick CRLF doc comment fix for v1 (#961)

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateString_Documentation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateString_Documentation_Tests.swift
@@ -176,4 +176,110 @@ class TemplateString_Documentation_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
+  func test__appendInterpolation_documentation__givenStringWithWindowsCRLF_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\r\nLine2\r\nLine3"
+
+    let expected = """
+    /// Line1
+    /// Line2
+    /// Line3
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+    \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__appendInterpolation_documentation__givenStringWithBareCR_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\rLine2\rLine3"
+
+    let expected = """
+    /// Line1
+    /// Line2
+    /// Line3
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+    \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__appendInterpolation_documentation__givenStringWithMixedLineEndings_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\r\nLine2\nLine3\rLine4"
+
+    let expected = """
+    /// Line1
+    /// Line2
+    /// Line3
+    /// Line4
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+    \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__appendInterpolation_documentation__givenStringWithWindowsCRLFAndIndentation_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\r\nLine2\r\nLine3"
+
+    let expected = """
+      /// Line1
+      /// Line2
+      /// Line3
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+      \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__appendInterpolation_documentation__givenStringWithWindowsCRLFAndEmptyLine_returnsStringInMultilineDocComment() throws {
+    // given
+    let documentation = "Line1\r\n\r\nLine3"
+
+    let expected = """
+    /// Line1
+    ///
+    /// Line3
+    var test: String = "Test"
+    """
+
+    // when
+    let actual = TemplateString("""
+    \(documentation: documentation)
+    var test: String = "Test"
+    """).description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
 }

--- a/apollo-ios-codegen/Sources/TemplateString/TemplateString.swift
+++ b/apollo-ios-codegen/Sources/TemplateString/TemplateString.swift
@@ -325,7 +325,7 @@ public struct TemplateString: ExpressibleByStringInterpolation, CustomStringConv
       }
 
       let components = comment
-        .split(separator: "\n", omittingEmptySubsequences: false)
+        .splitLines()
         .joinedAsCommentLines(withLinePrefix: prefix)
 
       appendInterpolation(components)
@@ -369,6 +369,40 @@ public func +(lhs: String, rhs: TemplateString) -> TemplateString {
 
 // MARK: - Extensions
 
+extension String {
+  /// Splits the string into lines, treating `\r\n`, `\r`, and all other
+  /// Unicode newline characters as single line separators. This ensures
+  /// correct behaviour regardless of the line-ending convention used in
+  /// GraphQL schema descriptions (e.g. Windows CRLF, legacy Mac CR, Unix LF).
+  fileprivate func splitLines() -> [Substring] {
+    var lines: [Substring] = []
+    var lineStart = startIndex
+    var index = startIndex
+
+    while index < endIndex {
+      let char = self[index]
+      let next = self.index(after: index)
+
+      if char == "\r" && next < endIndex && self[next] == "\n" {
+        // \r\n — treat as a single separator
+        lines.append(self[lineStart..<index])
+        index = self.index(after: next)
+        lineStart = index
+      } else if char.isNewline {
+        // \n, \r, \u{0085}, \u{2028}, \u{2029}, etc.
+        lines.append(self[lineStart..<index])
+        index = next
+        lineStart = index
+      } else {
+        index = next
+      }
+    }
+
+    lines.append(self[lineStart...])
+    return lines
+  }
+}
+
 extension Array where Element == Substring {
   func joinedAsLines(withIndent indent: String) -> String {
     var iterator = self.makeIterator()
@@ -383,11 +417,13 @@ extension Array where Element == Substring {
 
     return string
   }
+}
 
+extension Array where Element: StringProtocol {
   fileprivate func joinedAsCommentLines(withLinePrefix prefix: String) -> String {
     var string = ""
 
-    func add(line: Substring) {
+    func add(line: Element) {
       string += prefix
       if !line.isEmpty {
         string += " "


### PR DESCRIPTION
Backports #961 to the v1 branch.

The linked issue [apollographql/apollo-ios#3553](https://github.com/apollographql/apollo-ios/issues/3553) is milestoned for **Patch Releases (1.x.x)** and reproduces on 1.21.0, so the fix needs to ship on v1 as well as `main`.

## Summary

GraphQL field descriptions containing `\r\n` (Windows CRLF), bare `\r`, or other Unicode line endings caused invalid Swift to be generated — only the first line received the `///` doc comment prefix; subsequent lines were emitted as raw uncommented text, breaking compilation.

`appendInterpolation(comment:withLinePrefix:)` in `TemplateString.swift` split the description on `\n` only, leaving `\r` attached to each line. A new `String.splitLines()` helper now treats `\r\n` as a single separator and handles other Unicode newline characters via `Character.isNewline`.

## Cherry-pick

Single commit cherry-picked from #961 (commit `da291e41`). The relevant code on `v1` is identical to `main` at the call site, so the cherry-pick applied cleanly with no conflicts and no manual edits.

## Test plan

- [ ] CI green on v1
- [ ] `Apollo-CodegenTestPlan` passes — includes the 5 new `TemplateString_Documentation_Tests` cases (CRLF, bare CR, mixed line endings, CRLF with indentation, CRLF with empty line)