### PR TITLE
Fix SelectionSet equality crash on nullable-inner object lists

### DIFF
--- a/Tests/ApolloTests/SelectionSet_EquatableTests.swift
+++ b/Tests/ApolloTests/SelectionSet_EquatableTests.swift
@@ -1191,6 +1191,173 @@ class SelectionSet_EquatableTests: XCTestCase {
     expect(selectionSet1.hashValue).to(equal(selectionSet2.hashValue))
   }
 
+  func test__equatable__listOfNullableObjectsField__allPresent_returns_true() {
+    // given
+    final class HumanFragment: MockFragment, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: any ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("items", [Item?].self)
+      ]}
+
+      override class var __fulfilledFragments: [any SelectionSet.Type] {
+        [HumanFragment.self]
+      }
+
+      final class Item: MockSelectionSet, @unchecked Sendable {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: any ParentType { Types.Item }
+        override class var __selections: [Selection] {[
+          .field("id", Int.self)
+        ]}
+        override class var __fulfilledFragments: [any SelectionSet.Type] {
+          [Item.self]
+        }
+      }
+    }
+
+    let item = DataDict(data: [
+      "__typename": "Item",
+      "id": 1,
+    ], fulfilledFragments: [
+      ObjectIdentifier(HumanFragment.Item.self)
+    ])
+
+    // when
+    let selectionSet1 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "items": [item, item] as [DataDict?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    let selectionSet2 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "items": [item, item] as [DataDict?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    // then
+    expect(selectionSet1).to(equal(selectionSet2))
+    expect(selectionSet1.hashValue).to(equal(selectionSet2.hashValue))
+  }
+
+  func test__equatable__listOfNullableObjectsField__withNullElement_sameValues_returns_true() {
+    // given
+    final class HumanFragment: MockFragment, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: any ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("items", [Item?].self)
+      ]}
+
+      override class var __fulfilledFragments: [any SelectionSet.Type] {
+        [HumanFragment.self]
+      }
+
+      final class Item: MockSelectionSet, @unchecked Sendable {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: any ParentType { Types.Item }
+        override class var __selections: [Selection] {[
+          .field("id", Int.self)
+        ]}
+        override class var __fulfilledFragments: [any SelectionSet.Type] {
+          [Item.self]
+        }
+      }
+    }
+
+    let item = DataDict(data: [
+      "__typename": "Item",
+      "id": 1,
+    ], fulfilledFragments: [
+      ObjectIdentifier(HumanFragment.Item.self)
+    ])
+
+    // when
+    let selectionSet1 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "items": [item, nil, item] as [DataDict?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    let selectionSet2 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "items": [item, nil, item] as [DataDict?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    // then
+    expect(selectionSet1).to(equal(selectionSet2))
+    expect(selectionSet1.hashValue).to(equal(selectionSet2.hashValue))
+  }
+
+  func test__equatable__listOfNullableObjectsField__differentNullPositions_returns_false() {
+    // given
+    final class HumanFragment: MockFragment, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: any ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("items", [Item?].self)
+      ]}
+
+      override class var __fulfilledFragments: [any SelectionSet.Type] {
+        [HumanFragment.self]
+      }
+
+      final class Item: MockSelectionSet, @unchecked Sendable {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: any ParentType { Types.Item }
+        override class var __selections: [Selection] {[
+          .field("id", Int.self)
+        ]}
+        override class var __fulfilledFragments: [any SelectionSet.Type] {
+          [Item.self]
+        }
+      }
+    }
+
+    let item = DataDict(data: [
+      "__typename": "Item",
+      "id": 1,
+    ], fulfilledFragments: [
+      ObjectIdentifier(HumanFragment.Item.self)
+    ])
+
+    // when
+    let selectionSet1 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "items": [item, nil, item] as [DataDict?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    let selectionSet2 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "items": [nil, item, item] as [DataDict?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    // then
+    expect(selectionSet1).toNot(equal(selectionSet2))
+  }
+
   func test__equatable__2DimensionalListOfObjectsField__sameValues_returns_true() {
     // given
     final class HumanFragment: MockFragment, @unchecked Sendable {

--- a/Tests/ApolloTests/SelectionSet_EquatableTests.swift
+++ b/Tests/ApolloTests/SelectionSet_EquatableTests.swift
@@ -1504,6 +1504,313 @@ class SelectionSet_EquatableTests: XCTestCase {
     expect(selectionSet1.hashValue).toNot(equal(selectionSet2.hashValue))
   }
 
+  func test__equatable__2DimensionalListOfObjectsField__withNullInnerList_sameValues_returns_true() {
+    // given
+    final class HumanFragment: MockFragment, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: any ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("nestedItems", [[Item]?].self)
+      ]}
+
+      override class var __fulfilledFragments: [any SelectionSet.Type] {
+        [HumanFragment.self]
+      }
+
+      final class Item: MockSelectionSet, @unchecked Sendable {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: any ParentType { Types.Item }
+        override class var __selections: [Selection] {[
+          .field("id", Int.self)
+        ]}
+        override class var __fulfilledFragments: [any SelectionSet.Type] {
+          [Item.self]
+        }
+      }
+    }
+
+    let item = DataDict(data: [
+      "__typename": "Item",
+      "id": 1,
+    ], fulfilledFragments: [
+      ObjectIdentifier(HumanFragment.Item.self)
+    ])
+
+    // when
+    let selectionSet1 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": [[item], nil, [item]] as [[DataDict]?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    let selectionSet2 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": [[item], nil, [item]] as [[DataDict]?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    // then
+    expect(selectionSet1).to(equal(selectionSet2))
+    expect(selectionSet1.hashValue).to(equal(selectionSet2.hashValue))
+  }
+
+  func test__equatable__2DimensionalListOfObjectsField__differentNullInnerListPositions_returns_false() {
+    // given
+    final class HumanFragment: MockFragment, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: any ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("nestedItems", [[Item]?].self)
+      ]}
+
+      override class var __fulfilledFragments: [any SelectionSet.Type] {
+        [HumanFragment.self]
+      }
+
+      final class Item: MockSelectionSet, @unchecked Sendable {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: any ParentType { Types.Item }
+        override class var __selections: [Selection] {[
+          .field("id", Int.self)
+        ]}
+        override class var __fulfilledFragments: [any SelectionSet.Type] {
+          [Item.self]
+        }
+      }
+    }
+
+    let item = DataDict(data: [
+      "__typename": "Item",
+      "id": 1,
+    ], fulfilledFragments: [
+      ObjectIdentifier(HumanFragment.Item.self)
+    ])
+
+    // when
+    let selectionSet1 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": [[item], nil, [item]] as [[DataDict]?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    let selectionSet2 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": [nil, [item], [item]] as [[DataDict]?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    // then
+    expect(selectionSet1).toNot(equal(selectionSet2))
+  }
+
+  func test__equatable__2DimensionalListOfNullableObjectsField__withNullElementAndNullInnerList_sameValues_returns_true() {
+    // given
+    final class HumanFragment: MockFragment, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: any ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("nestedItems", [[Item?]?].self)
+      ]}
+
+      override class var __fulfilledFragments: [any SelectionSet.Type] {
+        [HumanFragment.self]
+      }
+
+      final class Item: MockSelectionSet, @unchecked Sendable {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: any ParentType { Types.Item }
+        override class var __selections: [Selection] {[
+          .field("id", Int.self)
+        ]}
+        override class var __fulfilledFragments: [any SelectionSet.Type] {
+          [Item.self]
+        }
+      }
+    }
+
+    let item = DataDict(data: [
+      "__typename": "Item",
+      "id": 1,
+    ], fulfilledFragments: [
+      ObjectIdentifier(HumanFragment.Item.self)
+    ])
+
+    // when
+    let selectionSet1 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": [[item, nil, item] as [DataDict?], nil, [item] as [DataDict?]] as [[DataDict?]?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    let selectionSet2 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": [[item, nil, item] as [DataDict?], nil, [item] as [DataDict?]] as [[DataDict?]?]
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    // then
+    expect(selectionSet1).to(equal(selectionSet2))
+    expect(selectionSet1.hashValue).to(equal(selectionSet2.hashValue))
+  }
+
+  func test__equatable__3DimensionalListOfNullableObjectsField__nullsAtEveryLevel_sameValues_returns_true() {
+    // given
+    final class HumanFragment: MockFragment, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: any ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("nestedItems", [[[Item?]?]?].self)
+      ]}
+
+      override class var __fulfilledFragments: [any SelectionSet.Type] {
+        [HumanFragment.self]
+      }
+
+      final class Item: MockSelectionSet, @unchecked Sendable {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: any ParentType { Types.Item }
+        override class var __selections: [Selection] {[
+          .field("id", Int.self)
+        ]}
+        override class var __fulfilledFragments: [any SelectionSet.Type] {
+          [Item.self]
+        }
+      }
+    }
+
+    let item = DataDict(data: [
+      "__typename": "Item",
+      "id": 1,
+    ], fulfilledFragments: [
+      ObjectIdentifier(HumanFragment.Item.self)
+    ])
+
+    // A 3-D list combining nulls at all three levels:
+    //  - outermost has a `nil` middle list,
+    //  - middle layer has a `nil` leaf list,
+    //  - leaf layer has a `nil` item.
+    let nestedItems: [[[DataDict?]?]?] = [
+      [
+        [item, nil, item] as [DataDict?],
+        nil
+      ] as [[DataDict?]?],
+      nil,
+      [
+        [item] as [DataDict?]
+      ] as [[DataDict?]?]
+    ]
+
+    // when
+    let selectionSet1 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": nestedItems
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    let selectionSet2 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": nestedItems
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    // then
+    expect(selectionSet1).to(equal(selectionSet2))
+    expect(selectionSet1.hashValue).to(equal(selectionSet2.hashValue))
+  }
+
+  func test__equatable__3DimensionalListOfNullableObjectsField__differentLeafNullPositions_returns_false() {
+    // given
+    final class HumanFragment: MockFragment, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: any ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("nestedItems", [[[Item?]?]?].self)
+      ]}
+
+      override class var __fulfilledFragments: [any SelectionSet.Type] {
+        [HumanFragment.self]
+      }
+
+      final class Item: MockSelectionSet, @unchecked Sendable {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: any ParentType { Types.Item }
+        override class var __selections: [Selection] {[
+          .field("id", Int.self)
+        ]}
+        override class var __fulfilledFragments: [any SelectionSet.Type] {
+          [Item.self]
+        }
+      }
+    }
+
+    let item = DataDict(data: [
+      "__typename": "Item",
+      "id": 1,
+    ], fulfilledFragments: [
+      ObjectIdentifier(HumanFragment.Item.self)
+    ])
+
+    // Same outer/middle shape; the leaf null shifts from position 1 to position 0. Without
+    // null-preservation the two would compare equal, so this also guards against any future
+    // refactor that filters nulls out of nested lists.
+    let nestedItems1: [[[DataDict?]?]?] = [
+      [
+        [item, nil, item] as [DataDict?]
+      ] as [[DataDict?]?]
+    ]
+    let nestedItems2: [[[DataDict?]?]?] = [
+      [
+        [nil, item, item] as [DataDict?]
+      ] as [[DataDict?]?]
+    ]
+
+    // when
+    let selectionSet1 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": nestedItems1
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    let selectionSet2 = HumanFragment(_dataDict: DataDict(
+      data: [
+        "__typename": "Character",
+        "nestedItems": nestedItems2
+      ],
+      fulfilledFragments: HumanFragment.__fulfilledFragmentIds
+    ))
+
+    // then
+    expect(selectionSet1).toNot(equal(selectionSet2))
+  }
+
   // MARK: - Integration Tests
 
   func test__equatable__givenQueryResponseFetchedFromStore()

