### PR TITLE
ci: migrate Subtree Push to GitHub App auth (groundwork for upstream branch protection)

### DIFF
--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -27,14 +27,17 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.base.ref }}
         fetch-depth: 0
-    - name: Setup SSH Keys
-      uses: webfactory/ssh-agent@v0.7.0
+    - name: Generate GitHub App Token
+      id: app-token
+      uses: actions/create-github-app-token@v1
       with:
-        ssh-private-key: |
-          ${{ secrets.APOLLO_IOS_DEPLOY_KEY }}
-          ${{ secrets.APOLLO_IOS_CODEGEN_DEPLOY_KEY }}
-          ${{ secrets.APOLLO_IOS_DEV_DEPLOY_KEY }}
-          ${{ secrets.APOLLO_IOS_PAGINATION_DEPLOY_KEY }}
+        app-id: ${{ secrets.APOLLO_IOS_SUBTREE_APP_ID }}
+        private-key: ${{ secrets.APOLLO_IOS_SUBTREE_APP_PRIVATE_KEY }}
+        owner: apollographql
+        repositories: |
+          apollo-ios
+          apollo-ios-codegen
+          apollo-ios-pagination
     - name: Configure Git
       uses: ./.github/actions/configure-git
     - name: Subtree - Apollo iOS
@@ -42,7 +45,7 @@ jobs:
       uses: ./.github/actions/subtree-split-push
       with:
         subtree: apollo-ios
-        remote: git@github.com:apollographql/apollo-ios.git
+        remote: https://github.com/apollographql/apollo-ios.git
         target-branch: ${{ github.event.pull_request.base.ref }}
         pr-number: ${{ github.event.pull_request.number }}
         pr-title: ${{ github.event.pull_request.title }}
@@ -52,7 +55,7 @@ jobs:
       uses: ./.github/actions/subtree-split-push
       with:
         subtree: apollo-ios-codegen
-        remote: git@github.com:apollographql/apollo-ios-codegen.git
+        remote: https://github.com/apollographql/apollo-ios-codegen.git
         target-branch: ${{ github.event.pull_request.base.ref }}
         pr-number: ${{ github.event.pull_request.number }}
         pr-title: ${{ github.event.pull_request.title }}
@@ -62,23 +65,31 @@ jobs:
       uses: ./.github/actions/subtree-split-push
       with:
         subtree: apollo-ios-pagination
-        remote: git@github.com:apollographql/apollo-ios-pagination.git
+        remote: https://github.com/apollographql/apollo-ios-pagination.git
         target-branch: ${{ github.event.pull_request.base.ref }}
         pr-number: ${{ github.event.pull_request.number }}
         pr-title: ${{ github.event.pull_request.title }}
     - name: Push Subtrees
       if: success()
       shell: bash
+      env:
+        GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
-        if [ -n "${{ steps.split-ios.outputs.split-sha }}" ]; then
-          git push git@github.com:apollographql/apollo-ios.git ${{ steps.split-ios.outputs.split-sha }}:refs/heads/${{ github.event.pull_request.base.ref }}
-        fi
-        if [ -n "${{ steps.split-codegen.outputs.split-sha }}" ]; then
-          git push git@github.com:apollographql/apollo-ios-codegen.git ${{ steps.split-codegen.outputs.split-sha }}:refs/heads/${{ github.event.pull_request.base.ref }}
-        fi
-        if [ -n "${{ steps.split-pagination.outputs.split-sha }}" ]; then
-          git push git@github.com:apollographql/apollo-ios-pagination.git ${{ steps.split-pagination.outputs.split-sha }}:refs/heads/${{ github.event.pull_request.base.ref }}
-        fi
+        # Push each split SHA to its upstream main. Uses an HTTPS URL with
+        # the GitHub App installation token in the Authorization header,
+        # so branch protection rules that restrict pushes to the app's
+        # identity will accept these pushes (and reject any others).
+        push_subtree() {
+          local repo="$1"
+          local sha="$2"
+          if [ -z "$sha" ]; then return; fi
+          git -c "http.https://github.com/.extraheader=Authorization: Bearer ${GH_APP_TOKEN}" \
+              push "https://github.com/apollographql/${repo}.git" \
+              "${sha}:refs/heads/${{ github.event.pull_request.base.ref }}"
+        }
+        push_subtree apollo-ios            "${{ steps.split-ios.outputs.split-sha }}"
+        push_subtree apollo-ios-codegen    "${{ steps.split-codegen.outputs.split-sha }}"
+        push_subtree apollo-ios-pagination "${{ steps.split-pagination.outputs.split-sha }}"
     - name: Push Updated History
       if: success()
       shell: bash

