### PR TITLE
Remove subtree pull step to prevent self-perpetuating CI conflicts

### DIFF
--- a/.github/actions/subtree-split-push/action.yml
+++ b/.github/actions/subtree-split-push/action.yml
@@ -30,7 +30,12 @@ runs:
       PR_TITLE: ${{ inputs.pr-title }}
     run: |
       echo "git: $(git --version)"
+      # Fetch upstream for diagnostic visibility in logs. We do NOT pull —
+      # the dev repo is the only writer to upstream subtree repos, so a pull
+      # would only ever do work in degenerate cases (and historically caused
+      # self-perpetuating merge conflicts on noisy files like package-lock.json).
+      # See claude/ci-subtree-troubleshooting.md for the "stale upstream" incident
+      # that motivated removing the pull.
       git fetch ${{ inputs.remote }} ${{ inputs.target-branch }}
-      git subtree pull -P ${{ inputs.subtree }} --squash -m "pull: ${{ inputs.subtree }} - PR #${{ inputs.pr-number }} - $PR_TITLE" ${{ inputs.remote }} ${{ inputs.target-branch }}
       splitResult=$(git subtree -P ${{ inputs.subtree }} split --squash --rejoin -m "split: ${{ inputs.subtree }} - PR #${{ inputs.pr-number }} - $PR_TITLE")
       echo "split_sha=$splitResult" >> $GITHUB_OUTPUT

--- a/claude/ci-subtree-troubleshooting.md
+++ b/claude/ci-subtree-troubleshooting.md
@@ -1,22 +1,62 @@
 # CI Subtree Push Troubleshooting
 
+## Core invariant: apollo-ios-dev is the only writer
+
+The three subtree upstream repos (`apollo-ios`, `apollo-ios-codegen`, `apollo-ios-pagination`) **must only receive content via the `PR Subtree Push` workflow in this repo.** Nobody pushes to them directly, no Renovate/Dependabot opens PRs against them, no manual commits land on their `main` branches.
+
+The workflow's design relies on this invariant. If it's broken (someone pushes directly to upstream), the next workflow run's `git push` to upstream will fail loudly with a non-fast-forward error — that's the intended signal that the invariant was violated. Investigate before bypassing.
+
 ## How the subtree push workflow works
 
-On every PR merge, `.github/workflows/pr-subtree-push.yml` runs the `subtree-split-push` action for each of the three subtrees (`apollo-ios`, `apollo-ios-codegen`, `apollo-ios-pagination`). The action splits each subtree and captures the resulting SHA as a step output. The workflow then has two gated steps:
+On every PR merge, `.github/workflows/pr-subtree-push.yml` runs the `subtree-split-push` action for each of the three subtrees. The workflow has three gated phases:
 
-1. **Split all three subtrees** (`if: always()` — all three are attempted regardless) — each runs `git subtree pull --squash` then `git subtree split --squash --rejoin`, writing rejoin metadata into local history and outputting the split SHA.
-2. **Push Subtrees** (`if: success()`) — only runs if all three splits succeeded. Pushes each split SHA directly to the upstream subtree repo.
+1. **Split all three subtrees** (`if: always()` — all three are attempted regardless) — each runs `git subtree split --squash --rejoin`, writing rejoin metadata into local history and outputting the split SHA. The action also fetches upstream for diagnostic visibility but **does not pull** — see "Why no pull?" below.
+2. **Push Subtrees** (`if: success()`) — only runs if all three splits succeeded. Pushes each split SHA directly to the upstream subtree repo as a fast-forward.
 3. **Push Updated History** (`if: success()`) — only runs if all pushes succeeded. Pushes the dev repo history (including rejoin metadata) back to `apollo-ios-dev/main`.
 
 If any step fails, the runner exits without ever pushing the broken rejoin metadata to `main`.
 
-## The broken metadata bug (historical)
+### Why no pull?
 
-This was fixed in PR #924, but understanding it helps diagnose any future regressions.
+The action used to run `git subtree pull --squash` before `split`. That step existed to defensively bring upstream commits into dev — but in our setup, upstream never has commits dev doesn't, so the pull was always either a no-op or a problem. The May 2026 incident (below) showed it was a self-perpetuating failure source. Removed in PR #990 (or whatever).
 
-**How it happened:** In the old workflow, split and push were coupled in a single action step. `git subtree split --squash --rejoin` wrote rejoin metadata into local history (referencing the new split SHA) _before_ the push to the upstream subtree remote. If the push then timed out, the split SHA was lost with the ephemeral CI runner. `Push Updated History` (which had `if: always()`) would still commit the broken metadata to `main`.
+## Historical incident: stale-upstream pull conflict (May 2026)
 