--- a/apollo-ios/Sources/ApolloAPI/Optional+asNullable.swift
+++ b/apollo-ios/Sources/ApolloAPI/Optional+asNullable.swift
@@ -4,10 +4,20 @@ import Foundation
 ///
 /// This is used to help handle nested optional values in dyanmic JSON data.
 @_spi(Internal)
-public protocol AnyOptional {}
+public protocol AnyOptional {
+  /// `true` iff the underlying optional is `.none`. Allows code that has already type-erased
+  /// an optional to `any AnyOptional` to distinguish `.none` from `.some` without a `Mirror`
+  /// or knowledge of the wrapped type.
+  var _isNone: Bool { get }
+}
 
 @_spi(Internal)
-extension Optional: AnyOptional { }
+extension Optional: AnyOptional {
+  public var _isNone: Bool {
+    if case .none = self { return true }
+    return false
+  }
+}
 
 extension Optional where Wrapped: Sendable {
 

--- a/apollo-ios/Sources/ApolloAPI/SelectionSet+Equatable.swift
+++ b/apollo-ios/Sources/ApolloAPI/SelectionSet+Equatable.swift
@@ -150,6 +150,15 @@ extension SelectionSet {
       return nestedList.map { self.convertElements(of: $0, to: selectionSetType) as DataDict.FieldValue }
     }
 
+    // Nullable-inner object list (`[Object?]`): preserve null slots so position-sensitive
+    // equality remains correct. Filtering would make `[a, null, b]` compare equal to `[a, b]`.
+    if let nullableList = list as? [DataDict?] {
+      return nullableList.map { dataDict -> DataDict.FieldValue in
+        guard let dataDict else { return NSNull() }
+        return selectionSetType.init(_dataDict: dataDict)
+      }
+    }
+
     preconditionFailure("Expected list data to contain objects.")
   }
 

