### PR TITLE
fix: Make SubscriptionStream initializer public

### DIFF
--- a/apollo-ios/Sources/Apollo/SubscriptionStream.swift
+++ b/apollo-ios/Sources/Apollo/SubscriptionStream.swift
@@ -54,7 +54,7 @@ public struct SubscriptionStream<Element: Sendable>: AsyncSequence, Sendable {
   /// - Parameters:
   ///   - stream: The underlying stream of elements.
   ///   - stateProvider: A closure that returns the current subscription state.
-  package init(
+  public init(
     stream: AsyncThrowingStream<Element, any Error>,
     stateProvider: @escaping @Sendable () -> SubscriptionState
   ) {


### PR DESCRIPTION
## Summary
- Makes the `SubscriptionStream` initializer `public` (was `package`) so adopters can construct `SubscriptionStream` values from custom `SubscriptionNetworkTransport` conformances.

In v2.1.0 the `SubscriptionNetworkTransport.send(subscription:...)` return type changed from `AsyncThrowingStream<...>` to `SubscriptionStream<...>`. Because `SubscriptionStream`'s only initializer was `package`-scoped, it became impossible to write a custom conformance to the public `SubscriptionNetworkTransport` protocol from outside the module.

The other types involved (`SubscriptionState`, `AsyncThrowingStream`) are already public, so opening up the initializer is sufficient.

Fixes [#3637](https://github.com/apollographql/apollo-ios/issues/3637).

## Test plan
- [x] Build succeeds (`Apollo` scheme)
- [ ] CI green