-**Why subsequent CI runs failed:** CI uses git 2.53.0, which strictly validates `git-subtree-split:` hashes. When it encounters the broken hash, it tries to fetch it from the upstream remote, the remote returns `not our ref`, and it hard-fails. Every future PR that touched the affected subtree would fail.
+Fixed in PR #989; root cause prevention in PR #990 (approx — match by date).
+
+**How it happened:** When the action did `git subtree pull --squash` before split, the pull's 3-way merge could conflict on noisy files like `package-lock.json` even when the dev and upstream content were structurally compatible. PR #982 (Renovate update to `rollup: 4.60.4`) triggered such a conflict during its post-merge workflow. The conflict failed the split step → `Push Subtrees` was gated off by `if: success()` → upstream never got the 4.60.4 update.
+
+**Why subsequent PRs cascaded:** Every PR after #982 also ran `git subtree pull --squash` against the now-stale upstream (still at rollup 4.60.3), hit the same conflict, and failed the same way. Each failure further widened the dev/upstream gap.
+
+**Symptoms:**
+```
+Auto-merging apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package-lock.json
+CONFLICT (content): Merge conflict in apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package-lock.json
+Auto-merging apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package.json
+CONFLICT (content): Merge conflict in apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript/package.json
+Automatic merge failed; fix conflicts and then commit the result.
+```
+
+**Recovery (one-time, used by PR #989):**
+
+1. Locally reproduce the workflow's pull on a branch off `main`:
+   ```bash
+   git fetch https://github.com/apollographql/<affected-subtree>.git main
+   git subtree pull -P <affected-subtree> --squash \
+     -m "pull: <affected-subtree> - manual resolve to unstick subtree push CI" \
+     https://github.com/apollographql/<affected-subtree>.git main
+   ```
+2. Resolve the conflict by accepting `--ours` for the conflicted files. Verify with `git diff origin/main` — should be empty (dev is correct, upstream is stale).
+3. Commit the merge, push the branch, open a PR. **Important: this PR must be merged with a merge commit, NOT squashed** — squashing flattens the two-parent structure that git-subtree relies on.
+4. On merge, the next workflow run's pull becomes a no-op (base matches upstream, no conflict) and push catches upstream up.
+
+After PR #990 (this fix), the pull is gone so this specific failure mode cannot recur.
+
+## Historical incident: broken rejoin metadata (PR #924, pre-2026)
+
+**How it happened:** In an older workflow, split and push were coupled in a single action step. `git subtree split --squash --rejoin` wrote rejoin metadata into local history (referencing the new split SHA) _before_ the push to the upstream subtree remote. If the push then timed out, the split SHA was lost with the ephemeral CI runner. `Push Updated History` (which had `if: always()`) would still commit the broken metadata to `main`.
+
+**Why subsequent CI runs failed:** CI's git strictly validates `git-subtree-split:` hashes. When it encounters the broken hash, it tries to fetch it from the upstream remote, the remote returns `not our ref`, and it hard-fails. Every future PR that touched the affected subtree would fail.
 
 **Symptoms:**
 ```
@@ -24,47 +64,30 @@ fatal: remote error: upload-pack: not our ref <sha>
 fatal: could not rev-parse split hash <sha> from commit <sha>
 ```
 
-## How to fix broken metadata (if it ever recurs)
+**Recovery (if it ever recurs):**
 
-The fix exploits the fact that the local Xcode-bundled git-subtree is more lenient than CI's git 2.53.0 — when it can't resolve a cached split hash, it silently skips it and reconstructs the split from scratch by walking all history. This is slower but succeeds.
+The local Xcode-bundled git-subtree is more lenient than CI's — when it can't resolve a cached split hash, it silently skips it and reconstructs the split from scratch by walking all history. Slower but succeeds.
 
-**Step 1: Identify the broken commit**
-
-Find the rejoin commit that references the missing split hash:
-```bash
-git log --oneline --grep="git-subtree-dir: <affected-subtree>" | head -5
-# Look for a "split: <subtree>" commit — check if its git-subtree-split SHA exists on the upstream remote
-```
-
-**Step 2: Reset HEAD to the broken rejoin commit**
-
-```bash
-git reset --hard <sha-of-broken-rejoin-commit>
-# Example: git reset --hard 8d85ccbb6
-```
-
-This is necessary so the local script operates from that point in history and the older git-subtree can fall back to full reconstruction.
-
-**Step 3: Run the push script locally**
-
-```bash
-./scripts/push-forked-branch.sh -p <subtree> -r https://github.com/apollographql/<subtree>.git -b main
-```
-
-This will take significantly longer than normal (several minutes) because git-subtree is reconstructing the split from scratch rather than using a cached starting point. That's expected.
-
-**Step 4: Restore main to remote HEAD**
-
-After the script completes, the upstream subtree repo now has the correct commits. Reset main back to match remote:
-```bash
-git fetch origin
-git reset --hard origin/main
-```
-
-**Step 5: Re-run the failing CI job**
-
-Trigger a re-run of the failing `PR Subtree Push` job from the GitHub Actions UI. It will now succeed because the missing split SHA now exists on the upstream subtree remote.
+1. Identify the broken rejoin commit:
+   ```bash
+   git log --oneline --grep="git-subtree-dir: <affected-subtree>" | head -5
+   # Look for a "split: <subtree>" commit — check if its git-subtree-split SHA exists on the upstream remote
+   ```
+2. Reset HEAD to the broken rejoin commit so the local script operates from that point in history:
+   ```bash
+   git reset --hard <sha-of-broken-rejoin-commit>
+   ```
+3. Run the push script locally (takes several minutes — it's reconstructing from scratch):
+   ```bash
+   ./scripts/push-forked-branch.sh -p <subtree> -r https://github.com/apollographql/<subtree>.git -b main
+   ```
+4. Restore main to remote HEAD:
+   ```bash
+   git fetch origin
+   git reset --hard origin/main
+   ```
+5. Re-run the failing `PR Subtree Push` job from the GitHub Actions UI. It will now succeed because the missing split SHA exists on the upstream remote.
 
 ## Which subtrees may need fixing
 
-Check the CI logs for the failing run. The three split steps use `if: always()` so all three are attempted — look for the `not our ref` error in each subtree's step output to identify which ones are affected.
+Check the CI logs for the failing run. The three split steps use `if: always()` so all three are attempted — look for errors in each subtree's step output to identify which ones are affected.


### PR DESCRIPTION
## Summary

Removes `git subtree pull --squash` from the `subtree-split-push` action. The pull step exists to merge upstream commits into dev — but **the dev repo is the only writer to the three upstream subtree repos**, so the pull was always either a no-op or a problem, never useful.

Follow-up to [PR #989](https://github.com/apollographql/apollo-ios-dev/pull/989), which unstuck CI after the pull step started self-perpetuating conflicts on May 20, 2026.

## The problem this prevents

When the pull's 3-way merge produces a spurious conflict on noisy files (e.g. `package-lock.json`), the split step fails. Because `Push Subtrees` is gated by `if: success()`, none of the three subtrees get pushed. Upstream falls further behind dev, and **every subsequent PR** re-runs the same pull against an even staler upstream and fails the same way. This is exactly what happened with Renovate's rollup 4.60.4 update — it took every merge offline until PR #989 manually unstuck it.

With the pull removed, this failure mode is structurally impossible.

## Why this is safe

- `git subtree split --rejoin` walks dev's history and reconstructs a linear subtree history. It doesn't need the pull to function — it uses prior rejoin commits already in dev's history as starting points.
- The new split tip's parent chain extends from upstream's current HEAD (by construction), so the subsequent push is a clean fast-forward.
- `git fetch` is kept (for diagnostic visibility in CI logs), just no merge.

## Failure mode if the invariant is broken

The change relies on **"dev is the only writer to upstream subtree repos"** — codified as a new "Core invariant" section in `claude/ci-subtree-troubleshooting.md`.

If someone breaks the invariant (e.g., pushes directly to `apollo-ios-codegen/main`), the next workflow run's `git push` to that upstream will fail loudly with a non-fast-forward error. That's the intended signal — investigate the unauthorized upstream push rather than papering over it.

This is strictly better than the old behavior, which silently failed every PR with confusing merge conflicts.

## Things to verify before merging (out of scope of this PR but related)

- Confirm Renovate is **not** configured against the three upstream subtree repos directly. (Renovate against `apollo-ios-dev` is correct and unaffected.)
- Consider adding branch protection rules on `apollo-ios/main`, `apollo-ios-codegen/main`, and `apollo-ios-pagination/main` to disallow direct pushes from anyone except the deploy key used by this workflow.

Both of those would tighten the invariant from "convention" to "enforced." I can spin those up as separate tasks if you'd like.

## Changes

- `.github/actions/subtree-split-push/action.yml` — removed `git subtree pull --squash`, kept `git fetch` for log diagnostics, added a comment explaining why.
- `claude/ci-subtree-troubleshooting.md` — added "Core invariant" section, documented the May 2026 incident, updated workflow description, preserved the existing PR #924 broken-metadata recovery section.

## Test plan
- [ ] CI checks pass on this PR.
- [ ] On merge, the `PR Subtree Push` workflow runs cleanly (no pull step in the logs, all splits succeed, push proceeds).
- [ ] The next 2-3 PRs after this one merge cleanly through the workflow.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>