### PR TITLE
fix(test-helpers): close SQLite connection before deleting database file in test teardown

### DIFF
--- a/Tests/ApolloInternalTestHelpers/SQLiteTestCacheProvider.swift
+++ b/Tests/ApolloInternalTestHelpers/SQLiteTestCacheProvider.swift
@@ -1,15 +1,20 @@
 import Foundation
 import Apollo
-import ApolloSQLite
+@_spi(Testing) import ApolloSQLite
 
-public class SQLiteTestCacheProvider: TestCacheProvider {  
+public class SQLiteTestCacheProvider: TestCacheProvider {
   public static func makeNormalizedCache() async -> TestDependency<any NormalizedCache> {
     await makeNormalizedCache(fileURL: temporarySQLiteFileURL())
   }
 
   public static func makeNormalizedCache(fileURL: URL) async -> TestDependency<any NormalizedCache> {
     let cache = try! SQLiteNormalizedCache(fileURL: fileURL)
+    // Close the SQLite connection before unlinking the file. Otherwise
+    // libsqlite3 emits "BUG IN CLIENT … vnode unlinked while in use" to stderr
+    // when callers recreate caches in tight loops (e.g. benchmark setup blocks).
+    nonisolated(unsafe) let captured = cache
     let tearDownHandler = { @Sendable in
+      captured.close()
       try Self.deleteCache(at: fileURL)
     }
     return (cache, tearDownHandler)

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -25,6 +25,19 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     sqlite3_close(db)
   }
 
+  /// Closes the underlying SQLite connection. After calling this, the database
+  /// must not be used for further operations. Intended for test teardown
+  /// scenarios where the database file is about to be unlinked — closing the
+  /// connection before unlink prevents libsqlite3's "vnode unlinked while in
+  /// use" diagnostic from firing.
+  @_spi(Testing)
+  public func close() {
+    dbQueue.sync {
+      sqlite3_close(db)
+      db = nil
+    }
+  }
+
   // MARK: - Internal Helpers
 
   private func performSync<T>(_ block: () throws -> T) throws -> T {

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -119,6 +119,20 @@ extension SQLiteNormalizedCache: NormalizedCache {
   }
 }
 
+// MARK: - SPI (Testing)
+
+extension SQLiteNormalizedCache {
+  /// Closes the underlying SQLite connection. After calling this, the cache
+  /// must not be used for further operations. Intended for test teardown
+  /// scenarios where the backing database file is about to be unlinked —
+  /// closing the connection before unlink avoids libsqlite3's "vnode unlinked
+  /// while in use" diagnostic when caches are recreated in tight loops.
+  @_spi(Testing)
+  public func close() {
+    (database as? ApolloSQLiteDatabase)?.close()
+  }
+}
+
 extension String {
   private var isBalanced: Bool {
     guard contains("(") || contains(")") else { return true }


### PR DESCRIPTION
## Summary

The SQLite test cache teardown handler removes the `.sqlite3` file from disk while the underlying SQLite connection is still open. The unlink-before-close ordering trips libsqlite3's API-violation check, dumping warnings to stderr:

```
[logging] BUG IN CLIENT OF libsqlite3.dylib: database integrity compromised by API violation: vnode unlinked while in use: /private/var/folders/.../db.sqlite3
[logging] invalidated open fd: 6 (0x11)
```

Tests still pass — it's only log spam — but it's noisy enough to obscure real diagnostics during benchmark runs that recreate caches per iteration.

## Fix

- Add an `@_spi(Testing)` `close()` method on `ApolloSQLiteDatabase` (drains the dispatch queue, calls `sqlite3_close`, nils the connection).
- Expose it via an `@_spi(Testing)` `close()` on `SQLiteNormalizedCache` (downcasts to the concrete database type — no protocol-surface change).
- Update `SQLiteTestCacheProvider`'s teardown handler to capture the cache and call `close()` before unlinking the file.

Both `close()` APIs are scoped behind `@_spi(Testing)` so the public surface of `ApolloSQLite` is unchanged for downstream consumers.

## Verification

Verified via a per-iteration cache-recreation repro that mirrors the benchmark-harness setup pattern (creates a holder class field, runs old teardown before reassigning, 50 iterations):

| | `BUG IN CLIENT` count |
| --- | --- |
| Baseline (no fix) | 4+ |
| With fix          | 0 |

`xcodebuild test -workspace ApolloDev.xcworkspace -scheme ApolloTests -testPlan Apollo-UnitTestPlan -destination 'platform=macOS' -only-testing:ApolloTests/SQLiteCacheTests` also passes cleanly with the new `close()` call in every SQLite test teardown.

## Test plan

- [x] `ApolloTests/SQLiteCacheTests` still passes (now exercises `close()` in every teardown).
- [x] Repro with rapid cache recreation: 0 SQLite warnings in `xcresulttool` action log (was 4+ before).
- [ ] Re-run `Apollo-CacheBenchmarksTestPlan` on the cache-rewrite branch once this is merged to confirm the original symptom is gone there too.

## Notes

- Touches only the test helper plus two small `@_spi(Testing)` additions in `apollo-ios/`. The SPI scope keeps these out of the public `ApolloSQLite` API; downstream consumers see no surface change.
- Spawned out of the cache-rewrite Phase 0 work (PR-004a baseline harness), where the warning first surfaced. The fix is independent of that branch and ships directly to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)