### PR TITLE
feat(sqlite): new schema DDL + SchemaVersion + SQLiteSchema namespace (PR-008)

### DIFF
--- a/Tests/ApolloTests/SQLiteDotSwiftDatabaseBehaviorTests.swift
+++ b/Tests/ApolloTests/SQLiteDotSwiftDatabaseBehaviorTests.swift
@@ -17,37 +17,46 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
     XCTAssertEqual(rows.count, 1)
 
     // Use SQLite directly to manipulate the database (cannot be done with ApolloSQLiteDatabase)
-    try dropSQLiteTable(dbURL: sqliteFileURL, tableName: ApolloSQLiteDatabase.tableName)
+    try dropSQLiteTable(dbURL: sqliteFileURL, tableName: SQLiteSchema.recordsTableName)
 
     XCTAssertThrowsError(try db.selectRawRows(forKeys: ["key"]))
   }
 
   // MARK: - schema_metadata
 
-  func test__readSchemaVersion__givenFreshlyCreatedTable_returnsZero() throws {
+  func test__readSchemaVersion__givenFreshlyCreatedTable_returnsNil() throws {
     let db = try ApolloSQLiteDatabase(fileURL: SQLiteTestCacheProvider.temporarySQLiteFileURL())
     try db.createSchemaMetadataTableIfNeeded()
 
-    XCTAssertEqual(try db.readSchemaVersion(), 0)
+    XCTAssertNil(try db.readSchemaVersion())
   }
 
   func test__readSchemaVersion__afterWrite_roundTripsValue() throws {
     let db = try ApolloSQLiteDatabase(fileURL: SQLiteTestCacheProvider.temporarySQLiteFileURL())
     try db.createSchemaMetadataTableIfNeeded()
 
-    try db.writeSchemaVersion(3)
+    try db.writeSchemaVersion(SchemaVersion(major: 3))
 
-    XCTAssertEqual(try db.readSchemaVersion(), 3)
+    XCTAssertEqual(try db.readSchemaVersion(), SchemaVersion(major: 3))
+  }
+
+  func test__readSchemaVersion__afterWriteWithMinor_roundTripsValue() throws {
+    let db = try ApolloSQLiteDatabase(fileURL: SQLiteTestCacheProvider.temporarySQLiteFileURL())
+    try db.createSchemaMetadataTableIfNeeded()
+
+    try db.writeSchemaVersion(SchemaVersion(major: 3, minor: 1))
+
+    XCTAssertEqual(try db.readSchemaVersion(), SchemaVersion(major: 3, minor: 1))
   }
 
   func test__writeSchemaVersion__overwritesPriorValue() throws {
     let db = try ApolloSQLiteDatabase(fileURL: SQLiteTestCacheProvider.temporarySQLiteFileURL())
     try db.createSchemaMetadataTableIfNeeded()
 
-    try db.writeSchemaVersion(1)
-    try db.writeSchemaVersion(3)
+    try db.writeSchemaVersion(SchemaVersion(major: 1))
+    try db.writeSchemaVersion(SchemaVersion(major: 3))
 
-    XCTAssertEqual(try db.readSchemaVersion(), 3)
+    XCTAssertEqual(try db.readSchemaVersion(), SchemaVersion(major: 3))
   }
 
   func test__createSchemaMetadataTableIfNeeded__isIdempotent() throws {
@@ -55,10 +64,10 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
 
     try db.createSchemaMetadataTableIfNeeded()
     try db.createSchemaMetadataTableIfNeeded()
-    try db.writeSchemaVersion(3)
+    try db.writeSchemaVersion(SchemaVersion(major: 3))
     try db.createSchemaMetadataTableIfNeeded()
 
-    XCTAssertEqual(try db.readSchemaVersion(), 3)
+    XCTAssertEqual(try db.readSchemaVersion(), SchemaVersion(major: 3))
   }
 
   func test__readSchemaVersion__persistsAcrossDatabaseHandles() throws {
@@ -66,10 +75,10 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
 
     let writer = try ApolloSQLiteDatabase(fileURL: url)
     try writer.createSchemaMetadataTableIfNeeded()
-    try writer.writeSchemaVersion(3)
+    try writer.writeSchemaVersion(SchemaVersion(major: 3))
 
     let reader = try ApolloSQLiteDatabase(fileURL: url)
-    XCTAssertEqual(try reader.readSchemaVersion(), 3)
+    XCTAssertEqual(try reader.readSchemaVersion(), SchemaVersion(major: 3))
   }
 
   func test__SQLiteNormalizedCache_init__createsSchemaMetadataTable() throws {
@@ -78,10 +87,11 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
     _ = try SQLiteNormalizedCache(fileURL: url)
 
     // Opening a fresh database against the same URL and querying the schema
-    // table should succeed (returning the default of 0) because
-    // `SQLiteNormalizedCache.init` is responsible for creating the table.
+    // table should succeed (returning nil because no version is stamped yet)
+    // because `SQLiteNormalizedCache.init` is responsible for creating the
+    // table.
     let probe = try ApolloSQLiteDatabase(fileURL: url)
-    XCTAssertEqual(try probe.readSchemaVersion(), 0)
+    XCTAssertNil(try probe.readSchemaVersion())
   }
 
   // MARK: - createNewRecordsTableIfNeeded
@@ -95,18 +105,18 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
 
     // Verify the table exists by reading its CREATE statement from
     // sqlite_master. Returning a non-empty SQL string confirms creation.
-    let createSQL = try readTableSQL(dbURL: url, tableName: ApolloSQLiteDatabase.tableName)
+    let createSQL = try readTableSQL(dbURL: url, tableName: SQLiteSchema.recordsTableName)
     XCTAssertFalse(createSQL.isEmpty)
   }
 