--- a/claude/setup-subtree-push-app.md
+++ b/claude/setup-subtree-push-app.md
@@ -1,0 +1,148 @@
+# Setup: Subtree Push GitHub App
+
+This runbook covers the one-time setup required to migrate the `PR Subtree Push` workflow from SSH deploy keys to a GitHub App, and to enforce push restrictions on the three upstream subtree repos.
+
+**Why:** The workflow's "dev is the only writer" invariant is currently a convention, not an enforced rule. Anyone with write access on `apollo-ios`, `apollo-ios-codegen`, or `apollo-ios-pagination` can push directly to `main` today. A GitHub App's identity is the only thing GitHub branch protection can `restrictions`-allow (deploy keys can't be put in that list), so the path to enforcement is: switch the workflow to use an app, then restrict pushes to that app.
+
+## Overview
+
+| Phase | Who | What |
+|---|---|---|
+| 1 | Org admin (you) | Create the GitHub App in the apollographql org |
+| 2 | Org admin (you) | Install the app on the four repos |
+| 3 | Org admin (you) | Add app ID + private key as repo secrets in `apollo-ios-dev` |
+| 4 | (Workflow already updated in this PR) | Merge this PR — workflow uses app token |
+| 5 | Org admin (you) | Verify a test PR's workflow run succeeds end-to-end |
+| 6 | Org admin (you) | Add push restrictions to each upstream `main` |
+| 7 | Org admin (you) | Clean up old deploy keys + secrets |
+
+Phases 1–3 must happen **before** this PR merges, otherwise the workflow will fail on the next PR merge to `main` (missing secrets).
+
+## Phase 1: Create the GitHub App
+
+1. Go to <https://github.com/organizations/apollographql/settings/apps/new>.
+2. Fill in:
+   - **Name:** `Apollo iOS Subtree Push` (or any unique name; lowercase + hyphens get used in the bot's username automatically)
+   - **Homepage URL:** `https://github.com/apollographql/apollo-ios-dev`
+   - **Webhook:** Uncheck "Active" (we don't need webhooks)
+   - **Repository permissions:**
+     - `Contents` → **Read & write** (required for pushing)
+     - `Metadata` → **Read-only** (required by default)
+     - Everything else → **No access**
+   - **Organization permissions:** none
+   - **User permissions:** none
+   - **Where can this GitHub App be installed?** Only on this account
+3. Click **Create GitHub App**.
+4. On the resulting page:
+   - Note the **App ID** at the top — you'll need it for secrets.
+   - Scroll to **Private keys**, click **Generate a private key**. A `.pem` file downloads. Keep this safe — it's effectively the app's password. **Do not commit it anywhere.**
+
+## Phase 2: Install the app on the four repos
+
+1. From the app's settings page, click **Install App** in the left sidebar.
+2. Click **Install** next to `apollographql`.
+3. Choose **Only select repositories** and select:
+   - `apollo-ios`
+   - `apollo-ios-codegen`
+   - `apollo-ios-pagination`
+   - `apollo-ios-dev` _(needed because the workflow runs from this repo and needs to mint a token)_
+4. Click **Install**.
+
+## Phase 3: Add secrets to `apollo-ios-dev`
+
+1. Go to <https://github.com/apollographql/apollo-ios-dev/settings/secrets/actions>.
+2. Click **New repository secret**, add:
+   - **Name:** `APOLLO_IOS_SUBTREE_APP_ID`
+   - **Value:** the App ID from Phase 1
+3. Click **New repository secret** again, add:
+   - **Name:** `APOLLO_IOS_SUBTREE_APP_PRIVATE_KEY`
+   - **Value:** the full contents of the `.pem` file from Phase 1, including the `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines
+
+After saving, you can delete the `.pem` file locally. The secret is the only place it needs to live.
+
+## Phase 4: Merge this PR
+
+With secrets in place, this PR can be merged. The workflow will use the app token on the next PR merge.
+
+## Phase 5: Verify
+
+1. Wait for the next PR to merge to `main` (or trigger a manual one — e.g. a tiny no-op PR touching only this file or a comment).
+2. In the workflow run, confirm:
+   - The **Generate GitHub App Token** step succeeds (no missing-secret errors).
+   - The **Push Subtrees** step succeeds (HTTP 200 / 204 in the logs).
+   - The three upstream `main` branches advance with the new split SHAs.
+3. If anything fails, the deploy keys are **still in place as a fallback** — you can revert this PR's workflow changes without any data loss.
+
+## Phase 6: Add branch protection restrictions
+
+Once Phase 5 passes, lock down the three upstream `main` branches so only the app can push.
+
+For each of `apollo-ios`, `apollo-ios-codegen`, `apollo-ios-pagination`:
+
+1. Go to `https://github.com/apollographql/<repo>/settings/branches`.
+2. Edit the protection rule for `main`.
+3. Check **Restrict who can push to matching branches**.
+4. In the **People, teams, or apps** picker, add the GitHub App you created in Phase 1.
+5. Also worth tightening while you're there:
+   - Check **Do not allow bypassing the above settings** (this is the `enforce_admins: true` setting — applies the rule to admins too).
+   - On `apollo-ios-pagination` specifically, uncheck **Allow force pushes** (it's currently enabled, unlike the other two).
+6. Save the rule.
+
+CLI alternative (for each upstream repo):
+```bash
+gh api -X PUT "repos/apollographql/<repo>/branches/main/protection" --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": ["ci/circleci: gitleaks", "ci/circleci: semgrep"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": {
+    "users": [],
+    "teams": [],
+    "apps": ["apollo-ios-subtree-push"]
+  },
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+(Replace `apollo-ios-subtree-push` with the actual slug GitHub assigns to your app — visible in its settings URL.)
+
+## Phase 7: Clean up
+
+Once the workflow has run successfully a few times with the app:
+
+1. **Remove deploy keys from the upstream repos:**
+   - `https://github.com/apollographql/apollo-ios/settings/keys` — delete the "Subtree Push" key
+   - Same for `apollo-ios-codegen` and `apollo-ios-pagination`
+   - (Leave `apollo-ios-dev`'s deploy key for now — see note below)
+2. **Remove unused secrets from apollo-ios-dev:**
+   - `APOLLO_IOS_DEPLOY_KEY`
+   - `APOLLO_IOS_CODEGEN_DEPLOY_KEY`
+   - `APOLLO_IOS_PAGINATION_DEPLOY_KEY`
+   - (Leave `APOLLO_IOS_DEV_DEPLOY_KEY` — see note below)
+
+**Note on `APOLLO_IOS_DEV_DEPLOY_KEY`:** The "Push Updated History" step pushes back to `apollo-ios-dev/main` using the workflow's checkout credentials (`GITHUB_TOKEN`), not this deploy key. The key may be unused, but verify before removing — there could be other workflows that depend on it.
+
+## Rollback
+
+If anything goes wrong after Phase 6 (branch protection blocking pushes unexpectedly):
+
+1. Edit each upstream's branch protection rule, **uncheck Restrict who can push** — pushes work normally again.
+2. If the workflow itself is broken (e.g., app token minting fails), revert the workflow PR. The deploy keys are still there (until Phase 7) and the previous workflow works as-is.
+
+## Why a GitHub App, not a PAT?
+
+- **No human owner.** Apps aren't tied to a person who might leave the company. PATs (even on a bot user) are.
+- **No seat cost.** Bot users count toward the org's paid-seat quota; apps don't.
+- **Scoped permissions.** The app's permissions are declared once and visible in its config. A PAT's scopes are opaque to anyone but its owner.
+- **Branch protection support.** Both apps and users can be in `restrictions`, but apps are the cleaner choice for automation identities.
+
+## Related files
+
+- `.github/workflows/pr-subtree-push.yml` — the workflow that uses the app token
+- `.github/actions/subtree-split-push/action.yml` — the composite action that does the per-subtree split
+- `claude/ci-subtree-troubleshooting.md` — troubleshooting playbook for when something goes wrong


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft.** Do not merge until Phases 1–3 of `claude/setup-subtree-push-app.md` are complete (GitHub App created, installed on the 4 repos, secrets `APOLLO_IOS_SUBTREE_APP_ID` and `APOLLO_IOS_SUBTREE_APP_PRIVATE_KEY` added to this repo). Merging earlier will fail the next post-merge workflow run with missing-secret errors.

## Summary

Replaces the four SSH deploy keys used by the `PR Subtree Push` workflow with a single GitHub App installation token, minted on the fly via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token). Upstream pushes switch from SSH to HTTPS with the token in the `Authorization` header.

This is groundwork for enforcing the **"`apollo-ios-dev` is the only writer to upstream subtree repos"** invariant via branch protection on `apollo-ios`, `apollo-ios-codegen`, and `apollo-ios-pagination`. Branch protection's `restrictions` list can only include users, teams, or apps — not deploy keys — so the auth identity has to change before that lockdown is possible.

## Sequencing

This PR is the **third** in a series:

1. **#989** _(merged)_ — manual recovery from the stale-upstream pull conflict that wedged CI in May 2026.
2. **[#993](https://github.com/apollographql/apollo-ios-dev/pull/993)** _(open)_ — structural fix: removes the `git subtree pull --squash` step that caused the wedge. Eliminates that specific failure mode.
3. **this PR** — switches workflow auth to a GitHub App, enabling branch protection enforcement of the invariant.

#993 should merge before this one. No file overlap, so rebasing is trivial if anything moves.

## What changed

- `.github/workflows/pr-subtree-push.yml`:
  - Removed `Setup SSH Keys` step (no more deploy keys for upstream pushes).
  - Added `Generate GitHub App Token` step using `actions/create-github-app-token@v1`, scoped to the three upstream repos.
  - Changed upstream remote URLs from `git@github.com:...` to `https://github.com/...`.
  - Rewrote `Push Subtrees` to use a `push_subtree` helper that injects the app token via `git -c http.extraheader=Authorization: Bearer …`.
- `claude/setup-subtree-push-app.md` — new runbook documenting the seven-phase migration (app creation through deploy-key cleanup), including a rollback procedure if branch protection misconfiguration locks out the workflow.

## What you (human) need to do

Phases 1–3 from the runbook, in order. Roughly 15 minutes total:

1. Create the GitHub App in <https://github.com/organizations/apollographql/settings/apps/new> with `Contents: write` + `Metadata: read`, no webhooks.
2. Install it on `apollo-ios`, `apollo-ios-codegen`, `apollo-ios-pagination`, and `apollo-ios-dev`.
3. Add `APOLLO_IOS_SUBTREE_APP_ID` and `APOLLO_IOS_SUBTREE_APP_PRIVATE_KEY` as secrets on `apollo-ios-dev`.

Then mark this PR ready, merge it, and watch the next subtree push workflow run for success.

After that's verified, Phase 6 (branch protection) and Phase 7 (deploy-key cleanup) — see the runbook.

## Safety properties

- **Rollback is cheap.** Old deploy keys remain in place until Phase 7. If the app approach breaks, revert this PR and the previous workflow resumes working as-is.
- **No upstream changes happen in this PR.** The push URLs change scheme, but they target the same branches with the same fast-forward semantics established by #993.
- **Token scope is minimal.** The installation token is scoped to only the three subtree repos with `contents: write`. It has no access to other apollographql repos.

## Test plan
- [ ] Phases 1–3 completed (manual setup verified in the apollographql org).
- [ ] Mark this PR ready for review.
- [ ] CI checks pass.
- [ ] On merge, the next subtree push workflow run uses the app token; all three upstream pushes succeed.
- [ ] Verify upstream HEADs advance correctly.
- [ ] Proceed to Phase 6 (branch protection) per the runbook.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>