--- a/apollo-ios/Sources/ApolloAPI/SelectionSet+Equatable.swift
+++ b/apollo-ios/Sources/ApolloAPI/SelectionSet+Equatable.swift
@@ -138,28 +138,31 @@ extension SelectionSet {
     }
   }
 
+  /// Convert elements of a list to the expected `SelectionSet` type.
+  /// 
+  /// At any depth, an element is one of:
+  ///   - `DataDict`: a leaf object — convert to a typed `SelectionSet`.
+  ///   - `[DataDict.FieldValue]`: a sub-list — recurse so deeper levels classify the same way.
+  ///   - A null marker: a propagated GraphQL null in an object or sub-list position. Represented by `NSNull()`.
   private func convertElements(
     of list: [DataDict.FieldValue],
     to selectionSetType: any RootSelectionSet.Type
   ) -> [DataDict.FieldValue] {
-    if let dataDictList = list as? [DataDict] {
-      return dataDictList.map { selectionSetType.init(_dataDict: $0) }
-    }
-
-    if let nestedList = list as? [[DataDict.FieldValue]] {
-      return nestedList.map { self.convertElements(of: $0, to: selectionSetType) as DataDict.FieldValue }
-    }
-
-    // Nullable-inner object list (`[Object?]`): preserve null slots so position-sensitive
-    // equality remains correct. Filtering would make `[a, null, b]` compare equal to `[a, b]`.
-    if let nullableList = list as? [DataDict?] {
-      return nullableList.map { dataDict -> DataDict.FieldValue in
-        guard let dataDict else { return NSNull() }
+    return list.map { element -> DataDict.FieldValue in
+      if let dataDict = element as? DataDict {
         return selectionSetType.init(_dataDict: dataDict)
       }
+      if let nestedList = element as? [DataDict.FieldValue] {
+        return convertElements(of: nestedList, to: selectionSetType) as DataDict.FieldValue
+      }
+      if element is NSNull {
+        return NSNull()
+      }
+      if let optional = element as? any AnyOptional, optional._isNone {
+        return NSNull()
+      }
+      preconditionFailure("Expected list element to be an object, a sub-list, or null.")
     }
-
-    preconditionFailure("Expected list data to contain objects.")
   }
 
 }


### PR DESCRIPTION
## Summary

`SelectionSet+Equatable.convertElements` traps with `preconditionFailure("Expected list data to contain objects.")` whenever a list field declared as `[Object?]` (non-null outer, nullable inner) contains an actual `null` element. This patch adds a `list as? [DataDict?]` branch that preserves null slots so the equatable walker no longer crashes — and so position-sensitive equality is still correct.

## Mechanism

When the backend returns a partial GraphQL response — e.g. one resolver inside a list throws and GraphQL's null-propagation rules bubble the error up only to the nearest nullable parent (the list element) — the iOS executor materializes the JSON `null` element as `NSNull()` via `DataDictMapper.acceptNullValue`. The list stored at `__data._data[field.responseKey]` is therefore heterogeneous: a mix of `DataDict` values and `NSNull`.

Then during `SelectionSet ==`:

1. `fieldsForEquality()` walks each fragment's fields.
2. `add(field:)` reaches the object-list branch and casts `fieldData as? [DataDict.FieldValue]` — this succeeds because both `DataDict` and `NSNull` are `Hashable & Sendable`.
3. `convertElements(of:to:)` then tries `list as? [DataDict]` — fails the moment any element is `NSNull`.
4. Falls through to `list as? [[FieldValue]]` — fails (not nested arrays).
5. `preconditionFailure("Expected list data to contain objects.")` fires.

Process dies. In our production app this surfaces as repeated crash bursts correlated 1:1 with backend disturbances (e.g. queue purges, transient DB timeouts) on any user that happens to be on a screen that calls `removeDuplicates()` on a fragment containing an `[Object?]` list.

## The fix

Add a third cast that handles the nullable-inner case:

```swift
if let nullableList = list as? [DataDict?] {
  return nullableList.map { dataDict -> DataDict.FieldValue in
    guard let dataDict else { return NSNull() }
    return selectionSetType.init(_dataDict: dataDict)
  }
}
```

`NSNull` bridges to `Optional.none` when cast to `DataDict?`, so this branch catches mixed `DataDict + NSNull` lists. Null slots are preserved as `NSNull()` so two SelectionSets with nulls in the same positions still compare equal, while shifting a null position correctly reports inequality. Filtering nulls would have been simpler but would break position-sensitive equality (`[a, null, b]` would compare equal to `[a, b]`, which is wrong).

The existing `[DataDict]` and `[[FieldValue]]` paths are unchanged so the all-present and nested-list fast paths keep their single-cast performance.

## Tests

`Tests/ApolloTests/SelectionSet_EquatableTests.swift` gains three regression tests next to the existing list-of-objects coverage:

- `test__equatable__listOfNullableObjectsField__allPresent_returns_true` — baseline; passes pre-fix (no null elements ⇒ `[DataDict]` cast succeeds).
- `test__equatable__listOfNullableObjectsField__withNullElement_sameValues_returns_true` — **reproduces the crash**: `Fatal error: Expected list data to contain objects.` at `apollo-ios/Sources/ApolloAPI/SelectionSet+Equatable.swift:153` prior to the fix. Passes post-fix.
- `test__equatable__listOfNullableObjectsField__differentNullPositions_returns_false` — verifies position sensitivity: shifting a null to a different slot reports inequality. Also crashed pre-fix.

To see the crash for yourself, revert the new branch in `convertElements` and run:

```
tuist test ApolloTests --test-targets "ApolloTests/SelectionSet_EquatableTests/test__equatable__listOfNullableObjectsField__withNullElement_sameValues_returns_true"
```

## Production impact

In our production app, this was the cause of Sentry issue APPLE-HGN (and three sibling groupings split by minor stack-frame variance): ~90 events / ~50 users / ~6 weeks of crashes. The triggering field in our schema is a `[ChatGateOption]!` whose inner type is nullable; under any backend disturbance that nulls a single option, the entire iOS process dies during the next `removeDuplicates()` cycle on the user-tree publisher. The same pattern is latent on every `[Object?]` field we ship — this PR closes that latent bug for everyone.