### PR TITLE
docs(cache): note Phase 1A writtenAt default and Phase 1C migration plan

### DIFF
--- a/apollo-ios/Design/cache-rewrite-phase1-plan.md
+++ b/apollo-ios/Design/cache-rewrite-phase1-plan.md
@@ -191,6 +191,10 @@ struct SystemTimeProvider: TimeProvider {
 
 The provider is held by `ApolloStore` and threaded into the normalizer construction.
 
+**Phase 1A interim:** `Record`'s legacy convenience initializer (`Record(key:_:writtenAt:)`) introduced alongside the field-aware `Record` change uses `writtenAt: Int64 = 0` as a default so existing call sites (the result normalizer's `Record(key: cachePath, object)` site, plus test fixtures using the dictionary-literal form) continue to compile unchanged. This is purely a placeholder during Phase 1A and 1B — no code reads `writtenAt` for any decision until TTL evaluation lands in Phase 1C. The reason the default is `0` rather than `Date.now` is to preserve deterministic equality for the parser-record tests (per [§3.2](#32-record-becomes-field-aware), two `Record`s with the same key and same field values but different `writtenAt` timestamps compare unequal; a `Date.now` default would make every test assertion comparing parser output against a literal-constructed fixture race against the wall clock).
+
+**Phase 1C migration:** when the `TimeProvider` plumbing above lands, the convenience initializer's `writtenAt` default is **dropped entirely** — the parameter becomes required. Production write sites pass the `TimeProvider`'s current epoch seconds; tests pass a pinned value from a stubbed clock. This forces every record-write site to take an explicit stance on the write timestamp rather than silently accepting an epoch-`0` record that would be immediately stale once TTL evaluation goes live.
+
 ## 5. Read-mode split
 
 Two read modes exist on `ApolloStore.load`:


### PR DESCRIPTION
## Summary

Adds two paragraphs to the engineering plan §4.3 (Write-path timestamp injection) capturing the decision discussed during PR-006 review.

## What's in the diff

Single addition to \`apollo-ios/Design/cache-rewrite-phase1-plan.md\` §4.3, immediately after the existing TimeProvider sketch:

- **Phase 1A interim** paragraph — documents that \`Record\`'s legacy convenience initializer uses \`writtenAt: Int64 = 0\` as a default, and that the default value is intentionally \`0\` rather than \`Date.now\` to preserve deterministic equality for the parser-record tests.
- **Phase 1C migration** paragraph — records the agreed direction: when the TimeProvider plumbing lands in Phase 1C, the convenience initializer's \`writtenAt\` default is dropped entirely. The parameter becomes required. Production write sites pass the TimeProvider's current epoch seconds; tests pass a pinned value from a stubbed clock.

## Why

PR-006 introduces the provisional default; without the design plan noting both the rationale ("why 0 and not Date.now") and the migration trigger ("Phase 1C drops the default entirely"), the next person to touch this code in Phase 1C would have to re-derive the constraint and the decision.

## Test plan

Docs-only change. No code modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)