### PR TITLE
feat(sqlite): row-per-element CRUD against position-keyed schema (PR-009)

### DIFF
--- a/Tests/ApolloTests/SQLiteRowPerElementCRUDTests.swift
+++ b/Tests/ApolloTests/SQLiteRowPerElementCRUDTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Nimble
 @testable @_spi(Execution) import Apollo
 @testable import ApolloSQLite
 import ApolloInternalTestHelpers
@@ -149,12 +150,57 @@ class SQLiteRowPerElementCRUDTests: XCTestCase {
     try db.insertOrUpdate(records: [original])
 
     let loaded = try db.selectRecords(forKeys: ["User:1"])
-    // An empty list writes zero element rows. With no scalar row and
-    // no list rows, the field is indistinguishable from "never
-    // written" — the documented behavior of the row-per-element
-    // schema. The record itself has no fields and is therefore not
-    // present in the result set.
-    XCTAssertEqual(loaded.count, 0)
+    // An empty list writes a single marker row (`position = -2`) so
+    // it stays distinguishable from a never-written field:
+    // `colors: []` is cached, valid data — not a cache miss.
+    expect(loaded).to(haveCount(1))
+    let reloaded = loaded[0].fields["colors"]?.value as? [Any]
+    expect(reloaded).toNot(beNil())
+    expect(reloaded).to(beEmpty())
+    expect(loaded[0].fields["colors"]?.writtenAt).to(equal(100))
+  }
+
+  func test__insertOrUpdate__overwritingNonEmptyListWithEmptyList__readsBackEmptyList() throws {
+    let db = try makeDatabase()
+    let full: [Record.Value] = ["red", "green"]
+    try db.insertOrUpdate(records: [Record(
+      key: "User:1",
+      fields: ["colors": CachedField(value: full as Record.Value, writtenAt: 100)]
+    )])
+
+    let empty: [Record.Value] = []
+    try db.insertOrUpdate(records: [Record(
+      key: "User:1",
+      fields: ["colors": CachedField(value: empty as Record.Value, writtenAt: 200)]
+    )])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    expect(loaded).to(haveCount(1))
+    let reloaded = loaded[0].fields["colors"]?.value as? [Any]
+    expect(reloaded).toNot(beNil())
+    expect(reloaded).to(beEmpty())
+    expect(loaded[0].fields["colors"]?.writtenAt).to(equal(200))
+  }
+
+  func test__insertOrUpdate__overwritingEmptyListWithNonEmptyList__readsBackElements() throws {
+    let db = try makeDatabase()
+    let empty: [Record.Value] = []
+    try db.insertOrUpdate(records: [Record(
+      key: "User:1",
+      fields: ["colors": CachedField(value: empty as Record.Value, writtenAt: 100)]
+    )])
+
+    let full: [Record.Value] = ["red", "green"]
+    try db.insertOrUpdate(records: [Record(
+      key: "User:1",
+      fields: ["colors": CachedField(value: full as Record.Value, writtenAt: 200)]
+    )])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    let reloaded = loaded[0].fields["colors"]?.value as? [Any]
+    expect(reloaded).to(haveCount(2))
+    expect(reloaded?[0] as? String).to(equal("red"))
+    expect(reloaded?[1] as? String).to(equal("green"))
   }
 
   // MARK: - Nested lists (2D, 3D)
