### PR TITLE
ci: Fix Xcode/Simulator versions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  XCODE_VERSION: "26.1"
+  XCODE_VERSION: "26.5"
 
 jobs:
   changes:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -10,7 +10,7 @@ on:
 env:
   BRANCH_NAME: "release/${{ github.event.inputs.versionNumber }}"
   VERSION_NUMBER: ${{ github.event.inputs.versionNumber }}
-  XCODE_VERSION: "26.1"
+  XCODE_VERSION: "26.5"
 
 jobs:
   create-release-pr:

--- a/.github/workflows/nightly-health-check.yml
+++ b/.github/workflows/nightly-health-check.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 7 * * *"
 
 env:
-  XCODE_VERSION: "26.1"
+  XCODE_VERSION: "26.5"
 
 jobs:
   tuist-generation:

--- a/.github/workflows/nightly-health-check.yml
+++ b/.github/workflows/nightly-health-check.yml
@@ -67,13 +67,13 @@ jobs:
             name: Apollo Unit Tests - macOS
             run-js-tests: false
           # iOS_current
-          - destination: platform=iOS Simulator,OS=26.1,name=iPhone 17
+          - destination: platform=iOS Simulator,OS=26.5,name=iPhone 17
             scheme: ApolloTests
             test-plan: Apollo-CITestPlan
             name: Apollo Unit Tests - iOS
             run-js-tests: false
           # tvOS_current
-          - destination: platform=tvOS Simulator,OS=26.1,name=Apple TV
+          - destination: platform=tvOS Simulator,OS=26.5,name=Apple TV
             scheme: ApolloTests
             test-plan: Apollo-CITestPlan
             name: Apollo Unit Tests - tvOS


### PR DESCRIPTION
The nightly build is consistently [failing due to not being able to match the specified test device](https://github.com/apollographql/apollo-ios-dev/actions/runs/26391366687/job/77681766291#step:5:18). This PR gets it to the latest version of Xcode available in the GitHub images and the correct simulator versions to match.