-  func test__createNewRecordsTableIfNeeded__stampsSchemaVersionThree() throws {
+  func test__createNewRecordsTableIfNeeded__stampsCurrentSchemaVersion() throws {
     let db = try ApolloSQLiteDatabase(fileURL: SQLiteTestCacheProvider.temporarySQLiteFileURL())
     try db.createSchemaMetadataTableIfNeeded()
 
     try db.createNewRecordsTableIfNeeded()
 
-    XCTAssertEqual(try db.readSchemaVersion(), 3)
-    XCTAssertEqual(ApolloSQLiteDatabase.currentSchemaVersion, 3)
+    XCTAssertEqual(try db.readSchemaVersion(), SQLiteSchema.currentVersion)
+    XCTAssertEqual(SQLiteSchema.currentVersion, SchemaVersion(major: 3, minor: 0))
   }
 
   func test__createNewRecordsTableIfNeeded__isIdempotent() throws {
@@ -118,10 +128,10 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
     try db.createNewRecordsTableIfNeeded()
     try db.createNewRecordsTableIfNeeded()
 
-    XCTAssertEqual(try db.readSchemaVersion(), 3)
+    XCTAssertEqual(try db.readSchemaVersion(), SQLiteSchema.currentVersion)
     // No throw from any of the three calls; same CREATE statement persists.
-    let createSQL = try readTableSQL(dbURL: url, tableName: ApolloSQLiteDatabase.tableName)
-    XCTAssertTrue(createSQL.contains(ApolloSQLiteDatabase.cacheKeyColumnName))
+    let createSQL = try readTableSQL(dbURL: url, tableName: SQLiteSchema.recordsTableName)
+    XCTAssertTrue(createSQL.contains(SQLiteSchema.Records.cacheKey))
   }
 
   func test__createNewRecordsTableIfNeeded__preservesWithoutRowID() throws {
@@ -131,7 +141,7 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
 
     try db.createNewRecordsTableIfNeeded()
 
-    let createSQL = try readTableSQL(dbURL: url, tableName: ApolloSQLiteDatabase.tableName)
+    let createSQL = try readTableSQL(dbURL: url, tableName: SQLiteSchema.recordsTableName)
     XCTAssertTrue(
       createSQL.range(of: "WITHOUT ROWID", options: .caseInsensitive) != nil,
       "Expected CREATE statement to retain WITHOUT ROWID, got: \(createSQL)"
@@ -145,7 +155,7 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
 
     try db.createNewRecordsTableIfNeeded()
 
-    let createSQL = try readTableSQL(dbURL: url, tableName: ApolloSQLiteDatabase.tableName)
+    let createSQL = try readTableSQL(dbURL: url, tableName: SQLiteSchema.recordsTableName)
     // The PRIMARY KEY clause must mention both composite columns; verifying
     // both names appear together in the SQL is sufficient to catch a regression
     // that dropped or reordered the composite key.
@@ -155,10 +165,41 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
       "Expected PRIMARY KEY clause in: \(createSQL)"
     )
     XCTAssertTrue(
-      normalized.contains(ApolloSQLiteDatabase.cacheKeyColumnName) &&
-      normalized.contains(ApolloSQLiteDatabase.fieldNameColumnName),
+      normalized.contains(SQLiteSchema.Records.cacheKey) &&
+      normalized.contains(SQLiteSchema.Records.fieldName),
       "Expected composite (cache_key, field_name) in: \(createSQL)"
     )
+  }
+
+  // MARK: - SchemaVersion parsing
+
+  func test__SchemaVersion_parse__givenDottedFormat_yieldsBothComponents() {
+    let parsed = SchemaVersion("3.1")
+    XCTAssertEqual(parsed, SchemaVersion(major: 3, minor: 1))
+  }
+
+  func test__SchemaVersion_parse__givenBareMajor_yieldsZeroMinor() {
+    let parsed = SchemaVersion("3")
+    XCTAssertEqual(parsed, SchemaVersion(major: 3, minor: 0))
+  }
+
+  func test__SchemaVersion_parse__givenMalformedInput_returnsNil() {
+    XCTAssertNil(SchemaVersion(""))
+    XCTAssertNil(SchemaVersion("abc"))
+    XCTAssertNil(SchemaVersion("3.x"))
+    XCTAssertNil(SchemaVersion("3."))
+    XCTAssertNil(SchemaVersion(".5"))
+  }
+
+  func test__SchemaVersion_description__roundTripsThroughParser() {
+    let original = SchemaVersion(major: 4, minor: 2)
+    XCTAssertEqual(SchemaVersion(original.description), original)
+  }
+
+  func test__SchemaVersion_comparable__ordersByMajorThenMinor() {
+    XCTAssertLessThan(SchemaVersion(major: 1), SchemaVersion(major: 2))
+    XCTAssertLessThan(SchemaVersion(major: 3, minor: 0), SchemaVersion(major: 3, minor: 1))
+    XCTAssertLessThan(SchemaVersion(major: 3, minor: 9), SchemaVersion(major: 4, minor: 0))
   }
 
   private func readTableSQL(dbURL: URL, tableName: String) throws -> String {
@@ -186,7 +227,7 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
     }
     return String(cString: cStr)
   }
