### PR TITLE
docs(cache): add progress-tracker update to §4.7 on-merge checklist

### DIFF
--- a/apollo-ios/Design/cache-rewrite-phase1-execution.md
+++ b/apollo-ios/Design/cache-rewrite-phase1-execution.md
@@ -169,7 +169,8 @@ Quality gates per §5 must all be green before opening the PR. If any gate fails
 1. Pull the merged change into local `main` (or the merged base).
 2. Rebase the next stacked PR onto the new base; resolve any conflicts.
 3. Re-verify the next PR's quality gates after rebase.
-4. Continue with the next PR.
+4. Update the progress tracker in the plan-branch PR's description (the long-lived PR with base `main` and head `cache-rewrite/phase-1-plan`): flip the merged PR's row from 🟡 to ✅, fill in the merge date, and adjust per-phase / overall percentages. Done via `gh api repos/.../pulls/{plan-PR-number} -X PATCH -F body=@…` per the dev-repo's GitHub-CLI workaround in `CLAUDE.md`.
+5. Continue with the next PR.
 
 ## 5. Quality gates
 


### PR DESCRIPTION
## Summary

Codifies the new workflow obligation that emerged from a manager request: keep a stack-progress table in the plan-branch PR's description, and update it as each PR merges. Adds one item to execution plan §4.7 *On merge*.

## What's in the diff

Single addition to \`apollo-ios/Design/cache-rewrite-phase1-execution.md\` §4.7, between *Re-verify the next PR's quality gates* and *Continue with the next PR*. Records both the obligation and the mechanical recipe (the \`gh api … PATCH\` GitHub-CLI workaround already documented in \`CLAUDE.md\`).

## Test plan

Docs-only change. The companion tracking table is being added to the plan-branch PR #967's description in the same window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)