@@ -204,6 +250,53 @@ class SQLiteRowPerElementCRUDTests: XCTestCase {
     let level2 = level1?[0] as? [Any]
     XCTAssertEqual(level2?[0] as? Int, 5,
                    "3D nesting should round-trip through two synthetic sub-records")
+  }
+
+  func test__roundTrip__nestedList_containingEmptyInnerList() throws {
+    let db = try makeDatabase()
+    // `[[1, 2], []]` — the empty inner list must survive the
+    // synthetic sub-record round-trip as `[]`, not leak a dangling
+    // `CacheReference` to the (row-less) synthetic key.
+    let row0: [Record.Value] = [1, 2]
+    let row1: [Record.Value] = []
+    let matrix: [Record.Value] = [row0 as Record.Value, row1 as Record.Value]
+    let original = Record(
+      key: "Math:1",
+      fields: ["matrix": CachedField(value: matrix as Record.Value, writtenAt: 100)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["Math:1"])
+    let reloadedOuter = loaded[0].fields["matrix"]?.value as? [Any]
+    expect(reloadedOuter).to(haveCount(2))
+    let inner0 = reloadedOuter?[0] as? [Any]
+    expect(inner0?.count).to(equal(2))
+    expect(inner0?[0] as? Int).to(equal(1))
+    expect(reloadedOuter?[1] as? CacheReference).to(beNil())
+    let inner1 = reloadedOuter?[1] as? [Any]
+    expect(inner1).toNot(beNil())
+    expect(inner1).to(beEmpty())
+  }
+
+  func test__roundTrip__nestedList_singleEmptyInnerList() throws {
+    let db = try makeDatabase()
+    // `[[]]` — a one-element outer list whose only element is empty.
+    let inner: [Record.Value] = []
+    let outer: [Record.Value] = [inner as Record.Value]
+    let original = Record(
+      key: "Math:1",
+      fields: ["matrix": CachedField(value: outer as Record.Value, writtenAt: 100)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["Math:1"])
+    let reloadedOuter = loaded[0].fields["matrix"]?.value as? [Any]
+    expect(reloadedOuter).to(haveCount(1))
+    let inner0 = reloadedOuter?[0] as? [Any]
+    expect(inner0).toNot(beNil())
+    expect(inner0).to(beEmpty())
   }
 
   func test__roundTrip__nestedList_listOfReferences() throws {
@@ -522,6 +615,39 @@ class SQLiteRowPerElementCRUDTests: XCTestCase {
 
     let loaded = try db.selectRecords(forKeys: ["Stock:AAPL"])
     XCTAssertEqual(loaded[0].fields["price"]?.value as? Double, 199.25)
+  }
+
+  // MARK: - Reserved-key audit (ADR 0006)
+
+  func test__insertOrUpdate__givenKeyContainingReservedSyntheticToken__throwsAndWritesNothing() throws {
+    let db = try makeDatabase()
+    // `.$[` is reserved for synthetic sub-record keys. A user key
+    // containing it (even without the trailing-digits shape the regex
+    // classifier requires) must be rejected so the SQL `LIKE`
+    // classifier can never match a stored user record.
+    let reserved = record("Order:receipt.$[final]", fields: ["total": 10])
+
+    expect { try db.insertOrUpdate(records: [reserved]) }.to(throwError { error in
+      guard case SQLiteError.reservedCacheKey(let key) = error else {
+        fail("Expected SQLiteError.reservedCacheKey, got \(error)")
+        return
+      }
+      expect(key).to(equal("Order:receipt.$[final]"))
+    })
+
+    expect(try db.selectRecords(forKeys: ["Order:receipt.$[final]"])).to(beEmpty())
+  }
+
+  func test__insertOrUpdate__givenReservedKeyAnywhereInBatch__writesNoRecordsFromBatch() throws {
+    let db = try makeDatabase()
+    let good = record("User:1", fields: ["name": "Anthony"])
+    let reserved = record("Item:x.$[3]", fields: ["qty": 1])
+
+    expect { try db.insertOrUpdate(records: [good, reserved]) }.to(throwError())
+
+    // The audit runs before the transaction opens: the valid record
+    // in the same batch is not written either.
+    expect(try db.selectRecords(forKeys: ["User:1"])).to(beEmpty())
   }
 
   // MARK: - Documented empty-record behavior

--- a/Tests/ApolloTests/SQLiteRowPerElementCRUDTests.swift
+++ b/Tests/ApolloTests/SQLiteRowPerElementCRUDTests.swift
@@ -1,0 +1,553 @@
+import XCTest
+@testable @_spi(Execution) import Apollo
+@testable import ApolloSQLite
+import ApolloInternalTestHelpers
+
+class SQLiteRowPerElementCRUDTests: XCTestCase {
+
+  // MARK: - Helpers
+
+  private func makeDatabase() throws -> ApolloSQLiteDatabase {
+    let db = try ApolloSQLiteDatabase(fileURL: SQLiteTestCacheProvider.temporarySQLiteFileURL())
+    try db.createSchemaMetadataTableIfNeeded()
+    try db.createNewRecordsTableIfNeeded()
+    return db
+  }
+
+  private func record(
+    _ key: CacheKey,
+    fields: [CacheKey: any Hashable & Sendable],
+    writtenAt: Int64 = 100
+  ) -> Record {
+    Record(
+      key: key,
+      fields: fields.mapValues { CachedField(value: $0, writtenAt: writtenAt) }
+    )
+  }
+
+  /// Counts every row in the records table — used to assert that
+  /// atomic list rewrites and cascading deletes leave no orphans.
+  private func totalRowCount(_ db: ApolloSQLiteDatabase) throws -> Int {
+    let dbURL = SQLiteTestCacheProvider.temporarySQLiteFileURL()
+    _ = dbURL // unused; rowCount runs via the internal-test select helper
+    // The cheapest way without exposing more internals is to load
+    // every known key and inspect — but we don't know all keys.
+    // Instead, use clearDatabase as a destructive end-of-test check
+    // where appropriate. For row-count assertions, the tests
+    // explicitly select the keys they wrote and check the returned
+    // structure.
+    fatalError("Use selectRecords to assert structure; this helper is unused")
+  }
+
+  // MARK: - Per-scalar round-trip
+
+  func test__roundTrip__stringValue() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["name": "Anthony"])])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertEqual(loaded[0].fields["name"]?.value as? String, "Anthony")
+    XCTAssertEqual(loaded[0].fields["name"]?.writtenAt, 100)
+  }
+
+  func test__roundTrip__intValue() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["age": 42])])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded[0].fields["age"]?.value as? Int, 42)
+  }
+
+  func test__roundTrip__doubleValue() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("Stock:AAPL", fields: ["price": 199.25])])
+
+    let loaded = try db.selectRecords(forKeys: ["Stock:AAPL"])
+    XCTAssertEqual(loaded[0].fields["price"]?.value as? Double, 199.25)
+  }
+
+  func test__roundTrip__boolValue_true() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["isActive": true])])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded[0].fields["isActive"]?.value as? Bool, true)
+  }
+
+  func test__roundTrip__boolValue_false() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["isActive": false])])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded[0].fields["isActive"]?.value as? Bool, false)
+  }
+
+  func test__roundTrip__cacheReference() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record(
+      "QUERY_ROOT",
+      fields: ["user": CacheReference("User:1")]
+    )])
+
+    let loaded = try db.selectRecords(forKeys: ["QUERY_ROOT"])
+    XCTAssertEqual(loaded[0].fields["user"]?.value as? CacheReference, CacheReference("User:1"))
+  }
+
+  // MARK: - Lists (1D)
+
+  func test__roundTrip__listOfStrings() throws {
+    let db = try makeDatabase()
+    let list: [Record.Value] = ["red", "green", "blue"]
+    let original = Record(
+      key: "User:1",
+      fields: ["colors": CachedField(value: list as Record.Value, writtenAt: 100)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    let reloaded = loaded[0].fields["colors"]?.value as? [Any]
+    XCTAssertEqual(reloaded?.count, 3)
+    XCTAssertEqual(reloaded?[0] as? String, "red")
+    XCTAssertEqual(reloaded?[1] as? String, "green")
+    XCTAssertEqual(reloaded?[2] as? String, "blue")
+  }
+
+  func test__roundTrip__listOfCacheReferences() throws {
+    let db = try makeDatabase()
+    let list: [Record.Value] = [
+      CacheReference("User:1"),
+      CacheReference("User:2"),
+    ]
+    let original = Record(
+      key: "QUERY_ROOT",
+      fields: ["users": CachedField(value: list as Record.Value, writtenAt: 100)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["QUERY_ROOT"])
+    let reloaded = loaded[0].fields["users"]?.value as? [Any]
+    XCTAssertEqual(reloaded?.count, 2)
+    XCTAssertEqual(reloaded?[0] as? CacheReference, CacheReference("User:1"))
+    XCTAssertEqual(reloaded?[1] as? CacheReference, CacheReference("User:2"))
+  }
+
+  func test__roundTrip__listOfMixedScalars() throws {
+    let db = try makeDatabase()
+    let list: [Record.Value] = [1, "two", 3.0, true]
+    let original = Record(
+      key: "Mixed:1",
+      fields: ["values": CachedField(value: list as Record.Value, writtenAt: 100)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["Mixed:1"])
+    let reloaded = loaded[0].fields["values"]?.value as? [Any]
+    XCTAssertEqual(reloaded?[0] as? Int, 1)
+    XCTAssertEqual(reloaded?[1] as? String, "two")
+    XCTAssertEqual(reloaded?[2] as? Double, 3.0)
+    XCTAssertEqual(reloaded?[3] as? Bool, true)
+  }
+
+  func test__roundTrip__emptyList() throws {
+    let db = try makeDatabase()
+    let list: [Record.Value] = []
+    let original = Record(
+      key: "User:1",
+      fields: ["colors": CachedField(value: list as Record.Value, writtenAt: 100)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    // An empty list writes zero element rows. With no scalar row and
+    // no list rows, the field is indistinguishable from "never
+    // written" — the documented behavior of the row-per-element
+    // schema. The record itself has no fields and is therefore not
+    // present in the result set.
+    XCTAssertEqual(loaded.count, 0)
+  }
+
+  // MARK: - Nested lists (2D, 3D)
+
+  func test__roundTrip__nestedList_2D() throws {
+    let db = try makeDatabase()
+    let row0: [Record.Value] = [1, 2]
+    let row1: [Record.Value] = [3, 4]
+    let matrix: [Record.Value] = [row0 as Record.Value, row1 as Record.Value]
+    let original = Record(
+      key: "Math:1",
+      fields: ["matrix": CachedField(value: matrix as Record.Value, writtenAt: 100)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["Math:1"])
+    let reloadedOuter = loaded[0].fields["matrix"]?.value as? [Any]
+    XCTAssertEqual(reloadedOuter?.count, 2)
+    let inner0 = reloadedOuter?[0] as? [Any]
+    let inner1 = reloadedOuter?[1] as? [Any]
+    XCTAssertEqual(inner0?.count, 2)
+    XCTAssertEqual(inner0?[0] as? Int, 1)
+    XCTAssertEqual(inner0?[1] as? Int, 2)
+    XCTAssertEqual(inner1?[0] as? Int, 3)
+    XCTAssertEqual(inner1?[1] as? Int, 4)
+  }
+
+  func test__roundTrip__nestedList_3D() throws {
+    let db = try makeDatabase()
+    // Cube `[[[5]]]` — exercises two levels of synthetic sub-record
+    // indirection (level 1 uses `<parent>.<field>.$[N]`; level 2+
+    // uses `<parent>.$[N]`).
+    let innermost: [Record.Value] = [5]
+    let middle: [Record.Value] = [innermost as Record.Value]
+    let outer: [Record.Value] = [middle as Record.Value]
+    let original = Record(
+      key: "Math:cube",
+      fields: ["cube": CachedField(value: outer as Record.Value, writtenAt: 100)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["Math:cube"])
+    let level0 = loaded[0].fields["cube"]?.value as? [Any]
+    let level1 = level0?[0] as? [Any]
+    let level2 = level1?[0] as? [Any]
+    XCTAssertEqual(level2?[0] as? Int, 5,
+                   "3D nesting should round-trip through two synthetic sub-records")
+  }
+
+  func test__roundTrip__nestedList_listOfReferences() throws {
+    let db = try makeDatabase()
+    // `[[User:1, User:2], [User:3]]` — list-of-list-of-references.
+    let group1: [Record.Value] = [CacheReference("User:1"), CacheReference("User:2")]
+    let group2: [Record.Value] = [CacheReference("User:3")]
+    let groups: [Record.Value] = [group1 as Record.Value, group2 as Record.Value]
+    let original = Record(
+      key: "Org:1",
+      fields: ["teams": CachedField(value: groups as Record.Value, writtenAt: 100)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["Org:1"])
+    let outer = loaded[0].fields["teams"]?.value as? [Any]
+    XCTAssertEqual(outer?.count, 2)
+    let team1 = outer?[0] as? [Any]
+    let team2 = outer?[1] as? [Any]
+    XCTAssertEqual(team1?[0] as? CacheReference, CacheReference("User:1"))
+    XCTAssertEqual(team1?[1] as? CacheReference, CacheReference("User:2"))
+    XCTAssertEqual(team2?[0] as? CacheReference, CacheReference("User:3"))
+  }
+
+  // MARK: - Record-level round-trip
+
+  func test__roundTrip__multiFieldRecord_preservesAllFields() throws {
+    let db = try makeDatabase()
+    let list: [Record.Value] = ["a", "b"]
+    let original = Record(
+      key: "User:1",
+      fields: [
+        "id": CachedField(value: "1" as Record.Value, writtenAt: 555),
+        "name": CachedField(value: "Anthony" as Record.Value, writtenAt: 555),
+        "age": CachedField(value: 42 as Record.Value, writtenAt: 555),
+        "isActive": CachedField(value: true as Record.Value, writtenAt: 555),
+        "owner": CachedField(value: CacheReference("Org:42") as Record.Value, writtenAt: 555),
+        "tags": CachedField(value: list as Record.Value, writtenAt: 555),
+      ]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertEqual(loaded[0].fields.count, 6)
+    XCTAssertEqual(loaded[0].fields["id"]?.value as? String, "1")
+    XCTAssertEqual(loaded[0].fields["name"]?.value as? String, "Anthony")
+    XCTAssertEqual(loaded[0].fields["age"]?.value as? Int, 42)
+    XCTAssertEqual(loaded[0].fields["isActive"]?.value as? Bool, true)
+    XCTAssertEqual(loaded[0].fields["owner"]?.value as? CacheReference, CacheReference("Org:42"))
+    XCTAssertEqual((loaded[0].fields["tags"]?.value as? [Any])?.count, 2)
+  }
+
+  // MARK: - UPSERT semantics
+
+  func test__insertOrUpdate__writingTwice_overwritesScalar() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["age": 42], writtenAt: 100)])
+    try db.insertOrUpdate(records: [record("User:1", fields: ["age": 99], writtenAt: 200)])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded[0].fields["age"]?.value as? Int, 99)
+    XCTAssertEqual(loaded[0].fields["age"]?.writtenAt, 200)
+  }
+
+  func test__insertOrUpdate__changingScalarValueType_clearsPriorColumn() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["data": 42])])
+    // Decoder reads int_value before string_value, so a stale
+    // int_value would shadow the new string and the assertion below
+    // would surface Int(42) instead of "forty-two".
+    try db.insertOrUpdate(records: [record("User:1", fields: ["data": "forty-two"])])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded[0].fields["data"]?.value as? String, "forty-two")
+  }
+
+  func test__insertOrUpdate__atomicListRewrite_shrinksLength() throws {
+    let db = try makeDatabase()
+    // Write a 4-element list, then a 2-element list. Without atomic
+    // rewrite, the trailing elements from the longer list would
+    // remain as orphaned rows and the reader would see a 4-element
+    // list with the first two overwritten.
+    let listLong: [Record.Value] = ["a", "b", "c", "d"]
+    let listShort: [Record.Value] = ["x", "y"]
+    try db.insertOrUpdate(records: [Record(
+      key: "User:1",
+      fields: ["colors": CachedField(value: listLong as Record.Value, writtenAt: 100)]
+    )])
+    try db.insertOrUpdate(records: [Record(
+      key: "User:1",
+      fields: ["colors": CachedField(value: listShort as Record.Value, writtenAt: 200)]
+    )])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    let reloaded = loaded[0].fields["colors"]?.value as? [Any]
+    XCTAssertEqual(reloaded?.count, 2, "Shorter list rewrite should leave exactly 2 elements")
+    XCTAssertEqual(reloaded?[0] as? String, "x")
+    XCTAssertEqual(reloaded?[1] as? String, "y")
+  }
+
+  // MARK: - Delete operations
+
+  func test__deleteRecord_forKey__removesOnlyMatchingRows() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [
+      record("User:1", fields: ["name": "A", "age": 1]),
+      record("User:2", fields: ["name": "B", "age": 2]),
+    ])
+
+    try db.deleteRecord(forKey: "User:1")
+
+    let loaded = try db.selectRecords(forKeys: ["User:1", "User:2"])
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertEqual(loaded[0].key, "User:2")
+  }
+
+  func test__deleteRecord_forKey__givenNonExistentKey_isNoOp() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["name": "A"])])
+
+    XCTAssertNoThrow(try db.deleteRecord(forKey: "User:does-not-exist"))
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded.count, 1)
+  }
+
+  func test__deleteRecords_matchingKey__removesMatchingPrefixes() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [
+      record("Animal:cat", fields: ["name": "Whiskers"]),
+      record("Animal:dog", fields: ["name": "Rex"]),
+      record("User:1", fields: ["name": "Anthony"]),
+    ])
+
+    try db.deleteRecords(matchingKey: "Animal")
+
+    let remaining = try db.selectRecords(forKeys: ["Animal:cat", "Animal:dog", "User:1"])
+    XCTAssertEqual(remaining.count, 1)
+    XCTAssertEqual(remaining[0].key, "User:1")
+  }
+
+  func test__deleteRecords_matchingKey__givenEmptyPattern_isNoOp() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["name": "A"])])
+
+    XCTAssertNoThrow(try db.deleteRecords(matchingKey: ""))
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded.count, 1)
+  }
+
+  func test__deleteRecords_matchingKey__escapesUnderscoreWildcard() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [
+      record("User_admin", fields: ["name": "literal-underscore"]),
+      record("UserA",      fields: ["name": "no-underscore"]),
+      record("User:1",     fields: ["name": "colon-not-underscore"]),
+    ])
+
+    try db.deleteRecords(matchingKey: "User_")
+
+    let remaining = try db.selectRecords(forKeys: ["User_admin", "UserA", "User:1"])
+    let remainingKeys = Set(remaining.map(\.key))
+    XCTAssertEqual(remainingKeys, ["UserA", "User:1"],
+                   "Only literal 'User_' substring should match; \"_\" wildcard should be escaped")
+  }
+
+  func test__deleteRecords_matchingKey__escapesPercentWildcard() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [
+      record("100%-coverage", fields: ["name": "literal-percent"]),
+      record("UserA",         fields: ["name": "no-percent"]),
+    ])
+
+    try db.deleteRecords(matchingKey: "100%")
+
+    let remaining = try db.selectRecords(forKeys: ["100%-coverage", "UserA"])
+    let remainingKeys = Set(remaining.map(\.key))
+    XCTAssertEqual(remainingKeys, ["UserA"])
+  }
+
+  // MARK: - Transactional behavior
+
+  func test__insertOrUpdate__whenScalarEncodingFails_rollsBackEntireBatch() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["name": "A"])])
+
+    struct Unencodable: Hashable, Sendable { let raw: String }
+    let bad = record("User:2", fields: ["weird": Unencodable(raw: "bang")])
+    let alsoGood = record("User:3", fields: ["name": "C"])
+
+    XCTAssertThrowsError(try db.insertOrUpdate(records: [bad, alsoGood]))
+
+    let loaded = try db.selectRecords(forKeys: ["User:1", "User:2", "User:3"])
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertEqual(loaded[0].key, "User:1")
+  }
+
+  func test__insertOrUpdate__listWithUnencodableElement_throwsSwiftErrorNotAbort() throws {
+    let db = try makeDatabase()
+    // A `[Unencodable]` list. Each element triggers the encoder's
+    // custom-scalar path which probes `isValidJSONObject` before
+    // calling `JSONSerialization.data` — so the failure surfaces as
+    // a Swift error (catchable) rather than an `NSException` abort
+    // (uncatchable, would terminate the test process).
+    struct Unencodable: Hashable, Sendable { let raw: String }
+    let list: [Record.Value] = [Unencodable(raw: "bang") as Record.Value]
+    let bad = Record(
+      key: "QUERY_ROOT",
+      fields: ["items": CachedField(value: list as Record.Value, writtenAt: 0)]
+    )
+
+    XCTAssertThrowsError(try db.insertOrUpdate(records: [bad])) { error in
+      XCTAssertTrue(error is SQLiteFieldEncodingError)
+    }
+  }
+
+  // MARK: - Custom-scalar (NSNull, generic dict, $reference disambig)
+
+  func test__roundTrip__nsNull_atTopLevel() throws {
+    let db = try makeDatabase()
+    let original = Record(
+      key: "User:1",
+      fields: ["middleName": CachedField(value: NSNull(), writtenAt: 0)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertTrue(loaded[0].fields["middleName"]?.value is NSNull)
+  }
+
+  func test__roundTrip__genericDictionary() throws {
+    let db = try makeDatabase()
+    let dict: [String: Record.Value] = ["a": 1, "b": "two", "c": true]
+    let original = Record(
+      key: "Custom:1",
+      fields: ["payload": CachedField(value: dict as Record.Value, writtenAt: 0)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["Custom:1"])
+    let reloaded = loaded[0].fields["payload"]?.value as? [String: Any]
+    XCTAssertEqual(reloaded?["a"] as? Int, 1)
+    XCTAssertEqual(reloaded?["b"] as? String, "two")
+    XCTAssertEqual(reloaded?["c"] as? Bool, true)
+  }
+
+  func test__roundTrip__dollarReferenceWithExtraKeys_treatedAsGenericDict() throws {
+    let db = try makeDatabase()
+    let dict: [String: Record.Value] = [
+      "$reference": "not-actually-a-ref",
+      "meta": 42,
+    ]
+    let original = Record(
+      key: "Custom:1",
+      fields: ["payload": CachedField(value: dict as Record.Value, writtenAt: 0)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["Custom:1"])
+    let reloaded = loaded[0].fields["payload"]?.value as? [String: Any]
+    XCTAssertEqual(reloaded?.count, 2,
+                   "Both keys must survive — extra key was dropped under the lenient match")
+    XCTAssertEqual(reloaded?["$reference"] as? String, "not-actually-a-ref")
+    XCTAssertEqual(reloaded?["meta"] as? Int, 42)
+    XCTAssertNil(loaded[0].fields["payload"]?.value as? CacheReference)
+  }
+
+  // MARK: - NSNumber Bool/numeric routing
+
+  func test__roundTrip__nsNumberWrappedBool_staysBool() throws {
+    let db = try makeDatabase()
+    let original = Record(
+      key: "User:1",
+      fields: ["isActive": CachedField(value: NSNumber(value: true), writtenAt: 0)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded[0].fields["isActive"]?.value as? Bool, true)
+  }
+
+  func test__roundTrip__nsNumberWrappedInt_staysInt() throws {
+    let db = try makeDatabase()
+    // `NSNumber(value: 1)` previously satisfied `as Bool` first and
+    // landed in `bool_value`. CFType-aware routing must keep it in
+    // `int_value` and round-trip as Int(1).
+    let original = Record(
+      key: "User:1",
+      fields: ["count": CachedField(value: NSNumber(value: 1), writtenAt: 0)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["User:1"])
+    XCTAssertEqual(loaded[0].fields["count"]?.value as? Int, 1)
+    XCTAssertNil(loaded[0].fields["count"]?.value as? Bool,
+                 "Integer NSNumber must not collapse to Bool")
+  }
+
+  func test__roundTrip__nsNumberWrappedDouble_staysDouble() throws {
+    let db = try makeDatabase()
+    let original = Record(
+      key: "Stock:AAPL",
+      fields: ["price": CachedField(value: NSNumber(value: 199.25), writtenAt: 0)]
+    )
+
+    try db.insertOrUpdate(records: [original])
+
+    let loaded = try db.selectRecords(forKeys: ["Stock:AAPL"])
+    XCTAssertEqual(loaded[0].fields["price"]?.value as? Double, 199.25)
+  }
+
+  // MARK: - Documented empty-record behavior
+
+  func test__insertOrUpdate__emptyRecord_producesNoRows() throws {
+    let db = try makeDatabase()
+    let empty = Record(key: "User:empty", fields: [:])
+
+    try db.insertOrUpdate(records: [empty])
+
+    let loaded = try db.selectRecords(forKeys: ["User:empty"])
+    XCTAssertEqual(loaded.count, 0)
+  }
+
+}

--- a/Tests/ApolloTests/SQLiteRowPerElementCRUDTests.swift
+++ b/Tests/ApolloTests/SQLiteRowPerElementCRUDTests.swift
@@ -25,20 +25,6 @@ class SQLiteRowPerElementCRUDTests: XCTestCase {
     )
   }
 
-  /// Counts every row in the records table — used to assert that
-  /// atomic list rewrites and cascading deletes leave no orphans.
-  private func totalRowCount(_ db: ApolloSQLiteDatabase) throws -> Int {
-    let dbURL = SQLiteTestCacheProvider.temporarySQLiteFileURL()
-    _ = dbURL // unused; rowCount runs via the internal-test select helper
-    // The cheapest way without exposing more internals is to load
-    // every known key and inspect — but we don't know all keys.
-    // Instead, use clearDatabase as a destructive end-of-test check
-    // where appropriate. For row-count assertions, the tests
-    // explicitly select the keys they wrote and check the returned
-    // structure.
-    fatalError("Use selectRecords to assert structure; this helper is unused")
-  }
-
   // MARK: - Per-scalar round-trip
 
   func test__roundTrip__stringValue() throws {

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -492,16 +492,16 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
         cacheKey: cacheKey,
         fieldName: fieldName,
         position: position,
-        column: .childKey(syntheticKey),
+        typedValue: .childKey(syntheticKey),
         writtenAt: writtenAt
       )
     } else {
-      let column = try SQLiteFieldEncoding.encode(element)
+      let typedValue = try SQLiteFieldEncoding.encode(element)
       try upsertRow(
         cacheKey: cacheKey,
         fieldName: fieldName,
         position: position,
-        column: column,
+        typedValue: typedValue,
         writtenAt: writtenAt
       )
     }
@@ -533,7 +533,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     cacheKey: CacheKey,
     fieldName: String,
     position: Int64,
-    column: SQLiteFieldEncoding.Column,
+    typedValue: SQLiteFieldEncoding.TypedValue,
     writtenAt: Int64
   ) throws {
     let sql = """
@@ -569,7 +569,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     sqlite3_bind_text(stmt, 2, fieldName, -1, SQLITE_TRANSIENT)
     sqlite3_bind_int64(stmt, 3, position)
 
-    switch column {
+    switch typedValue {
     case .int(let v):           sqlite3_bind_int64(stmt, 4, v)
     case .string(let v):        sqlite3_bind_text(stmt, 5, v, -1, SQLITE_TRANSIENT)
     case .real(let v):          sqlite3_bind_double(stmt, 6, v)
@@ -614,7 +614,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
   /// into `Record` instances. Follows synthetic `child_key_value`
   /// pointers to materialize nested lists.
   private func loadRecordBatch(_ keys: Set<CacheKey>) throws -> [Record] {
-    let placeholders = keys.map { _ in "?" }.joined(separator: ", ")
+    let placeholders = Array(repeating: "?", count: keys.count).joined(separator: ", ")
     let sql = """
     SELECT
       \(SQLiteSchema.Records.cacheKey),

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -327,6 +327,19 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
   public func insertOrUpdate(records: [Record]) throws {
     guard !records.isEmpty else { return }
 
+    // Reserved-key audit (ADR 0006): `.$[` is reserved for the
+    // synthetic sub-record keys generated for nested-list storage.
+    // Rejecting user keys that contain the token guarantees the
+    // synthetic-key classifiers (`syntheticKeySuffixPattern` and
+    // `syntheticKeySuffixLikePattern`) can never match a stored user
+    // record. Checked before the transaction opens so a bad key in a
+    // batch writes nothing.
+    for record in records {
+      if record.key.contains(SQLiteSchema.Records.syntheticKeyToken) {
+        throw SQLiteError.reservedCacheKey(key: record.key)
+      }
+    }
+
     try performSync {
       try exec("BEGIN TRANSACTION", errorMessage: "Failed to begin insertOrUpdate transaction")
       do {
@@ -424,6 +437,9 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
   /// Writes one field's value, choosing the right row shape:
   /// - scalars get one row at `position = -1`
   /// - list-typed values get N rows at positions `0..N-1`
+  /// - empty lists get a single marker row at `position = -2` with no
+  ///   value column populated, so `[]` stays distinguishable from a
+  ///   never-written field
   /// - nested-list elements recurse via a synthetic sub-record
   ///
   /// Any prior rows for `(cacheKey, fieldName)` are cleared first so
@@ -446,6 +462,16 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     try directDelete(cacheKey: cacheKey, fieldName: fieldName)
 
     if let array = value as? [Record.Value] {
+      guard !array.isEmpty else {
+        try upsertRow(
+          cacheKey: cacheKey,
+          fieldName: fieldName,
+          position: SQLiteSchema.Records.emptyListPositionValue,
+          typedValue: nil,
+          writtenAt: writtenAt
+        )
+        return
+      }
       for (idx, element) in array.enumerated() {
         try writeElement(
           cacheKey: cacheKey,
@@ -529,11 +555,16 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
   /// every value column from `excluded.*`, so a field changing type
   /// (e.g. Int → String at the same position) also clears its prior
   /// column.
+  ///
+  /// A `nil` `typedValue` binds no value column (unbound parameters
+  /// are NULL) and is valid only for the empty-list marker row at
+  /// `position = -2` — the marker's meaning is carried entirely by
+  /// its `position`.
   private func upsertRow(
     cacheKey: CacheKey,
     fieldName: String,
     position: Int64,
-    typedValue: SQLiteFieldEncoding.TypedValue,
+    typedValue: SQLiteFieldEncoding.TypedValue?,
     writtenAt: Int64
   ) throws {
     let sql = """
@@ -576,6 +607,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     case .bool(let v):          sqlite3_bind_int64(stmt, 7, v ? 1 : 0)
     case .childKey(let v):      sqlite3_bind_text(stmt, 8, v, -1, SQLITE_TRANSIENT)
     case .customScalar(let v):  sqlite3_bind_text(stmt, 9, v, -1, SQLITE_TRANSIENT)
+    case nil:                   break  // empty-list marker: all value columns NULL
     }
 
     sqlite3_bind_int64(stmt, 10, writtenAt)
@@ -654,14 +686,21 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
       let cacheKey = String(cString: cacheKeyPtr)
       let fieldName = String(cString: fieldNamePtr)
       let position = sqlite3_column_int64(stmt, 2)
-      let value = try SQLiteFieldEncoding.decode(
-        boolValue: Self.optionalInt64(stmt: stmt, column: 6),
-        intValue: Self.optionalInt64(stmt: stmt, column: 3),
-        floatValue: Self.optionalDouble(stmt: stmt, column: 5),
-        stringValue: Self.optionalText(stmt: stmt, column: 4),
-        childKeyValue: Self.optionalText(stmt: stmt, column: 7),
-        customScalarValue: Self.optionalText(stmt: stmt, column: 8)
-      )
+      let value: Record.Value
+      if position == SQLiteSchema.Records.emptyListPositionValue {
+        // Empty-list marker rows populate no value column; the
+        // position alone carries the meaning.
+        value = ([] as [Record.Value]) as Record.Value
+      } else {
+        value = try SQLiteFieldEncoding.decode(
+          boolValue: Self.optionalInt64(stmt: stmt, column: 6),
+          intValue: Self.optionalInt64(stmt: stmt, column: 3),
+          floatValue: Self.optionalDouble(stmt: stmt, column: 5),
+          stringValue: Self.optionalText(stmt: stmt, column: 4),
+          childKeyValue: Self.optionalText(stmt: stmt, column: 7),
+          customScalarValue: Self.optionalText(stmt: stmt, column: 8)
+        )
+      }
       let writtenAt = sqlite3_column_int64(stmt, 9)
       rawRows.append(DecodedRow(
         cacheKey: cacheKey, fieldName: fieldName, position: position,
@@ -677,10 +716,10 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
   }
 
   /// Groups raw rows by cache_key, then by field_name, distinguishing
-  /// scalar fields (single row at `position = -1`) from list fields
-  /// (rows at `position >= 0`, sorted), and recursively resolves any
-  /// synthetic child_key_value references into their nested-list
-  /// contents.
+  /// scalar fields (single row at `position = -1`), empty lists
+  /// (single marker row at `position = -2`), and list fields (rows at
+  /// `position >= 0`, sorted), and recursively resolves any synthetic
+  /// child_key_value references into their nested-list contents.
   private func assembleRecords(from rows: [DecodedRow]) throws -> [Record] {
     var byKey: [CacheKey: [DecodedRow]] = [:]
     for row in rows {
@@ -698,7 +737,11 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
       for (fieldName, fieldRows) in byField {
         let sorted = fieldRows.sorted { $0.position < $1.position }
 
-        if sorted.count == 1 && sorted[0].position == SQLiteSchema.Records.defaultPositionValue {
+        if sorted.count == 1 && sorted[0].position == SQLiteSchema.Records.emptyListPositionValue {
+          // Empty-list marker row — the value was decoded as `[]`.
+          let row = sorted[0]
+          fields[fieldName] = CachedField(value: row.value, writtenAt: row.writtenAt)
+        } else if sorted.count == 1 && sorted[0].position == SQLiteSchema.Records.defaultPositionValue {
           let row = sorted[0]
           let resolved = try resolveSyntheticIfNeeded(row.value)
           fields[fieldName] = CachedField(value: resolved, writtenAt: row.writtenAt)

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Apollo
+@_spi(Execution) import Apollo
 import SQLite3
 
 public final class ApolloSQLiteDatabase: SQLiteDatabase {
@@ -320,6 +320,453 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     try performSync {
       _ = try exec("PRAGMA journal_mode = \(mode.rawValue);", errorMessage: "Failed to set journal mode")
     }
+  }
+
+  // MARK: - Row-per-element schema
+
+  public func insertOrUpdate(records: [Record]) throws {
+    guard !records.isEmpty else { return }
+
+    try performSync {
+      try exec("BEGIN TRANSACTION", errorMessage: "Failed to begin insertOrUpdate transaction")
+      do {
+        for record in records {
+          for (fieldName, cachedField) in record.fields {
+            try writeFieldOrList(
+              cacheKey: record.key,
+              fieldName: fieldName,
+              value: cachedField.value,
+              writtenAt: cachedField.writtenAt
+            )
+          }
+        }
+      } catch {
+        rollbackTransaction()
+        throw error
+      }
+      do {
+        try exec("COMMIT TRANSACTION", errorMessage: "Failed to commit insertOrUpdate transaction")
+      } catch {
+        rollbackTransaction()
+        throw error
+      }
+    }
+  }
+
+  public func deleteRecord(forKey cacheKey: CacheKey) throws {
+    // Direct delete only — synthetic sub-records (`<parent>.<field>.$[N]`)
+    // produced by nested-list writes are not cascaded here. If the
+    // record being deleted has list-typed fields with depth ≥ 2, the
+    // corresponding synthetic sub-record rows remain in the database
+    // as orphans. They are unreachable from any cache key after this
+    // delete (the parent's `child_key_value` pointers are gone) but
+    // they take up storage until a follow-up cascade-delete PR cleans
+    // them up. Reads are unaffected — orphans never surface through
+    // `selectRecords`.
+    try performSync {
+      try directDelete(cacheKey: cacheKey)
+    }
+  }
+
+  public func deleteRecords(matchingKey pattern: CacheKey) throws {
+    guard !pattern.isEmpty else { return }
+    // `LIKE` treats `%` and `_` as wildcards. Escape them (along with
+    // the escape character itself) so callers passing a literal
+    // substring like "User_" don't accidentally delete "UserA1",
+    // "User:1", "Users", etc.
+    let escaped = pattern
+      .replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "%", with: "\\%")
+      .replacingOccurrences(of: "_", with: "\\_")
+    let wildcardPattern = "%\(escaped)%"
+
+    try performSync {
+      let sql = """
+      DELETE FROM \(SQLiteSchema.recordsTableName)
+      WHERE \(SQLiteSchema.Records.cacheKey) LIKE ? COLLATE NOCASE ESCAPE '\\'
+      """
+      let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare row-per-element pattern delete")
+      defer { sqlite3_finalize(stmt) }
+
+      sqlite3_bind_text(stmt, 1, wildcardPattern, -1, SQLITE_TRANSIENT)
+      let result = sqlite3_step(stmt)
+      if result != SQLITE_DONE {
+        throw SQLiteError.step(message: "Row-per-element pattern delete failed: \(sqliteErrorMessage())", resultCode: result)
+      }
+    }
+  }
+
+  /// Test-only read path: loads every row for the given cache keys,
+  /// reassembles them into `Record` instances, and follows synthetic
+  /// sub-record `child_key_value` pointers to materialize nested lists.
+  /// **Not part of the `SQLiteDatabase` public protocol** — production
+  /// reads will use a projection-aware API introduced in a later PR
+  /// (per ADR 0007). This helper exists so the write/delete tests can
+  /// verify round-trip behavior in the interim.
+  internal func selectRecords(forKeys keys: Set<CacheKey>) throws -> [Record] {
+    guard !keys.isEmpty else { return [] }
+
+    var records: [Record] = []
+    for batch in keys.chunked(into: 500) {
+      let batchRecords = try performSync {
+        try loadRecordBatch(Set(batch))
+      }
+      // Filter out synthetic sub-records — they're consumed by their
+      // parent's nested-list assembly via `resolveSyntheticIfNeeded`
+      // and shouldn't surface as top-level records to callers.
+      records.append(contentsOf: batchRecords.filter { !Self.isSyntheticKey($0.key) })
+    }
+    return records
+  }
+
+  // MARK: - Row-per-element internals
+
+  /// Writes one field's value, choosing the right row shape:
+  /// - scalars get one row at `position = -1`
+  /// - list-typed values get N rows at positions `0..N-1`
+  /// - nested-list elements recurse via a synthetic sub-record
+  ///
+  /// Any prior rows for `(cacheKey, fieldName)` are cleared first so
+  /// shape transitions (scalar → list, list → scalar, longer-list →
+  /// shorter-list) leave no in-field orphans. The clear-then-write
+  /// happens inside the caller's transaction so partial states are
+  /// never observable to readers.
+  ///
+  /// Note: this implementation does NOT cascade-clean synthetic sub-
+  /// records pointed to by the previous rows. If the prior value was
+  /// a list with depth ≥ 2, those synthetic sub-record rows remain
+  /// in the database as orphans (unreachable but persistent). A
+  /// follow-up cascade-delete PR handles that cleanup.
+  private func writeFieldOrList(
+    cacheKey: CacheKey,
+    fieldName: String,
+    value: Record.Value,
+    writtenAt: Int64
+  ) throws {
+    try directDelete(cacheKey: cacheKey, fieldName: fieldName)
+
+    if let array = value as? [Record.Value] {
+      for (idx, element) in array.enumerated() {
+        try writeElement(
+          cacheKey: cacheKey,
+          fieldName: fieldName,
+          position: Int64(idx),
+          element: element,
+          writtenAt: writtenAt
+        )
+      }
+    } else {
+      try writeElement(
+        cacheKey: cacheKey,
+        fieldName: fieldName,
+        position: SQLiteSchema.Records.defaultPositionValue,
+        element: value,
+        writtenAt: writtenAt
+      )
+    }
+  }
+
+  /// Writes one row's worth of data: either a leaf typed value, or a
+  /// nested list which becomes a synthetic sub-record linked via
+  /// `child_key_value`.
+  private func writeElement(
+    cacheKey: CacheKey,
+    fieldName: String,
+    position: Int64,
+    element: Record.Value,
+    writtenAt: Int64
+  ) throws {
+    if let nestedArray = element as? [Record.Value] {
+      let syntheticKey = syntheticSubRecordKey(
+        parentCacheKey: cacheKey,
+        parentFieldName: fieldName,
+        position: position
+      )
+      try writeFieldOrList(
+        cacheKey: syntheticKey,
+        fieldName: SQLiteSchema.Records.syntheticFieldName,
+        value: nestedArray as Record.Value,
+        writtenAt: writtenAt
+      )
+      try upsertRow(
+        cacheKey: cacheKey,
+        fieldName: fieldName,
+        position: position,
+        column: .childKey(syntheticKey),
+        writtenAt: writtenAt
+      )
+    } else {
+      let column = try SQLiteFieldEncoding.encode(element)
+      try upsertRow(
+        cacheKey: cacheKey,
+        fieldName: fieldName,
+        position: position,
+        column: column,
+        writtenAt: writtenAt
+      )
+    }
+  }
+
+  /// Constructs a synthetic sub-record cache key. If the parent is
+  /// already a synthetic sub-record (`fieldName` is the sentinel `$`),
+  /// the new key just appends `.$[<position>]` to keep the synthetic
+  /// chain readable. Otherwise the new key embeds the parent field
+  /// name: `<parentCacheKey>.<parentFieldName>.$[<position>]`.
+  private func syntheticSubRecordKey(
+    parentCacheKey: CacheKey,
+    parentFieldName: String,
+    position: Int64
+  ) -> CacheKey {
+    if parentFieldName == SQLiteSchema.Records.syntheticFieldName {
+      return "\(parentCacheKey).$[\(position)]"
+    } else {
+      return "\(parentCacheKey).\(parentFieldName).$[\(position)]"
+    }
+  }
+
+  /// Issues one UPSERT against the records table for a single row.
+  /// `ON CONFLICT (cache_key, field_name, position) DO UPDATE` copies
+  /// every value column from `excluded.*`, so a field changing type
+  /// (e.g. Int → String at the same position) also clears its prior
+  /// column.
+  private func upsertRow(
+    cacheKey: CacheKey,
+    fieldName: String,
+    position: Int64,
+    column: SQLiteFieldEncoding.Column,
+    writtenAt: Int64
+  ) throws {
+    let sql = """
+    INSERT INTO \(SQLiteSchema.recordsTableName) (
+      \(SQLiteSchema.Records.cacheKey),
+      \(SQLiteSchema.Records.fieldName),
+      \(SQLiteSchema.Records.position),
+      \(SQLiteSchema.Records.intValue),
+      \(SQLiteSchema.Records.stringValue),
+      \(SQLiteSchema.Records.floatValue),
+      \(SQLiteSchema.Records.boolValue),
+      \(SQLiteSchema.Records.childKeyValue),
+      \(SQLiteSchema.Records.customScalarValue),
+      \(SQLiteSchema.Records.writtenAt)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(
+      \(SQLiteSchema.Records.cacheKey),
+      \(SQLiteSchema.Records.fieldName),
+      \(SQLiteSchema.Records.position)
+    ) DO UPDATE SET
+      \(SQLiteSchema.Records.intValue)          = excluded.\(SQLiteSchema.Records.intValue),
+      \(SQLiteSchema.Records.stringValue)       = excluded.\(SQLiteSchema.Records.stringValue),
+      \(SQLiteSchema.Records.floatValue)        = excluded.\(SQLiteSchema.Records.floatValue),
+      \(SQLiteSchema.Records.boolValue)         = excluded.\(SQLiteSchema.Records.boolValue),
+      \(SQLiteSchema.Records.childKeyValue)     = excluded.\(SQLiteSchema.Records.childKeyValue),
+      \(SQLiteSchema.Records.customScalarValue) = excluded.\(SQLiteSchema.Records.customScalarValue),
+      \(SQLiteSchema.Records.writtenAt)         = excluded.\(SQLiteSchema.Records.writtenAt)
+    """
+    let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare record-row upsert")
+    defer { sqlite3_finalize(stmt) }
+
+    sqlite3_bind_text(stmt, 1, cacheKey, -1, SQLITE_TRANSIENT)
+    sqlite3_bind_text(stmt, 2, fieldName, -1, SQLITE_TRANSIENT)
+    sqlite3_bind_int64(stmt, 3, position)
+
+    switch column {
+    case .int(let v):           sqlite3_bind_int64(stmt, 4, v)
+    case .string(let v):        sqlite3_bind_text(stmt, 5, v, -1, SQLITE_TRANSIENT)
+    case .real(let v):          sqlite3_bind_double(stmt, 6, v)
+    case .bool(let v):          sqlite3_bind_int64(stmt, 7, v ? 1 : 0)
+    case .childKey(let v):      sqlite3_bind_text(stmt, 8, v, -1, SQLITE_TRANSIENT)
+    case .customScalar(let v):  sqlite3_bind_text(stmt, 9, v, -1, SQLITE_TRANSIENT)
+    }
+
+    sqlite3_bind_int64(stmt, 10, writtenAt)
+
+    let result = sqlite3_step(stmt)
+    if result != SQLITE_DONE {
+      throw SQLiteError.step(message: "Record-row upsert failed: \(sqliteErrorMessage())", resultCode: result)
+    }
+  }
+
+  /// Deletes the rows for a given cache key (and optional field). Does
+  /// not cascade synthetic sub-records — that's a follow-up PR.
+  private func directDelete(cacheKey: CacheKey, fieldName: String? = nil) throws {
+    let sql: String
+    if fieldName == nil {
+      sql = "DELETE FROM \(SQLiteSchema.recordsTableName) WHERE \(SQLiteSchema.Records.cacheKey) = ?"
+    } else {
+      sql = "DELETE FROM \(SQLiteSchema.recordsTableName) WHERE \(SQLiteSchema.Records.cacheKey) = ? AND \(SQLiteSchema.Records.fieldName) = ?"
+    }
+    let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare direct delete")
+    defer { sqlite3_finalize(stmt) }
+
+    sqlite3_bind_text(stmt, 1, cacheKey, -1, SQLITE_TRANSIENT)
+    if let fieldName {
+      sqlite3_bind_text(stmt, 2, fieldName, -1, SQLITE_TRANSIENT)
+    }
+    let result = sqlite3_step(stmt)
+    if result != SQLITE_DONE {
+      throw SQLiteError.step(message: "Direct delete failed: \(sqliteErrorMessage())", resultCode: result)
+    }
+  }
+
+  // MARK: - Row-per-element read assembly (test-only)
+
+  /// Loads all rows for a batch of cache keys and groups them back
+  /// into `Record` instances. Follows synthetic `child_key_value`
+  /// pointers to materialize nested lists.
+  private func loadRecordBatch(_ keys: Set<CacheKey>) throws -> [Record] {
+    let placeholders = keys.map { _ in "?" }.joined(separator: ", ")
+    let sql = """
+    SELECT
+      \(SQLiteSchema.Records.cacheKey),
+      \(SQLiteSchema.Records.fieldName),
+      \(SQLiteSchema.Records.position),
+      \(SQLiteSchema.Records.intValue),
+      \(SQLiteSchema.Records.stringValue),
+      \(SQLiteSchema.Records.floatValue),
+      \(SQLiteSchema.Records.boolValue),
+      \(SQLiteSchema.Records.childKeyValue),
+      \(SQLiteSchema.Records.customScalarValue),
+      \(SQLiteSchema.Records.writtenAt)
+    FROM \(SQLiteSchema.recordsTableName)
+    WHERE \(SQLiteSchema.Records.cacheKey) IN (\(placeholders))
+    ORDER BY \(SQLiteSchema.Records.cacheKey),
+             \(SQLiteSchema.Records.fieldName),
+             \(SQLiteSchema.Records.position)
+    """
+    let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare row-per-element select")
+    defer { sqlite3_finalize(stmt) }
+
+    var bindIdx: Int32 = 1
+    for key in keys {
+      sqlite3_bind_text(stmt, bindIdx, key, -1, SQLITE_TRANSIENT)
+      bindIdx += 1
+    }
+
+    var rawRows: [DecodedRow] = []
+    var step = sqlite3_step(stmt)
+    while step == SQLITE_ROW {
+      guard let cacheKeyPtr = sqlite3_column_text(stmt, 0) else {
+        throw SQLiteError.step(message: "Unexpected NULL cache_key in row-per-element select", resultCode: SQLITE_NOMEM)
+      }
+      guard let fieldNamePtr = sqlite3_column_text(stmt, 1) else {
+        throw SQLiteError.step(message: "Unexpected NULL field_name in row-per-element select", resultCode: SQLITE_NOMEM)
+      }
+      let cacheKey = String(cString: cacheKeyPtr)
+      let fieldName = String(cString: fieldNamePtr)
+      let position = sqlite3_column_int64(stmt, 2)
+      let value = try SQLiteFieldEncoding.decode(
+        boolValue: Self.optionalInt64(stmt: stmt, column: 6),
+        intValue: Self.optionalInt64(stmt: stmt, column: 3),
+        floatValue: Self.optionalDouble(stmt: stmt, column: 5),
+        stringValue: Self.optionalText(stmt: stmt, column: 4),
+        childKeyValue: Self.optionalText(stmt: stmt, column: 7),
+        customScalarValue: Self.optionalText(stmt: stmt, column: 8)
+      )
+      let writtenAt = sqlite3_column_int64(stmt, 9)
+      rawRows.append(DecodedRow(
+        cacheKey: cacheKey, fieldName: fieldName, position: position,
+        value: value, writtenAt: writtenAt
+      ))
+      step = sqlite3_step(stmt)
+    }
+    if step != SQLITE_DONE {
+      throw SQLiteError.step(message: "Failed to step row-per-element select: \(sqliteErrorMessage())", resultCode: step)
+    }
+
+    return try assembleRecords(from: rawRows)
+  }
+
+  /// Groups raw rows by cache_key, then by field_name, distinguishing
+  /// scalar fields (single row at `position = -1`) from list fields
+  /// (rows at `position >= 0`, sorted), and recursively resolves any
+  /// synthetic child_key_value references into their nested-list
+  /// contents.
+  private func assembleRecords(from rows: [DecodedRow]) throws -> [Record] {
+    var byKey: [CacheKey: [DecodedRow]] = [:]
+    for row in rows {
+      byKey[row.cacheKey, default: []].append(row)
+    }
+
+    var records: [Record] = []
+    for (key, keyRows) in byKey {
+      // Returns ALL records, including synthetic sub-records. The
+      // synthetic-key filter happens at the `selectRecords` boundary
+      // for top-level reads; internal callers like
+      // `resolveSyntheticIfNeeded` need synthetic sub-records here.
+      var fields: Record.Fields = [:]
+      let byField = Dictionary(grouping: keyRows, by: \.fieldName)
+      for (fieldName, fieldRows) in byField {
+        let sorted = fieldRows.sorted { $0.position < $1.position }
+
+        if sorted.count == 1 && sorted[0].position == SQLiteSchema.Records.defaultPositionValue {
+          let row = sorted[0]
+          let resolved = try resolveSyntheticIfNeeded(row.value)
+          fields[fieldName] = CachedField(value: resolved, writtenAt: row.writtenAt)
+        } else {
+          var elements: [Record.Value] = []
+          var maxWrittenAt: Int64 = 0
+          for row in sorted where row.position >= 0 {
+            let resolved = try resolveSyntheticIfNeeded(row.value)
+            elements.append(resolved)
+            maxWrittenAt = max(maxWrittenAt, row.writtenAt)
+          }
+          fields[fieldName] = CachedField(value: elements as Record.Value, writtenAt: maxWrittenAt)
+        }
+      }
+      records.append(Record(key: key, fields: fields))
+    }
+    return records
+  }
+
+  /// If `value` is a `CacheReference` whose key matches the synthetic-
+  /// key suffix pattern, load the synthetic sub-record and return its
+  /// inner list. Otherwise return the value unchanged.
+  private func resolveSyntheticIfNeeded(_ value: Record.Value) throws -> Record.Value {
+    guard let ref = value as? CacheReference, Self.isSyntheticKey(ref.key) else {
+      return value
+    }
+    // Load the synthetic sub-record. Its rows are clustered under
+    // field_name = "$" and live at the synthetic cache_key.
+    let subRecords = try loadRecordBatch([ref.key])
+    guard let subRecord = subRecords.first,
+          let listField = subRecord.fields[SQLiteSchema.Records.syntheticFieldName] else {
+      // Defensive: the synthetic key was referenced but the sub-
+      // record's rows are missing. Return the reference unchanged
+      // so the issue surfaces in the caller's assertion rather than
+      // here as a silent empty list.
+      return value
+    }
+    return listField.value
+  }
+
+  // MARK: - Row-per-element helpers
+
+  private static func isSyntheticKey(_ key: CacheKey) -> Bool {
+    key.range(of: SQLiteSchema.Records.syntheticKeySuffixPattern, options: .regularExpression) != nil
+  }
+
+  private static func optionalInt64(stmt: OpaquePointer?, column: Int32) -> Int64? {
+    if sqlite3_column_type(stmt, column) == SQLITE_NULL { return nil }
+    return sqlite3_column_int64(stmt, column)
+  }
+
+  private static func optionalDouble(stmt: OpaquePointer?, column: Int32) -> Double? {
+    if sqlite3_column_type(stmt, column) == SQLITE_NULL { return nil }
+    return sqlite3_column_double(stmt, column)
+  }
+
+  private static func optionalText(stmt: OpaquePointer?, column: Int32) -> String? {
+    if sqlite3_column_type(stmt, column) == SQLITE_NULL { return nil }
+    guard let ptr = sqlite3_column_text(stmt, column) else { return nil }
+    return String(cString: ptr)
+  }
+
+  private struct DecodedRow {
+    let cacheKey: CacheKey
+    let fieldName: CacheKey
+    let position: Int64
+    let value: Record.Value
+    let writtenAt: Int64
   }
 }
 

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -572,7 +572,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     switch typedValue {
     case .int(let v):           sqlite3_bind_int64(stmt, 4, v)
     case .string(let v):        sqlite3_bind_text(stmt, 5, v, -1, SQLITE_TRANSIENT)
-    case .real(let v):          sqlite3_bind_double(stmt, 6, v)
+    case .float(let v):         sqlite3_bind_double(stmt, 6, v)
     case .bool(let v):          sqlite3_bind_int64(stmt, 7, v ? 1 : 0)
     case .childKey(let v):      sqlite3_bind_text(stmt, 8, v, -1, SQLITE_TRANSIENT)
     case .customScalar(let v):  sqlite3_bind_text(stmt, 9, v, -1, SQLITE_TRANSIENT)

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -16,6 +16,11 @@ public enum SQLiteError: Error, CustomStringConvertible {
   case open(path: String, resultCode: Int32)
   case prepare(message: String, resultCode: Int32)
   case step(message: String, resultCode: Int32)
+  /// A caller attempted to store a record whose cache key contains
+  /// `SQLiteSchema.Records.syntheticKeyToken`, which is reserved for
+  /// the synthetic sub-record keys the database generates internally
+  /// for nested-list storage.
+  case reservedCacheKey(key: String)
 
   public var description: String {
     switch self {
@@ -27,6 +32,8 @@ public enum SQLiteError: Error, CustomStringConvertible {
       return message
     case .step(let message, _):
       return message
+    case .reservedCacheKey(let key):
+      return "Cache key '\(key)' contains '\(SQLiteSchema.Records.syntheticKeyToken)', which is reserved for synthetic sub-record keys, and cannot be stored"
     }
   }
 }
@@ -91,12 +98,23 @@ public protocol SQLiteDatabase {
   ///   inserted, so a partial-list state is never observable to
   ///   readers and shape transitions (scalar↔list, longer-list →
   ///   shorter-list) leave no in-field orphans.
+  /// - **Empty lists** (`[]`) become a single marker row at
+  ///   `position = -2` (`SQLiteSchema.Records.emptyListPositionValue`)
+  ///   with no value column populated, so a cached empty list stays
+  ///   distinguishable from a field that was never written.
   /// - **Nested-list elements** (a list whose elements are themselves
   ///   lists, e.g. `[[Int]]`) recurse via a synthetic sub-record at
   ///   `<parent>.<field>.$[<position>]`. The parent row's
   ///   `child_key_value` points to the sub-record key. The sub-record
   ///   holds the inner list's element rows under the sentinel
   ///   `field_name = "$"`.
+  ///
+  /// Throws `SQLiteError.reservedCacheKey` — before any row is
+  /// written — if any record's cache key contains the reserved
+  /// synthetic-key token `SQLiteSchema.Records.syntheticKeyToken`
+  /// (`.$[`). Reserving the token guarantees user records can never
+  /// collide with the synthetic sub-record keys generated for
+  /// nested-list storage.
   ///
   /// Note: when overwriting a field whose previous value was a nested
   /// list, the synthetic sub-record rows are *not* cleaned up by this

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -77,6 +77,62 @@ public protocol SQLiteDatabase {
   @available(*, deprecated, renamed: "addOrUpdate(records:)")
   func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws
 
+  // MARK: - Row-per-element schema
+
+  /// Writes the given records as rows in the row-per-element records
+  /// table, in a single transaction. For each `(cacheKey, fieldName)`:
+  ///
+  /// - **Scalar fields** (`String`, `Int`, `Bool`, `Double`,
+  ///   `CacheReference`, etc.) become a single row at the default
+  ///   `position` value (`-1`).
+  /// - **List-typed fields** are written as `N` rows at positions
+  ///   `0..N-1`. The write is atomic: any existing rows for
+  ///   `(cacheKey, fieldName)` are deleted before the new ones are
+  ///   inserted, so a partial-list state is never observable to
+  ///   readers and shape transitions (scalar↔list, longer-list →
+  ///   shorter-list) leave no in-field orphans.
+  /// - **Nested-list elements** (a list whose elements are themselves
+  ///   lists, e.g. `[[Int]]`) recurse via a synthetic sub-record at
+  ///   `<parent>.<field>.$[<position>]`. The parent row's
+  ///   `child_key_value` points to the sub-record key. The sub-record
+  ///   holds the inner list's element rows under the sentinel
+  ///   `field_name = "$"`.
+  ///
+  /// Note: when overwriting a field whose previous value was a nested
+  /// list, the synthetic sub-record rows are *not* cleaned up by this
+  /// method. They remain in the database as orphans until a follow-up
+  /// cascade-delete PR ships. Reads are unaffected — orphans are
+  /// unreachable through `selectRecords`.
+  ///
+  /// If any row fails to bind or step, the whole transaction is rolled
+  /// back so callers either see all writes applied or none.
+  ///
+  /// Requires the row-per-element records table (see
+  /// `createNewRecordsTableIfNeeded()`).
+  func insertOrUpdate(records: [Record]) throws
+
+  /// Removes every row whose `cache_key` matches `cacheKey`.
+  ///
+  /// Synthetic sub-records (`<parent>.<field>.$[N]`) produced by
+  /// nested-list writes against this `cacheKey` are *not* cascade-
+  /// deleted by this method. If the record being deleted has list-
+  /// typed fields with depth ≥ 2, the corresponding synthetic sub-
+  /// record rows remain in the database as orphans (unreachable but
+  /// persistent). A follow-up cascade-delete PR handles that
+  /// cleanup. Reads are unaffected — orphans never surface through
+  /// `selectRecords`.
+  ///
+  /// Distinct from the legacy `deleteRecord(for:)` by the column it
+  /// targets; this method operates on the row-per-element schema's
+  /// `cache_key`.
+  func deleteRecord(forKey cacheKey: CacheKey) throws
+
+  /// Removes every row whose `cache_key` matches the wildcard
+  /// `pattern`. Comparison is case-insensitive (`COLLATE NOCASE`).
+  /// `\`, `%`, and `_` in `pattern` are escaped so they match
+  /// literally rather than acting as `LIKE` wildcards.
+  func deleteRecords(matchingKey pattern: CacheKey) throws
+
 }
 
 extension SQLiteDatabase {

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteFieldEncoding.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteFieldEncoding.swift
@@ -42,7 +42,7 @@ internal enum SQLiteFieldEncoding {
   internal enum TypedValue: Equatable {
     case bool(Bool)
     case int(Int64)
-    case real(Double)
+    case float(Double)
     case string(String)
     case childKey(String)
     case customScalar(String)
@@ -69,7 +69,7 @@ internal enum SQLiteFieldEncoding {
            .nsIntegerType, .cfIndexType:
         return .int(n.int64Value)
       default:
-        return .real(n.doubleValue)
+        return .float(n.doubleValue)
       }
     case let v as String:
       return .string(v)

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteFieldEncoding.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteFieldEncoding.swift
@@ -1,0 +1,226 @@
+import Foundation
+@_spi(Execution) import Apollo
+
+/// Encodes a single `Record` field value (or a single list element)
+/// into the typed-column slot of the row-per-element records-table
+/// layout, and reconstructs the value back from a fetched row.
+///
+/// The encoder operates per VALUE, not per array. Lists are not
+/// encoded into a single column — each list element is stored as its
+/// own row at `position = 0..N-1` and the database layer iterates
+/// element-by-element, calling this encoder once per element. This
+/// file therefore never sees `[Record.Value]` inputs at the top
+/// level; arrays are flattened into multiple rows at a higher layer
+/// and the encoder rejects them defensively.
+///
+/// Column mapping for a single value:
+///
+///   `Bool` (incl. `NSNumber`-boxed bool) → `bool_value` (stored as `0` / `1`)
+///   `Int` / `Int64` (incl. integer `NSNumber`)        → `int_value`             (INTEGER)
+///   `Double` (incl. floating-point `NSNumber`)        → `float_value`           (REAL)
+///   `String`                                          → `string_value`
+///   `CacheReference`                                  → `child_key_value`       (stores `.key`)
+///   `NSNull` (the GraphQL null marker)                → `custom_scalar_value`   (`"null"`)
+///   `[String: Record.Value]` and other JSON shapes    → `custom_scalar_value`   (JSON)
+///
+/// Exactly one value column is non-null on a well-formed row.
+///
+/// **Type-identity on round-trip.** SQLite `INTEGER` is 64-bit; the
+/// decoder returns `Int` (which is 64-bit on every Apple deployment
+/// target this SDK supports). A field originally written as `Int64`
+/// reads back as `Int` — values are preserved exactly, but the Swift
+/// type identity does change. Callers comparing via `AnyHashable`
+/// should account for this.
+internal enum SQLiteFieldEncoding {
+
+  /// The column slot a single non-array value occupies on a row.
+  internal enum Column: Equatable {
+    case bool(Bool)
+    case int(Int64)
+    case real(Double)
+    case string(String)
+    case childKey(String)
+    case customScalar(String)
+  }
+
+  /// Selects the column slot for a single value.
+  ///
+  /// Numeric values (whether native Swift `Int` / `Double` or
+  /// `NSNumber`-bridged from JSON) all reach the `as NSNumber` case
+  /// first via Foundation's implicit bridging. `CFGetTypeID` then
+  /// distinguishes booleans (`CFBooleanGetTypeID`) from numeric kinds,
+  /// keeping `NSNumber(value: 1)` in `int_value` and
+  /// `NSNumber(value: true)` in `bool_value` — they would otherwise
+  /// both satisfy `as Bool`.
+  static func encode(_ value: Record.Value) throws -> Column {
+    switch value {
+    case let n as NSNumber:
+      if CFGetTypeID(n) == CFBooleanGetTypeID() {
+        return .bool(n.boolValue)
+      }
+      switch CFNumberGetType(n) {
+      case .sInt8Type, .sInt16Type, .sInt32Type, .sInt64Type,
+           .charType, .shortType, .intType, .longType, .longLongType,
+           .nsIntegerType, .cfIndexType:
+        return .int(n.int64Value)
+      default:
+        return .real(n.doubleValue)
+      }
+    case let v as String:
+      return .string(v)
+    case let ref as CacheReference:
+      return .childKey(ref.key)
+    case is [Record.Value]:
+      // List-typed fields are exploded into multiple rows at the
+      // database layer; the per-value encoder must not be called for
+      // them. Throwing here surfaces a programming error early
+      // instead of silently producing a malformed `custom_scalar`.
+      throw SQLiteFieldEncodingError.arrayAtValueLevel
+    default:
+      // `JSONSerialization` raises `NSInvalidArgumentException` (an
+      // ObjC exception, not a Swift error) when passed a non-
+      // Foundation type, which would bypass `do/catch` and abort the
+      // process. Wrapping in a single-element array satisfies
+      // `isValidJSONObject`'s "must be array or dict at the top
+      // level" requirement so scalar JSON-compatibility is
+      // validated.
+      guard JSONSerialization.isValidJSONObject([value]) else {
+        throw SQLiteFieldEncodingError.unsupportedValueType(String(describing: type(of: value)))
+      }
+      return .customScalar(try Self.encodeJSON(value))
+    }
+  }
+
+  /// Reconstructs a value from a fetched row. Exactly one of the
+  /// optional column values should be non-nil; populated-column
+  /// priority matches the encoding order above so that wrong-multi-
+  /// column rows fail fast on the first encountered slot.
+  static func decode(
+    boolValue: Int64?,
+    intValue: Int64?,
+    floatValue: Double?,
+    stringValue: String?,
+    childKeyValue: String?,
+    customScalarValue: String?
+  ) throws -> Record.Value {
+    if let bool = boolValue {
+      return bool != 0
+    }
+    if let int = intValue {
+      return Int(int)
+    }
+    if let real = floatValue {
+      return real
+    }
+    if let str = stringValue {
+      return str
+    }
+    if let childKey = childKeyValue {
+      return CacheReference(childKey)
+    }
+    if let customText = customScalarValue {
+      let parsed = try Self.decodeJSON(customText)
+      guard let value = Self.recordValueFromJSON(parsed) else {
+        throw SQLiteFieldEncodingError.malformedCustomScalar
+      }
+      return value
+    }
+    throw SQLiteFieldEncodingError.noValueColumnPopulated
+  }
+
+  // MARK: - JSON helpers
+
+  /// Stable wrapper key matching the JSON-blob layout's representation
+  /// for cache references nested inside dictionaries. Keeping the same
+  /// key ensures dicts serialized by the legacy layer round-trip
+  /// identically through this layer.
+  private static let referenceWrapperKey = "$reference"
+
+  /// `.sortedKeys` makes the on-disk TEXT representation deterministic
+  /// — the same logical content always produces the same string
+  /// regardless of dictionary iteration order. `.fragmentsAllowed`
+  /// lets the custom-scalar fallback encode bare JSON fragments (e.g.
+  /// `null` for `NSNull`).
+  private static func encodeJSON(_ object: Any) throws -> String {
+    let data = try JSONSerialization.data(
+      withJSONObject: object,
+      options: [.sortedKeys, .fragmentsAllowed]
+    )
+    guard let text = String(data: data, encoding: .utf8) else {
+      throw SQLiteFieldEncodingError.invalidUTF8
+    }
+    return text
+  }
+
+  private static func decodeJSON(_ text: String) throws -> Any {
+    guard let data = text.data(using: .utf8) else {
+      throw SQLiteFieldEncodingError.invalidUTF8
+    }
+    return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+  }
+
+  /// Narrows a `JSONSerialization` output (`NSNumber`/`NSString`/
+  /// `NSArray`/`NSDictionary`/`NSNull` and their Swift bridges) into a
+  /// concrete `Record.Value`. Returns `nil` only for shapes that don't
+  /// map — in practice this means types `JSONSerialization` itself
+  /// can't produce.
+  ///
+  /// `NSNull` is the documented GraphQL null marker and is preserved
+  /// as-is so it survives a write/read round-trip.
+  ///
+  /// A `$reference` wrapper is recognized only when the dict has
+  /// **exactly one key** — a dict that happens to use that key
+  /// alongside other keys (a legitimate custom scalar collision)
+  /// falls through to the generic-dict branch instead, so its full
+  /// payload survives.
+  ///
+  /// `Bool` is checked before `Int` because `NSNumber` boolean
+  /// bridging satisfies `as? Int`; ordering keeps booleans as booleans.
+  private static func recordValueFromJSON(_ json: Any) -> Record.Value? {
+    if json is NSNull {
+      return NSNull()
+    }
+    if let dict = json as? [String: Any] {
+      if dict.count == 1, let key = dict[referenceWrapperKey] as? String {
+        return CacheReference(key)
+      }
+      let narrowed = dict.mapValues { Self.deserializeJSONValue($0) }
+      return narrowed as Record.Value
+    }
+    if let array = json as? [Any] {
+      return array.map { Self.deserializeJSONValue($0) } as Record.Value
+    }
+    if let v = json as? Bool { return v }
+    if let v = json as? Int { return v }
+    if let v = json as? Double { return v }
+    if let v = json as? String { return v }
+    return nil
+  }
+
+  private static func deserializeJSONValue(_ json: Any) -> Record.Value {
+    Self.recordValueFromJSON(json) ?? String(describing: json)
+  }
+}
+
+internal enum SQLiteFieldEncodingError: Error, CustomStringConvertible {
+  case noValueColumnPopulated
+  case malformedCustomScalar
+  case invalidUTF8
+  case unsupportedValueType(String)
+  case arrayAtValueLevel
+
+  var description: String {
+    switch self {
+    case .noValueColumnPopulated:
+      return "Row has no populated value column"
+    case .malformedCustomScalar:
+      return "custom_scalar_value did not decode to a Hashable & Sendable JSON value"
+    case .invalidUTF8:
+      return "Failed to convert JSON between Data and String"
+    case .unsupportedValueType(let typeName):
+      return "Field value of type \(typeName) cannot be JSON-encoded"
+    case .arrayAtValueLevel:
+      return "Array values are list-typed fields and must be exploded into multiple rows; the per-value encoder should not be called for them"
+    }
+  }
+}

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteFieldEncoding.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteFieldEncoding.swift
@@ -33,8 +33,13 @@ import Foundation
 /// should account for this.
 internal enum SQLiteFieldEncoding {
 
-  /// The column slot a single non-array value occupies on a row.
-  internal enum Column: Equatable {
+  /// A `Record.Value` already classified into the column slot it
+  /// occupies on a row. The case payload carries the typed-Swift
+  /// representation of the value as it will be bound to the
+  /// statement, and the case tag identifies the destination column
+  /// (`bool_value`, `int_value`, `float_value`, `string_value`,
+  /// `child_key_value`, or `custom_scalar_value`).
+  internal enum TypedValue: Equatable {
     case bool(Bool)
     case int(Int64)
     case real(Double)
@@ -43,7 +48,7 @@ internal enum SQLiteFieldEncoding {
     case customScalar(String)
   }
 
-  /// Selects the column slot for a single value.
+  /// Classifies a single value into its destination column slot.
   ///
   /// Numeric values (whether native Swift `Int` / `Double` or
   /// `NSNumber`-bridged from JSON) all reach the `as NSNumber` case
@@ -52,7 +57,7 @@ internal enum SQLiteFieldEncoding {
   /// keeping `NSNumber(value: 1)` in `int_value` and
   /// `NSNumber(value: true)` in `bool_value` — they would otherwise
   /// both satisfy `as Bool`.
-  static func encode(_ value: Record.Value) throws -> Column {
+  static func encode(_ value: Record.Value) throws -> TypedValue {
     switch value {
     case let n as NSNumber:
       if CFGetTypeID(n) == CFBooleanGetTypeID() {

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteFieldEncoding.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteFieldEncoding.swift
@@ -23,7 +23,10 @@ import Foundation
 ///   `NSNull` (the GraphQL null marker)                → `custom_scalar_value`   (`"null"`)
 ///   `[String: Record.Value]` and other JSON shapes    → `custom_scalar_value`   (JSON)
 ///
-/// Exactly one value column is non-null on a well-formed row.
+/// Exactly one value column is non-null on a well-formed row. (The
+/// one exception is the empty-list marker row at `position = -2`,
+/// which populates no value column; it is written and read entirely
+/// at the database layer and never passes through this encoder.)
 ///
 /// **Type-identity on round-trip.** SQLite `INTEGER` is 64-bit; the
 /// decoder returns `Int` (which is 64-bit on every Apple deployment

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteSchema.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteSchema.swift
@@ -41,6 +41,15 @@ public enum SQLiteSchema {
     /// writes that omit `position` still land in the right row.
     public static let defaultPositionValue: Int64 = -1
 
+    /// The `position` value for the single marker row written when a
+    /// list-typed field's value is empty (`[]`). An empty list writes
+    /// no element rows, so without a marker it would be
+    /// indistinguishable from a field that was never written — a
+    /// distinction GraphQL cares about (`friends: []` is cached, valid
+    /// data; an absent field is a cache miss). The marker row
+    /// populates no value column; readers decode it back to `[]`.
+    public static let emptyListPositionValue: Int64 = -2
+
     /// The `field_name` column value used for the rows inside a
     /// synthetic sub-record. Synthetic sub-records hold the elements
     /// of a nested list; they don't have multiple named fields, so a
@@ -49,21 +58,32 @@ public enum SQLiteSchema {
     /// cannot collide with any real GraphQL field name.
     public static let syntheticFieldName: String = "$"
 
+    /// The reserved substring that marks a cache key as a synthetic
+    /// sub-record key. Every synthetic key contains this token
+    /// (`<parent>.<field>.$[<position>]`, or `<parent>.$[<position>]`
+    /// for deeper nesting). `insertOrUpdate` rejects user-supplied
+    /// cache keys containing it — the reserved-key audit from
+    /// ADR 0006 — which makes the two classifiers below collision-
+    /// safe by construction: no stored user record can ever match
+    /// them.
+    public static let syntheticKeyToken: String = ".$["
+
     /// Regex matching the trailing `.$[<integer>]` segment of a
     /// synthetic sub-record cache key. Anchored to the end of the
-    /// string. The `$` character cannot appear in a GraphQL Name, so
-    /// this pattern only matches the synthetic keys this database
-    /// produces for nested-list indirection — user-defined cache keys
-    /// will not match unless they deliberately mimic the format.
+    /// string. The `$` character cannot appear in a GraphQL Name, and
+    /// user cache keys containing `syntheticKeyToken` are rejected at
+    /// write time, so this pattern only ever matches the synthetic
+    /// keys this database produces for nested-list indirection.
     public static let syntheticKeySuffixPattern: String = #"\.\$\[[0-9]+\]$"#
 
     /// SQL `LIKE` pattern matching the trailing `.$[<anything>]`
     /// segment of a synthetic sub-record cache key. Less precise than
     /// `syntheticKeySuffixPattern` (SQLite `LIKE` has no character-
-    /// class support for digits), but sufficient for the cascading-
-    /// delete walk: the writer never produces a cache key ending in
-    /// `.$[<non-integer>]`, so a stray match is impossible against
-    /// data we wrote.
+    /// class support for digits), but safe for the same reason as the
+    /// regex: the writer never produces a cache key ending in
+    /// `.$[<non-integer>]`, and user keys containing
+    /// `syntheticKeyToken` are rejected at write time, so a stray
+    /// match is impossible against stored data.
     public static let syntheticKeySuffixLikePattern: String = "%.$[%]"
   }
 

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteSchema.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteSchema.swift
@@ -40,6 +40,31 @@ public enum SQLiteSchema {
     /// at this position. Matches the column's DDL `DEFAULT -1` so
     /// writes that omit `position` still land in the right row.
     public static let defaultPositionValue: Int64 = -1
+
+    /// The `field_name` column value used for the rows inside a
+    /// synthetic sub-record. Synthetic sub-records hold the elements
+    /// of a nested list; they don't have multiple named fields, so a
+    /// single sentinel `field_name` clusters all their rows together.
+    /// The `$` character cannot start a GraphQL Name, so this sentinel
+    /// cannot collide with any real GraphQL field name.
+    public static let syntheticFieldName: String = "$"
+
+    /// Regex matching the trailing `.$[<integer>]` segment of a
+    /// synthetic sub-record cache key. Anchored to the end of the
+    /// string. The `$` character cannot appear in a GraphQL Name, so
+    /// this pattern only matches the synthetic keys this database
+    /// produces for nested-list indirection — user-defined cache keys
+    /// will not match unless they deliberately mimic the format.
+    public static let syntheticKeySuffixPattern: String = #"\.\$\[[0-9]+\]$"#
+
+    /// SQL `LIKE` pattern matching the trailing `.$[<anything>]`
+    /// segment of a synthetic sub-record cache key. Less precise than
+    /// `syntheticKeySuffixPattern` (SQLite `LIKE` has no character-
+    /// class support for digits), but sufficient for the cascading-
+    /// delete walk: the writer never produces a cache key ending in
+    /// `.$[<non-integer>]`, so a stray match is impossible against
+    /// data we wrote.
+    public static let syntheticKeySuffixLikePattern: String = "%.$[%]"
   }
 
   /// Columns for the legacy single-row JSON-blob records-table layout used


### PR DESCRIPTION
## Goal

Land the amended PR-009 scope per [ADR 0006](apollo-ios/Design/adr/0006-list-storage-strategy.md): row-per-element write + delete CRUD against the position-keyed schema introduced in PR-008b (#1005). The JSON `list_value` path is gone; nested lists recurse via synthetic sub-records at `<parent>.<field>.$[<position>]`.

**Cascading deletion of synthetic sub-records is split into a follow-up PR** with extensive cascade-correctness tests. This PR establishes the foundation; the cascade PR ships the cleanup walks.

## What's in this PR

### Public API on `SQLiteDatabase`

| Method | Behavior |
|---|---|
| `insertOrUpdate(records: [Record])` | For each field: scalar → one row at `position = -1`; list → N rows at positions `0..N-1`. Each write atomically clears the field's prior rows before inserting the new ones, so list rewrites and scalar↔list transitions never leave in-field orphans. |
| `deleteRecord(forKey:)` | Direct `DELETE WHERE cache_key = ?`. Does not cascade synthetic sub-records (see below). |
| `deleteRecords(matchingKey:)` | `LIKE … COLLATE NOCASE ESCAPE '\\'` with `\`, `%`, `_` in the user-supplied pattern escaped so literal substrings don't act as wildcards. Does not cascade synthetic sub-records. |

### Synthetic sub-records for nested lists

Per ADR 0006 + the design conversation:

- Outer-list rows for a list-of-list field hold `child_key_value = "<parent>.<field>.$[N]"` pointing at a synthetic sub-record.
- The sub-record's element rows live under `field_name = "$"` (sentinel — `$` can't start a GraphQL Name, so no collision with real fields).
- Deeper nesting (`[[[T]]]`) appends `.$[N]` per level: `User:1.matrix3d.$[0].$[0].$[0]` is the level-3 sub-record's key.
- Detection regex: `\.\$\[[0-9]+\]$`.

### Encoder (`SQLiteFieldEncoding`)

Per-value, never per-array. Lists are exploded into rows at the database layer.

| Swift value | Column |
|---|---|
| `NSNumber` (boolean via `CFGetTypeID == CFBooleanGetTypeID`) | `bool_value` |
| `NSNumber` (integer kinds via `CFNumberGetType`) | `int_value` |
| `NSNumber` (other numeric kinds) | `float_value` |
| `String` | `string_value` |
| `CacheReference` | `child_key_value` (stores `.key`) |
| `NSNull` and any other JSON-shaped value | `custom_scalar_value` (`.sortedKeys + .fragmentsAllowed` JSON) |
| `[Record.Value]` | precondition violation — caller must explode it |

The custom-scalar fallback gates on `JSONSerialization.isValidJSONObject([value])` before encoding so an unsupported type surfaces a Swift error rather than an `NSException` abort. The `$reference` dict-wrapper is recognized only when the dict has *exactly one* key, so a legitimate custom scalar that happens to include `$reference` alongside other keys round-trips intact.

### Test-only read path

A non-public `internal selectRecords(forKeys:)` reassembles records from rows and resolves synthetic `child_key_value` pointers to materialize nested lists. Used by the test suite to verify what `insertOrUpdate` wrote. The production read path is a projection-aware API to be introduced in PR-009b–h per ADR 0007 — not on the public protocol.

### Tests

`SQLiteRowPerElementCRUDTests.swift` (new file) — **32 tests, all passing**:

- Per-type round-trip ×6 (string, int, double, bool ×2, cache reference)
- Lists: scalars, cache references, mixed scalars, empty
- Nested lists: 2D, 3D, list-of-list-of-references
- Multi-field record preserves all fields including `writtenAt`
- UPSERT: writing twice overwrites; changing value type clears prior typed column
- Atomic list rewrite shrinks length cleanly (no orphan rows for the field itself)
- Delete by exact key: removes only matching rows; non-existent key is no-op
- Delete by pattern: matches prefixes, empty pattern is no-op, `_` and `%` escaped
- Transactional rollback: scalar encoding failure, list-element encoding failure
- Custom-scalar hardening: NSNull top level, generic dict, `$reference` with extra keys treated as generic dict
- NSNumber bool/int/double routing keeps each value's type identity
- Empty record produces no rows (documented behavior)

## What's deferred to the follow-up cascade PR

Three places where synthetic sub-record orphans can accumulate under this PR's behavior:

1. **`deleteRecord(forKey:)`** — deletes the record's own rows but leaves any synthetic sub-records the record's nested-list fields pointed at. They become unreachable but persistent.
2. **`insertOrUpdate` atomic-rewrite over a nested-list field** — clears the field's own rows but not the synthetic sub-records the prior rows pointed at. They orphan.
3. **`deleteRecords(matchingKey:)` + synthetic sub-records** — the flat `LIKE` filter may or may not match synthetic sub-records depending on the pattern. Behavior is currently ambiguous; the cascade PR pins it down.

The cascade PR will:

- Add `cascadeDeleteFromCacheKey` and `cascadeDeleteFromField` CTEs (and a `LIKE`-pattern variant for `deleteRecords(matchingKey:)`).
- Wire them into all three call sites above.
- Add a test-only helper that **bypasses the synthetic-key filter in `selectRecords`** so orphan detection actually verifies the database state (the previous cascade tests on this PR's branch passed *regardless of cascade behavior* because `selectRecords` filtered synthetic keys before the assertions ran — a real test bug surfaced during review).
- Ship 8+ cascade-correctness tests:
  - depth-1 / depth-2 / depth-3 cascade
  - cascade isolation: deleting record A doesn't disturb record B's synthetic sub-records
  - multiple list-typed fields on one record → each field's synthetic sub-records all cascade
  - mixed list contents (synthetic + real `CacheReference`) — cascade follows synthetic only
  - real `CacheReference` *inside* a synthetic sub-record — that ref's target NOT cascaded
  - atomic-rewrite cascade for nested → scalar transition
  - atomic-rewrite cascade for nested → differently-typed nested
  - `deleteRecords(matchingKey:)` + synthetic interaction (with a pinned-down behavior)

The deferred cascade and its tests don't gate this PR's correctness for the operations it ships — `selectRecords` never returns orphan synthetic sub-records as top-level records, so the read surface is unaffected. The cascade is about storage hygiene + the eventual `clearDatabase` cleanliness contract.

## Acceptance criteria

- [x] Encoder + CRUD + tests compile.
- [x] All 32 new tests pass.
- [x] Full `Apollo-UnitTestPlan` is green.
- [x] Zero navigator errors.
- [x] `selectRecords` is not on the public protocol — only an `internal` helper.
- [x] Doc comments on `insertOrUpdate` and `deleteRecord(forKey:)` clearly call out the deferred cascade.

## Stacks on

`cache-rewrite/phase-1-plan` at `e06a2b859` (the PR-008b merge commit).

## Followup

1. **(next)** Cascading-delete PR — adds the cascade walks + extensive cascade-correctness tests.
2. Per ADR 0007's sub-phase 1A.5: PR-009b (`FieldProjection` types), PR-009c–h.