-  
+
   private func dropSQLiteTable(dbURL: URL, tableName: String) throws {
     var db: OpaquePointer?
     let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX | SQLITE_OPEN_URI
@@ -194,7 +235,7 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
     if result != SQLITE_OK {
       throw SQLiteError.open(path: dbURL.path, resultCode: result)
     }
-    
+
     let sql = "DROP TABLE IF EXISTS \(tableName)"
     let execResult = sqlite3_exec(db, sql, nil, nil, nil)
     if execResult != SQLITE_OK {

--- a/Tests/ApolloTests/SQLiteDotSwiftDatabaseBehaviorTests.swift
+++ b/Tests/ApolloTests/SQLiteDotSwiftDatabaseBehaviorTests.swift
@@ -83,6 +83,109 @@ class ApolloSQLiteDatabaseBehaviorTests: XCTestCase {
     let probe = try ApolloSQLiteDatabase(fileURL: url)
     XCTAssertEqual(try probe.readSchemaVersion(), 0)
   }
+
+  // MARK: - createNewRecordsTableIfNeeded
+
+  func test__createNewRecordsTableIfNeeded__createsRecordsTable() throws {
+    let url = SQLiteTestCacheProvider.temporarySQLiteFileURL()
+    let db = try ApolloSQLiteDatabase(fileURL: url)
+    try db.createSchemaMetadataTableIfNeeded()
+
+    try db.createNewRecordsTableIfNeeded()
+
+    // Verify the table exists by reading its CREATE statement from
+    // sqlite_master. Returning a non-empty SQL string confirms creation.
+    let createSQL = try readTableSQL(dbURL: url, tableName: ApolloSQLiteDatabase.tableName)
+    XCTAssertFalse(createSQL.isEmpty)
+  }
+
+  func test__createNewRecordsTableIfNeeded__stampsSchemaVersionThree() throws {
+    let db = try ApolloSQLiteDatabase(fileURL: SQLiteTestCacheProvider.temporarySQLiteFileURL())
+    try db.createSchemaMetadataTableIfNeeded()
+
+    try db.createNewRecordsTableIfNeeded()
+
+    XCTAssertEqual(try db.readSchemaVersion(), 3)
+    XCTAssertEqual(ApolloSQLiteDatabase.currentSchemaVersion, 3)
+  }
+
+  func test__createNewRecordsTableIfNeeded__isIdempotent() throws {
+    let url = SQLiteTestCacheProvider.temporarySQLiteFileURL()
+    let db = try ApolloSQLiteDatabase(fileURL: url)
+    try db.createSchemaMetadataTableIfNeeded()
+
+    try db.createNewRecordsTableIfNeeded()
+    try db.createNewRecordsTableIfNeeded()
+    try db.createNewRecordsTableIfNeeded()
+
+    XCTAssertEqual(try db.readSchemaVersion(), 3)
+    // No throw from any of the three calls; same CREATE statement persists.
+    let createSQL = try readTableSQL(dbURL: url, tableName: ApolloSQLiteDatabase.tableName)
+    XCTAssertTrue(createSQL.contains(ApolloSQLiteDatabase.cacheKeyColumnName))
+  }
+
+  func test__createNewRecordsTableIfNeeded__preservesWithoutRowID() throws {
+    let url = SQLiteTestCacheProvider.temporarySQLiteFileURL()
+    let db = try ApolloSQLiteDatabase(fileURL: url)
+    try db.createSchemaMetadataTableIfNeeded()
+
+    try db.createNewRecordsTableIfNeeded()
+
+    let createSQL = try readTableSQL(dbURL: url, tableName: ApolloSQLiteDatabase.tableName)
+    XCTAssertTrue(
+      createSQL.range(of: "WITHOUT ROWID", options: .caseInsensitive) != nil,
+      "Expected CREATE statement to retain WITHOUT ROWID, got: \(createSQL)"
+    )
+  }
+
+  func test__createNewRecordsTableIfNeeded__hasCompositePrimaryKey() throws {
+    let url = SQLiteTestCacheProvider.temporarySQLiteFileURL()
+    let db = try ApolloSQLiteDatabase(fileURL: url)
+    try db.createSchemaMetadataTableIfNeeded()
+
+    try db.createNewRecordsTableIfNeeded()
+
+    let createSQL = try readTableSQL(dbURL: url, tableName: ApolloSQLiteDatabase.tableName)
+    // The PRIMARY KEY clause must mention both composite columns; verifying
+    // both names appear together in the SQL is sufficient to catch a regression
+    // that dropped or reordered the composite key.
+    let normalized = createSQL.replacingOccurrences(of: "\"", with: "")
+    XCTAssertTrue(
+      normalized.contains("PRIMARY KEY"),
+      "Expected PRIMARY KEY clause in: \(createSQL)"
+    )
+    XCTAssertTrue(
+      normalized.contains(ApolloSQLiteDatabase.cacheKeyColumnName) &&
+      normalized.contains(ApolloSQLiteDatabase.fieldNameColumnName),
+      "Expected composite (cache_key, field_name) in: \(createSQL)"
+    )
+  }
+
+  private func readTableSQL(dbURL: URL, tableName: String) throws -> String {
+    var db: OpaquePointer?
+    let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX | SQLITE_OPEN_URI
+    let openResult = sqlite3_open_v2(dbURL.path, &db, flags, nil)
+    guard openResult == SQLITE_OK else {
+      throw SQLiteError.open(path: dbURL.path, resultCode: openResult)
+    }
+    defer { sqlite3_close(db) }
+
+    var stmt: OpaquePointer?
+    let prepareResult = sqlite3_prepare_v2(db, "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", -1, &stmt, nil)
+    guard prepareResult == SQLITE_OK else {
+      throw SQLiteError.prepare(message: "Failed to prepare sqlite_master lookup", resultCode: prepareResult)
+    }
+    defer { sqlite3_finalize(stmt) }
+
+    let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    sqlite3_bind_text(stmt, 1, tableName, -1, sqliteTransient)
+
+    let step = sqlite3_step(stmt)
+    guard step == SQLITE_ROW, let cStr = sqlite3_column_text(stmt, 0) else {
+      return ""
+    }
+    return String(cString: cStr)
+  }
   
   private func dropSQLiteTable(dbURL: URL, tableName: String) throws {
     var db: OpaquePointer?

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -74,75 +74,74 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
   public func createRecordsTableIfNeeded() throws {
     try performSync {
       let sql = """
-      CREATE TABLE IF NOT EXISTS "records" (
-        "_id"  INTEGER,
-        "key"  TEXT UNIQUE,
-        "record"  TEXT,
-        PRIMARY KEY("_id" AUTOINCREMENT)
+      CREATE TABLE IF NOT EXISTS "\(SQLiteSchema.recordsTableName)" (
+        "\(SQLiteSchema.LegacyRecords.id)"      INTEGER,
+        "\(SQLiteSchema.LegacyRecords.key)"     TEXT UNIQUE,
+        "\(SQLiteSchema.LegacyRecords.record)"  TEXT,
+        PRIMARY KEY("\(SQLiteSchema.LegacyRecords.id)" AUTOINCREMENT)
       );
       """
-      try exec(sql, errorMessage: "Failed to create 'records' database table")
+      try exec(sql, errorMessage: "Failed to create '\(SQLiteSchema.recordsTableName)' database table")
     }
   }
 
   public func createNewRecordsTableIfNeeded() throws {
     try performSync {
       let sql = """
-      CREATE TABLE IF NOT EXISTS "\(Self.tableName)" (
-        "\(Self.cacheKeyColumnName)"           TEXT NOT NULL,
-        "\(Self.fieldNameColumnName)"          TEXT NOT NULL,
-        "\(Self.intValueColumnName)"           INTEGER,
-        "\(Self.stringValueColumnName)"        TEXT,
-        "\(Self.floatValueColumnName)"         REAL,
-        "\(Self.boolValueColumnName)"          INTEGER,
-        "\(Self.listValueColumnName)"          TEXT,
-        "\(Self.childKeyValueColumnName)"      TEXT,
-        "\(Self.customScalarValueColumnName)"  TEXT,
-        "\(Self.writtenAtColumnName)"          INTEGER NOT NULL,
-        PRIMARY KEY ("\(Self.cacheKeyColumnName)", "\(Self.fieldNameColumnName)")
+      CREATE TABLE IF NOT EXISTS "\(SQLiteSchema.recordsTableName)" (
+        "\(SQLiteSchema.Records.cacheKey)"           TEXT NOT NULL,
+        "\(SQLiteSchema.Records.fieldName)"          TEXT NOT NULL,
+        "\(SQLiteSchema.Records.intValue)"           INTEGER,
+        "\(SQLiteSchema.Records.stringValue)"        TEXT,
+        "\(SQLiteSchema.Records.floatValue)"         REAL,
+        "\(SQLiteSchema.Records.boolValue)"          INTEGER,
+        "\(SQLiteSchema.Records.listValue)"          TEXT,
+        "\(SQLiteSchema.Records.childKeyValue)"      TEXT,
+        "\(SQLiteSchema.Records.customScalarValue)"  TEXT,
+        "\(SQLiteSchema.Records.writtenAt)"          INTEGER NOT NULL,
+        PRIMARY KEY ("\(SQLiteSchema.Records.cacheKey)", "\(SQLiteSchema.Records.fieldName)")
       ) WITHOUT ROWID;
       """
-      try exec(sql, errorMessage: "Failed to create row-per-field '\(Self.tableName)' database table")
+      try exec(sql, errorMessage: "Failed to create row-per-field '\(SQLiteSchema.recordsTableName)' database table")
     }
-    try writeSchemaVersion(Self.currentSchemaVersion)
+    try writeSchemaVersion(SQLiteSchema.currentVersion)
   }
 
   public func createSchemaMetadataTableIfNeeded() throws {
     try performSync {
       let sql = """
-      CREATE TABLE IF NOT EXISTS "\(Self.schemaMetadataTableName)" (
-        "\(Self.schemaMetadataKeyColumnName)"   TEXT PRIMARY KEY,
-        "\(Self.schemaMetadataValueColumnName)" TEXT
+      CREATE TABLE IF NOT EXISTS "\(SQLiteSchema.Metadata.tableName)" (
+        "\(SQLiteSchema.Metadata.keyColumn)"   TEXT PRIMARY KEY,
+        "\(SQLiteSchema.Metadata.valueColumn)" TEXT
       );
       """
-      try exec(sql, errorMessage: "Failed to create '\(Self.schemaMetadataTableName)' database table")
+      try exec(sql, errorMessage: "Failed to create '\(SQLiteSchema.Metadata.tableName)' database table")
     }
   }
 
-  public func readSchemaVersion() throws -> Int {
+  public func readSchemaVersion() throws -> SchemaVersion? {
     try performSync {
       let sql = """
-      SELECT \(Self.schemaMetadataValueColumnName)
-      FROM \(Self.schemaMetadataTableName)
-      WHERE \(Self.schemaMetadataKeyColumnName) = ?
+      SELECT \(SQLiteSchema.Metadata.valueColumn)
+      FROM \(SQLiteSchema.Metadata.tableName)
+      WHERE \(SQLiteSchema.Metadata.keyColumn) = ?
       """
 
       let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare schema-version read")
       defer { sqlite3_finalize(stmt) }
 
-      sqlite3_bind_text(stmt, 1, Self.schemaVersionMetadataKey, -1, SQLITE_TRANSIENT)
+      sqlite3_bind_text(stmt, 1, SQLiteSchema.Metadata.versionKey, -1, SQLITE_TRANSIENT)
 
       let stepResult = sqlite3_step(stmt)
       switch stepResult {
       case SQLITE_DONE:
-        // No row stored for the schema-version key — treat as version 0.
-        return 0
+        // No row stored for the schema-version key.
+        return nil
       case SQLITE_ROW:
         guard let textPtr = sqlite3_column_text(stmt, 0) else {
-          return 0
+          return nil
         }
-        let raw = String(cString: textPtr)
-        return Int(raw) ?? 0
+        return SchemaVersion(String(cString: textPtr))
       default:
         throw SQLiteError.step(
           message: "Schema-version read failed: \(sqliteErrorMessage())",
@@ -152,19 +151,19 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     }
   }
 
-  public func writeSchemaVersion(_ version: Int) throws {
+  public func writeSchemaVersion(_ version: SchemaVersion) throws {
     try performSync {
       let sql = """
-      INSERT INTO \(Self.schemaMetadataTableName) (\(Self.schemaMetadataKeyColumnName), \(Self.schemaMetadataValueColumnName))
+      INSERT INTO \(SQLiteSchema.Metadata.tableName) (\(SQLiteSchema.Metadata.keyColumn), \(SQLiteSchema.Metadata.valueColumn))
       VALUES (?, ?)
-      ON CONFLICT(\(Self.schemaMetadataKeyColumnName)) DO UPDATE SET \(Self.schemaMetadataValueColumnName) = excluded.\(Self.schemaMetadataValueColumnName)
+      ON CONFLICT(\(SQLiteSchema.Metadata.keyColumn)) DO UPDATE SET \(SQLiteSchema.Metadata.valueColumn) = excluded.\(SQLiteSchema.Metadata.valueColumn)
       """
 
       let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare schema-version write")
       defer { sqlite3_finalize(stmt) }
 
-      sqlite3_bind_text(stmt, 1, Self.schemaVersionMetadataKey, -1, SQLITE_TRANSIENT)
-      sqlite3_bind_text(stmt, 2, String(version), -1, SQLITE_TRANSIENT)
+      sqlite3_bind_text(stmt, 1, SQLiteSchema.Metadata.versionKey, -1, SQLITE_TRANSIENT)
+      sqlite3_bind_text(stmt, 2, version.description, -1, SQLITE_TRANSIENT)
 
       let stepResult = sqlite3_step(stmt)
       if stepResult != SQLITE_DONE {
@@ -187,9 +186,9 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
         let rows = try performSync {
           let placeholders = batch.map { _ in "?" }.joined(separator: ", ")
           let sql = """
-          SELECT \(Self.keyColumnName), \(Self.recordColumName)
-          FROM \(Self.tableName)
-          WHERE \(Self.keyColumnName) IN (\(placeholders))
+          SELECT \(SQLiteSchema.LegacyRecords.key), \(SQLiteSchema.LegacyRecords.record)
+          FROM \(SQLiteSchema.recordsTableName)
+          WHERE \(SQLiteSchema.LegacyRecords.key) IN (\(placeholders))
           """
 
           let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare select statement")
@@ -227,9 +226,9 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
 
     try performSync {
       let sql = """
-      INSERT INTO \(Self.tableName) (\(Self.keyColumnName), \(Self.recordColumName))
+      INSERT INTO \(SQLiteSchema.recordsTableName) (\(SQLiteSchema.LegacyRecords.key), \(SQLiteSchema.LegacyRecords.record))
       VALUES (?, ?)
-      ON CONFLICT(\(Self.keyColumnName)) DO UPDATE SET \(Self.recordColumName) = excluded.\(Self.recordColumName)
+      ON CONFLICT(\(SQLiteSchema.LegacyRecords.key)) DO UPDATE SET \(SQLiteSchema.LegacyRecords.record) = excluded.\(SQLiteSchema.LegacyRecords.record)
       """
 
       try exec("BEGIN TRANSACTION", errorMessage: "Failed to begin insert/update transaction")
@@ -240,7 +239,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
       for (key, record) in records {
         sqlite3_bind_text(stmt, 1, key, -1, SQLITE_TRANSIENT)
         sqlite3_bind_text(stmt, 2, record, -1, SQLITE_TRANSIENT)
-        
+
         let result = sqlite3_step(stmt)
         if result != SQLITE_DONE {
           rollbackTransaction()
@@ -262,7 +261,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
 
   public func deleteRecord(for cacheKey: CacheKey) throws {
     try performSync {
-      let sql = "DELETE FROM \(Self.tableName) WHERE \(Self.keyColumnName) = ?"
+      let sql = "DELETE FROM \(SQLiteSchema.recordsTableName) WHERE \(SQLiteSchema.LegacyRecords.key) = ?"
       let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare delete statement")
       defer { sqlite3_finalize(stmt) }
 
@@ -279,7 +278,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     let wildcardPattern = "%\(pattern)%"
 
     try performSync {
-      let sql = "DELETE FROM \(Self.tableName) WHERE \(Self.keyColumnName) LIKE ? COLLATE NOCASE"
+      let sql = "DELETE FROM \(SQLiteSchema.recordsTableName) WHERE \(SQLiteSchema.LegacyRecords.key) LIKE ? COLLATE NOCASE"
       let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare delete pattern statement")
       defer { sqlite3_finalize(stmt) }
 
@@ -293,7 +292,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
 
   public func clearDatabase(shouldVacuumOnClear: Bool) throws {
     try performSync {
-      try exec("DELETE FROM \(Self.tableName)", errorMessage: "Failed to clear database")
+      try exec("DELETE FROM \(SQLiteSchema.recordsTableName)", errorMessage: "Failed to clear database")
       if shouldVacuumOnClear {
         try exec("VACUUM;", errorMessage: "Failed to vacuum database")
       }

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -85,6 +85,28 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     }
   }
 
+  public func createNewRecordsTableIfNeeded() throws {
+    try performSync {
+      let sql = """
+      CREATE TABLE IF NOT EXISTS "\(Self.tableName)" (
+        "\(Self.cacheKeyColumnName)"           TEXT NOT NULL,
+        "\(Self.fieldNameColumnName)"          TEXT NOT NULL,
+        "\(Self.intValueColumnName)"           INTEGER,
+        "\(Self.stringValueColumnName)"        TEXT,
+        "\(Self.floatValueColumnName)"         REAL,
+        "\(Self.boolValueColumnName)"          INTEGER,
+        "\(Self.listValueColumnName)"          TEXT,
+        "\(Self.childKeyValueColumnName)"      TEXT,
+        "\(Self.customScalarValueColumnName)"  TEXT,
+        "\(Self.writtenAtColumnName)"          INTEGER NOT NULL,
+        PRIMARY KEY ("\(Self.cacheKeyColumnName)", "\(Self.fieldNameColumnName)")
+      ) WITHOUT ROWID;
+      """
+      try exec(sql, errorMessage: "Failed to create row-per-field '\(Self.tableName)' database table")
+    }
+    try writeSchemaVersion(Self.currentSchemaVersion)
+  }
+
   public func createSchemaMetadataTableIfNeeded() throws {
     try performSync {
       let sql = """

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -37,6 +37,16 @@ public protocol SQLiteDatabase {
 
   func createRecordsTableIfNeeded() throws
 
+  /// Creates the row-per-field records table if it doesn't exist, and
+  /// stamps `schema_metadata.version` with `currentSchemaVersion`. The
+  /// table uses a composite `(cache_key, field_name)` primary key and is
+  /// declared `WITHOUT ROWID` so rows for one record cluster on disk in
+  /// primary-key order, which keeps batched reads sequential.
+  ///
+  /// The caller must ensure the schema-metadata table already exists
+  /// (call `createSchemaMetadataTableIfNeeded()` first).
+  func createNewRecordsTableIfNeeded() throws
+
   /// Creates the schema-metadata table if it doesn't exist. The table is a
   /// key/value store keyed on `String`; the only reserved key currently
   /// recognized is `version`, holding the integer schema version of the
@@ -110,4 +120,27 @@ public extension SQLiteDatabase {
   static var schemaVersionMetadataKey: String {
     "version"
   }
+
+  /// The schema version that the row-per-field records table layout
+  /// corresponds to. `createNewRecordsTableIfNeeded()` stamps this value
+  /// into `schema_metadata` so older databases can be detected by reading
+  /// `readSchemaVersion()` and comparing.
+  static var currentSchemaVersion: Int {
+    3
+  }
+
+  // Column names for the row-per-field `records` table created by
+  // `createNewRecordsTableIfNeeded()`. The legacy single-row table
+  // continues to use `idColumnName`/`keyColumnName`/`recordColumName`.
+
+  static var cacheKeyColumnName: String { "cache_key" }
+  static var fieldNameColumnName: String { "field_name" }
+  static var intValueColumnName: String { "int_value" }
+  static var stringValueColumnName: String { "string_value" }
+  static var floatValueColumnName: String { "float_value" }
+  static var boolValueColumnName: String { "bool_value" }
+  static var listValueColumnName: String { "list_value" }
+  static var childKeyValueColumnName: String { "child_key_value" }
+  static var customScalarValueColumnName: String { "custom_scalar_value" }
+  static var writtenAtColumnName: String { "written_at" }
 }

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -16,7 +16,7 @@ public enum SQLiteError: Error, CustomStringConvertible {
   case open(path: String, resultCode: Int32)
   case prepare(message: String, resultCode: Int32)
   case step(message: String, resultCode: Int32)
-  
+
   public var description: String {
     switch self {
     case .execution(let message, _):
@@ -38,8 +38,8 @@ public protocol SQLiteDatabase {
   func createRecordsTableIfNeeded() throws
 
   /// Creates the row-per-field records table if it doesn't exist, and
-  /// stamps `schema_metadata.version` with `currentSchemaVersion`. The
-  /// table uses a composite `(cache_key, field_name)` primary key and is
+  /// stamps `SQLiteSchema.Metadata.versionKey` with `SQLiteSchema.currentVersion`.
+  /// The table uses a composite `(cache_key, field_name)` primary key and is
   /// declared `WITHOUT ROWID` so rows for one record cluster on disk in
   /// primary-key order, which keeps batched reads sequential.
   ///
@@ -49,19 +49,20 @@ public protocol SQLiteDatabase {
 
   /// Creates the schema-metadata table if it doesn't exist. The table is a
   /// key/value store keyed on `String`; the only reserved key currently
-  /// recognized is `version`, holding the integer schema version of the
-  /// records table layout (read via `readSchemaVersion()`).
+  /// recognized is `SQLiteSchema.Metadata.versionKey`, holding the
+  /// `SchemaVersion` of the records-table layout (read via `readSchemaVersion()`).
   func createSchemaMetadataTableIfNeeded() throws
 
-  /// Returns the integer schema version stamped in the metadata table, or
-  /// `0` when no row exists. Callers use the value to decide whether the
-  /// stored data needs to be migrated to a newer schema layout.
-  func readSchemaVersion() throws -> Int
+  /// Returns the `SchemaVersion` stamped in the metadata table, or `nil` if
+  /// no version row exists or the stored value cannot be parsed. Callers
+  /// use the value to decide whether the stored data needs to be migrated
+  /// to a newer schema layout.
+  func readSchemaVersion() throws -> SchemaVersion?
 
-  /// Writes the integer schema version into the metadata table, replacing
-  /// any prior value. The metadata table must already exist; the caller is
+  /// Writes the `SchemaVersion` into the metadata table, replacing any
+  /// prior value. The metadata table must already exist; the caller is
   /// expected to call `createSchemaMetadataTableIfNeeded()` first.
-  func writeSchemaVersion(_ version: Int) throws
+  func writeSchemaVersion(_ version: SchemaVersion) throws
 
   func selectRawRows(forKeys keys: Set<CacheKey>) throws -> [DatabaseRow]
 
@@ -84,63 +85,4 @@ extension SQLiteDatabase {
     try addOrUpdate(records: [(cacheKey, recordString)])
   }
 
-}
-
-public extension SQLiteDatabase {
-
-  static var tableName: String {
-    "records"
-  }
-
-  static var idColumnName: String {
-    "_id"
-  }
-
-  static var keyColumnName: String {
-    "key"
-  }
-
-  static var recordColumName: String {
-    "record"
-  }
-
-  static var schemaMetadataTableName: String {
-    "schema_metadata"
-  }
-
-  static var schemaMetadataKeyColumnName: String {
-    "key"
-  }
-
-  static var schemaMetadataValueColumnName: String {
-    "value"
-  }
-
-  /// The metadata key under which the records-table schema version is stored.
-  static var schemaVersionMetadataKey: String {
-    "version"
-  }
-
-  /// The schema version that the row-per-field records table layout
-  /// corresponds to. `createNewRecordsTableIfNeeded()` stamps this value
-  /// into `schema_metadata` so older databases can be detected by reading
-  /// `readSchemaVersion()` and comparing.
-  static var currentSchemaVersion: Int {
-    3
-  }
-
-  // Column names for the row-per-field `records` table created by
-  // `createNewRecordsTableIfNeeded()`. The legacy single-row table
-  // continues to use `idColumnName`/`keyColumnName`/`recordColumName`.
-
-  static var cacheKeyColumnName: String { "cache_key" }
-  static var fieldNameColumnName: String { "field_name" }
-  static var intValueColumnName: String { "int_value" }
-  static var stringValueColumnName: String { "string_value" }
-  static var floatValueColumnName: String { "float_value" }
-  static var boolValueColumnName: String { "bool_value" }
-  static var listValueColumnName: String { "list_value" }
-  static var childKeyValueColumnName: String { "child_key_value" }
-  static var customScalarValueColumnName: String { "custom_scalar_value" }
-  static var writtenAtColumnName: String { "written_at" }
 }

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteSchema.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteSchema.swift
@@ -1,0 +1,50 @@
+/// Compile-time constants for the SQLite cache database schema.
+///
+/// Grouped to make table boundaries explicit and to avoid free-floating
+/// static properties on `SQLiteDatabase`. The two records-table layouts
+/// share a physical table name (`recordsTableName`); only the column set
+/// differs.
+public enum SQLiteSchema {
+
+  /// The records-table schema version that this build of Apollo iOS reads
+  /// and writes. Stamped into `Metadata` on a fresh database; consulted by
+  /// later openers to decide whether the on-disk layout needs to be
+  /// migrated to the current shape.
+  public static var currentVersion: SchemaVersion {
+    SchemaVersion(major: 3, minor: 0)
+  }
+
+  /// Shared physical name of the records table across both layouts.
+  public static let recordsTableName = "records"
+
+  /// Columns for the row-per-field records-table layout.
+  public enum Records {
+    public static let cacheKey = "cache_key"
+    public static let fieldName = "field_name"
+    public static let intValue = "int_value"
+    public static let stringValue = "string_value"
+    public static let floatValue = "float_value"
+    public static let boolValue = "bool_value"
+    public static let listValue = "list_value"
+    public static let childKeyValue = "child_key_value"
+    public static let customScalarValue = "custom_scalar_value"
+    public static let writtenAt = "written_at"
+  }
+
+  /// Columns for the legacy single-row JSON-blob records-table layout used
+  /// by pre-3.0 Apollo iOS caches. Still referenced while migration support
+  /// from older caches lives in the SQLite layer.
+  public enum LegacyRecords {
+    public static let id = "_id"
+    public static let key = "key"
+    public static let record = "record"
+  }
+
+  /// Names and columns for the `schema_metadata` key/value table.
+  public enum Metadata {
+    public static let tableName = "schema_metadata"
+    public static let keyColumn = "key"
+    public static let valueColumn = "value"
+    public static let versionKey = "version"
+  }
+}

--- a/apollo-ios/Sources/ApolloSQLite/SchemaVersion.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SchemaVersion.swift
@@ -20,20 +20,21 @@ public struct SchemaVersion: Sendable, Hashable, Comparable, CustomStringConvert
   /// input. A bare integer (`"3"`) is treated as `"3.0"` so older stamps that
   /// omitted the minor component still load.
   public init?(_ rawValue: String) {
-    let trimmed = rawValue.trimmingCharacters(in: .whitespaces)
-    guard !trimmed.isEmpty else { return nil }
-
-    let parts = trimmed.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
-    guard let parsedMajor = Int(parts[0]) else { return nil }
-
-    if parts.count == 1 {
-      self.major = parsedMajor
-      self.minor = 0
+    let majorPart: Substring
+    let minorPart: Substring
+    if let dot = rawValue.firstIndex(of: ".") {
+      majorPart = rawValue[..<dot]
+      minorPart = rawValue[rawValue.index(after: dot)...]
     } else {
-      guard let parsedMinor = Int(parts[1]) else { return nil }
-      self.major = parsedMajor
-      self.minor = parsedMinor
+      majorPart = Substring(rawValue)
+      minorPart = "0"
     }
+
+    guard let major = Int(majorPart), let minor = Int(minorPart) else {
+      return nil
+    }
+    self.major = major
+    self.minor = minor
   }
 
   public var description: String {

--- a/apollo-ios/Sources/ApolloSQLite/SchemaVersion.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SchemaVersion.swift
@@ -1,0 +1,47 @@
+/// A dotted-decimal version tag for the SQLite records-table layout.
+///
+/// `major` typically aligns with the Apollo iOS major release that introduces
+/// a schema change; `minor` allows for incremental schema iterations within
+/// the same major release. Ordering is lexicographic over `(major, minor)`.
+///
+/// The on-disk representation is the `description` string (`"M.m"`),
+/// stored as TEXT in the `schema_metadata` table.
+public struct SchemaVersion: Sendable, Hashable, Comparable, CustomStringConvertible {
+
+  public let major: Int
+  public let minor: Int
+
+  public init(major: Int, minor: Int = 0) {
+    self.major = major
+    self.minor = minor
+  }
+
+  /// Parses a string formatted as `"M.m"` or `"M"`. Returns `nil` for malformed
+  /// input. A bare integer (`"3"`) is treated as `"3.0"` so older stamps that
+  /// omitted the minor component still load.
+  public init?(_ rawValue: String) {
+    let trimmed = rawValue.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return nil }
+
+    let parts = trimmed.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+    guard let parsedMajor = Int(parts[0]) else { return nil }
+
+    if parts.count == 1 {
+      self.major = parsedMajor
+      self.minor = 0
+    } else {
+      guard let parsedMinor = Int(parts[1]) else { return nil }
+      self.major = parsedMajor
+      self.minor = parsedMinor
+    }
+  }
+
+  public var description: String {
+    "\(major).\(minor)"
+  }
+
+  public static func < (lhs: SchemaVersion, rhs: SchemaVersion) -> Bool {
+    if lhs.major != rhs.major { return lhs.major < rhs.major }
+    return lhs.minor < rhs.minor
+  }
+}


### PR DESCRIPTION
## Summary

PR-008 per [execution plan §8](apollo-ios/Design/cache-rewrite-phase1-execution.md). Adds the row-per-field records-table DDL alongside the existing legacy layout. Also folds in two small refinements landed on review feedback:

- **Dotted-decimal `SchemaVersion`** — schema versions are now structured `(major, minor)` tuples (e.g. `SchemaVersion(major: 3, minor: 0)`) stored on disk as the dotted string `"3.0"`. Leaves room for minor schema iterations within a major Apollo release without burning a major version.
- **`SQLiteSchema` namespace enum** — every SQLite name constant is grouped into a single top-level caseless enum (`SQLiteSchema.Records.cacheKey`, `SQLiteSchema.LegacyRecords.id`, `SQLiteSchema.Metadata.versionKey`, etc.), replacing the scattered statics that were previously attached to the `SQLiteDatabase` extension.

Nothing calls the new creator yet — that's PR-010's job — so this PR is purely additive infrastructure with its own tests.

## What's in the diff

**New DDL.** `SQLiteDatabase.createNewRecordsTableIfNeeded()` issues `CREATE TABLE IF NOT EXISTS records` against the new schema (see [engineering plan §7.1](apollo-ios/Design/cache-rewrite-phase1-plan.md)):

- composite primary key on `(cache_key, field_name)`
- `WITHOUT ROWID` so rows for one record cluster on disk in PK order — batched reads scan sequentially
- typed value columns (`int_value`, `string_value`, `float_value`, `bool_value`, `list_value`, `child_key_value`, `custom_scalar_value`)
- `written_at INTEGER NOT NULL` for per-field TTL evaluation

After the table is created (or confirmed to exist), the method stamps `SQLiteSchema.Metadata.versionKey` with `SQLiteSchema.currentVersion` (= `SchemaVersion(major: 3, minor: 0)`) via `writeSchemaVersion(_:)`.

**`SchemaVersion` value type** (`apollo-ios/Sources/ApolloSQLite/SchemaVersion.swift`):
```swift
public struct SchemaVersion: Sendable, Hashable, Comparable, CustomStringConvertible {
  public let major: Int
  public let minor: Int

  public init(major: Int, minor: Int = 0)
  public init?(_ rawValue: String)   // "M.m" or "M"
  public var description: String     // "M.m"
}
```

The parser accepts both `"3"` and `"3.0"` so older stamps that omitted the minor component still load. `readSchemaVersion()` returns `SchemaVersion?` — `nil` for a missing or malformed row.

**`SQLiteSchema` namespace** (`apollo-ios/Sources/ApolloSQLite/SQLiteSchema.swift`):
```swift
public enum SQLiteSchema {
  public static var currentVersion: SchemaVersion { SchemaVersion(major: 3, minor: 0) }
  public static let recordsTableName = "records"

  public enum Records {       // row-per-field columns
    public static let cacheKey = "cache_key"
    public static let fieldName = "field_name"
    // ... typed value columns + writtenAt
  }
  public enum LegacyRecords { // JSON-blob columns
    public static let id = "_id"
    public static let key = "key"
    public static let record = "record"
  }
  public enum Metadata {      // schema_metadata table
    public static let tableName = "schema_metadata"
    public static let keyColumn = "key"
    public static let valueColumn = "value"
    public static let versionKey = "version"
  }
}
```

Every call site in `ApolloSQLiteDatabase` and the tests now reads from `SQLiteSchema`. The previous free-floating statics on `SQLiteDatabase` extension are removed.

**Legacy layout untouched.** `createRecordsTableIfNeeded()` still creates the JSON-blob layout via `SQLiteSchema.LegacyRecords.*` columns. The new method is not called from anywhere yet — it'll be wired into the cache's init in PR-010 (drop-and-rebuild migration). PR-009 will use it to test CRUD against the new schema.

## Acceptance ([execution plan §8](apollo-ios/Design/cache-rewrite-phase1-execution.md))

- [x] Table creation idempotent — `test__createNewRecordsTableIfNeeded__isIdempotent`
- [x] `WITHOUT ROWID` preserved — `test__createNewRecordsTableIfNeeded__preservesWithoutRowID` (reads the CREATE statement back from `sqlite_master`)
- [x] `schema_metadata.version=3` stamped — `test__createNewRecordsTableIfNeeded__stampsCurrentSchemaVersion`

Additional coverage:
- Composite primary key preserved — `test__createNewRecordsTableIfNeeded__hasCompositePrimaryKey`
- Dotted minor versions round-trip — `test__readSchemaVersion__afterWriteWithMinor_roundTripsValue`
- Bare-major strings still parse — `test__SchemaVersion_parse__givenBareMajor_yieldsZeroMinor`
- Malformed values return nil — `test__SchemaVersion_parse__givenMalformedInput_returnsNil`
- `SchemaVersion` Comparable ordering — `test__SchemaVersion_comparable__ordersByMajorThenMinor`

## Test plan

- Full `Apollo-UnitTestPlan`: **1,001 tests passing, 0 failing** on macOS

## Stack

- Base: `cache-rewrite/phase-1-plan` (PR-007 #999 merged)
- Head: `cache-rewrite/phase-1a-new-records-schema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
