### PR TITLE
docs(cache): ADR 0006 — list storage strategy

### DIFF
--- a/apollo-ios/Design/adr/0006-list-storage-strategy.md
+++ b/apollo-ios/Design/adr/0006-list-storage-strategy.md
@@ -1,6 +1,6 @@
-# ADR 0006 — List storage strategy: JSON-encoded `list_value` vs sibling `list_items` table
+# ADR 0006 — List storage strategy: JSON blob, sibling table, or in-place rows with `position`
 
-- **Status:** Proposed — decision deferred to PR-011a list-heavy benchmark data; locked before PR-012 (3.0-alpha tag)
+- **Status:** Proposed — Option 3 (in-place rows with `position`) is the **leading candidate**; final lock before PR-012 (3.0-alpha tag) based on PR-011a list-heavy benchmark data
 - **Date:** 2026-05-28
 - **Phase 1 PR:** Out-of-stack docs follow-up to PR-009
 - **Engineering plan reference:** [cache-rewrite-phase1-plan.md §7.1, §7.4](../cache-rewrite-phase1-plan.md)
@@ -14,21 +14,20 @@ The §7.1 choice traces to Zach's [SQLite Performance Benchmarks](https://apollo
 
 PR-009's encoder/decoder already implements the JSON path end-to-end and hardens it (PR-009 review-findings commit: `JSONSerialization.isValidJSONObject` probe, `NSNull` round-trip, `$reference`-wrapper disambiguation, `sortedKeys` for stable on-disk bytes). The implementation is real; what is missing is the *evidence* that this implementation is the right one.
 
-This ADR scopes that question and the evidence-collection plan that resolves it.
+This ADR scopes the question and the evidence-collection plan that resolves it.
 
 ## Decision
 
-**Defer.** The choice between the two options below is not made by this ADR. The ADR commits to:
+**Defer.** The choice between the three options below is not made by this ADR. The ADR commits to:
 
 1. Treating the §7.1 `list_value TEXT` shape as a **provisional default**, not a ratified choice, until list-heavy benchmark data exists.
-2. Adding list-heavy scenarios to the PR-011 / PR-011a performance-measurement harness (see §3, "Deciding evidence").
-3. **Locking the decision before PR-012** — the 3.0-alpha tag — based on those numbers. The lock happens by amending this ADR with a Status flip from *Proposed* to *Accepted* and a final §2 Decision paragraph naming the chosen option.
-
-The two options under evaluation are:
+2. Naming **Option 3 (in-place rows with `position`)** as the leading candidate, on design-merit grounds. Final ratification still requires the PR-011a numbers.
+3. Adding list-heavy scenarios to the PR-011 / PR-011a performance-measurement harness (see §4, "Deciding evidence").
+4. **Locking the decision before PR-012** — the 3.0-alpha tag. The lock happens by amending this ADR with a Status flip from *Proposed* to *Accepted* and a final §2 Decision paragraph naming the chosen option.
 
 ### Option 1 — Ratify JSON-encoded `list_value` (current §7.1 shape)
 
-Keep the row-per-field layout exactly as specified in engineering plan §7.1. Each list-typed field stores its elements as a JSON-encoded `TEXT` blob in `list_value`. Nested lists (`[[Int]]`, `[[CacheReference]]`) are handled naturally by JSON's recursive structure — no schema change required.
+Each list-typed field stores its elements as a JSON-encoded `TEXT` blob in `list_value`. Nested lists (`[[Int]]`, `[[CacheReference]]`) are handled naturally by JSON's recursive structure — no schema change required.
 
 ### Option 2 — Migrate list-typed fields to a sibling `list_items` table
 
@@ -45,55 +44,76 @@ CREATE TABLE IF NOT EXISTS list_items (
   bool_value           INTEGER,
   child_key_value      TEXT,
   custom_scalar_value  TEXT,
-  -- nested-list strategy: TBD; see §4 trade-off table
   PRIMARY KEY (cache_key, field_name, position),
   FOREIGN KEY (cache_key, field_name) REFERENCES records(cache_key, field_name) ON DELETE CASCADE
 ) WITHOUT ROWID;
 ```
 
-The `list_value` column in `records` is either dropped or repurposed as a fast-path for very short lists; the design detail is part of the option's evaluation. Reads issue a second `SELECT … WHERE cache_key = ? AND field_name = ? ORDER BY position` for any list-typed field (or a `LEFT JOIN` if the planner prefers).
+Reads issue a second `SELECT … WHERE cache_key = ? AND field_name = ? ORDER BY position` for any list-typed field (or a `LEFT JOIN`). Nested lists require an explicit depth strategy — depth column, recursive `list_of_lists` table, or JSON fallback above depth 1.
 
-Nested lists (`[[Int]]`, `[[CacheReference]]`) require an explicit depth strategy under Option 2 — either a `depth` column with a self-referential structure, or a separate `list_of_lists` shape, or a fallback to JSON-encoding for nesting depth > 1. There is no shape that mirrors Option 1's natural recursion without paying additional schema complexity.
+### Option 3 — In-place rows with `position`; recurse via `child_key_value` for depth ≥ 2 (leading candidate)
+
+Extend the records table's PK with a `position` column. Scalars use a sentinel `position = -1`; list elements use `position = 0..N-1`. List-element rows live in the same table as the parent record, at the same `cache_key`. Thanks to `WITHOUT ROWID` clustering, they are physically adjacent to the parent's scalar fields on disk.
+
+```sql
+CREATE TABLE IF NOT EXISTS records (
+  cache_key            TEXT NOT NULL,
+  field_name           TEXT NOT NULL,
+  position             INTEGER NOT NULL DEFAULT -1,  -- -1 = scalar; 0..N-1 = list element
+  int_value            INTEGER,
+  string_value         TEXT,
+  float_value          REAL,
+  bool_value           INTEGER,
+  child_key_value      TEXT,
+  custom_scalar_value  TEXT,
+  written_at           INTEGER NOT NULL,
+  PRIMARY KEY (cache_key, field_name, position)
+) WITHOUT ROWID;
+```
+
+The depth-1 case (`[Int]`, `[String]`, `[Friend]` — ~99% of GraphQL list-typed fields in practice) is handled entirely in-place: one `SELECT … WHERE cache_key = ?` returns scalar fields *and* list elements in the same result set, clustered together on disk. No JSON, no second table, no join.
+
+Nested lists (`[[Int]]`, `[[CacheReference]]` — the rare case) recurse via the existing `CacheKey` indirection: an outer list's row holds a synthetic `child_key_value` (e.g., `User:1.tags[3]`) pointing to a sub-record, which itself uses the depth-1 layout for the inner list. This reuses the reference machinery the cache already has rather than introducing a new mechanism. Depth is bounded by the GraphQL schema, not unbounded — the executor walks a selection set whose shape is compiled in, so we never need recursive CTEs or "find all descendants" queries.
+
+This is the industry-standard **adjacency-list-with-position** pattern applied to a domain where depth is bounded and known at codegen time. The heavier hierarchical-data patterns (nested set, closure table, materialized path) exist to answer queries we never ask.
 
 ## Trade-offs
 
-| Dimension | Option 1 (JSON `list_value`) | Option 2 (`list_items` table) |
-|---|---|---|
-| Read cost — short list | One row, one column. Decode `JSONSerialization` once. | Second `SELECT` or join. Per-element row construction. |
-| Read cost — long list | `JSONSerialization` cost grows with list length. | Per-row dispatch grows with length; potentially better cache locality with `WITHOUT ROWID` clustering. |
-| Write cost — full overwrite | One row UPSERT regardless of list cardinality. | N row UPSERTs for length N. Bulk transaction required for atomicity. |
-| Write cost — single-element edit | Re-encode and re-write the entire list. | One row UPSERT at the relevant `position`. |
-| Order preservation | Implicit (JSON arrays are ordered). | Explicit `position` column on every row. |
-| Type symmetry with scalars | Asymmetric — scalars get typed columns, list elements collapse to JSON. | Symmetric — list elements get the same typed-column layout as scalars in the parent table. |
-| Nested lists (`[[Int]]`, `[[CacheReference]]`) | Native — JSON nests recursively. | Requires depth strategy: recursive `list_of_lists` table, depth column, or JSON-fallback above depth 1. |
-| Child-reference indexing | Impossible without parsing JSON. Blocks per-element FK or sentinel columns for Phase 2 `@onDelete` cascade. | Each `child_key_value` element is a row — directly indexable. Phase 2 cascade can model relationships at the storage layer. |
-| SQL operations on members | Not feasible (opaque blob). | Filter, join, aggregate on list members directly. |
-| Schema surface | One table. | Two tables. Every future schema migration touches both. |
-| Implementation effort to ship | Already complete (PR-009 + review-findings commit). | New encoder, new decoder, new `WITHOUT ROWID` table, new migration step, new transactional contract for write atomicity. |
+| Dimension | Option 1 (JSON `list_value`) | Option 2 (`list_items` table) | Option 3 (in-place `position` + indirection) |
+|---|---|---|---|
+| Read cost | One row, but `JSONSerialization` decode cost grows with list length. | Extra `SELECT` or join per list-typed field. | Same `SELECT` as the parent record (clustered via `WITHOUT ROWID`); depth ≥ 2 adds one `SELECT` per outer element. |
+| Write cost | One row UPSERT for full list; full re-encode for any element edit. | N row UPSERTs; single-element edit is one UPSERT at `position`. | N row UPSERTs in the same table; single-element edit is one UPSERT at `position`. |
+| Order preservation | Implicit (JSON arrays are ordered). | Explicit `position INTEGER` column. | Explicit `position INTEGER` column; typed sort, no zero-padding. |
+| Type symmetry with scalars | Asymmetric — scalars typed, list elements collapse to JSON. | Symmetric within the separate table. | Symmetric within the same table. |
+| Nested lists `[[T]]` | Native — JSON nests recursively. | Requires depth strategy (depth column, `list_of_lists` table, or JSON fallback). | Recurses via `child_key_value` to a synthetic sub-record; reuses existing reference indirection; bounded by GraphQL schema depth. |
+| Child-reference indexing (Phase 2 `@onDelete` cascade) | Impossible without parsing JSON to find children. | Each reference element is its own row. | Each reference element is its own row in the same table; existing cascade walker handles it without a second source. |
+| Schema surface + impl effort | One table. Already implemented (PR-009 + review-findings). | Two tables. New encoder, decoder, migration step, transactional contract for write atomicity. | One table with extended PK `(cache_key, field_name, position)` and `DEFAULT -1` sentinel. Position-aware reader/writer plus the depth ≥ 2 recursion path. PR-009's encoder retains most of its current shape. |
 
 ## Deciding evidence
 
-The PR-011 / PR-011a perf-harness PRs are the right place to collect the missing data. Adding list-heavy scenarios there has the side benefit of strengthening the 3.0-alpha published dataset against future regressions, independent of this ADR's outcome.
+The PR-011 / PR-011a perf-harness PRs are the right place to collect the missing data. Adding list-heavy scenarios there strengthens the 3.0-alpha published dataset against future regressions, independent of this ADR's outcome.
 
 Scenarios to add (Tier 2 — `NormalizedCache` protocol level — and Tier 3 — direct SQLite operations):
 
 | Scenario | Tier | Purpose |
 |---|---|---|
-| `read-record-with-list-of-N-scalars` (N ∈ {10, 100, 1000}) | 2, 3 | Read cost as list length grows |
+| `read-record-with-list-of-N-scalars` (N ∈ {10, 100, 1000}) | 2, 3 | Read cost as list length grows; tests Option 3's clustered-row read |
 | `read-record-with-list-of-N-references` (N ∈ {10, 100, 1000}) | 2, 3 | Reference-typed list cost; relevant to Phase 2 cascade |
-| `write-list-of-N-scalars` (cold + warm) | 2, 3 | Full-list write cost; pivotal for Option 1 vs 2 |
+| `write-list-of-N-scalars` (cold + warm) | 2, 3 | Full-list write cost; the per-row vs single-row write head-to-head |
 | `write-list-of-N-references` (cold + warm) | 2, 3 | As above with reference elements |
-| `mutate-single-element-in-list-of-N` (N ∈ {10, 100, 1000}) | 2 | Pivotal for the "edit one item" workload that favors Option 2 |
-| `read-record-with-nested-list-[[Int]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | Stresses Option 2's depth strategy |
+| `mutate-single-element-in-list-of-N` (N ∈ {10, 100, 1000}) | 2 | Pivotal — Option 1 re-encodes; Options 2 + 3 each UPSERT one row |
+| `mutate-element-at-position-K-in-list-of-N` | 2 | Direct measurement of Option 3's `UPDATE … WHERE position = ?` path vs Option 1's full-JSON rewrite |
+| `read-record-with-nested-list-[[Int]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | Quantifies Option 3's depth ≥ 2 indirection cost vs Option 1's nested-JSON decode |
 | `read-record-with-nested-list-[[CacheReference]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | As above with the reference shape Phase 2 cares about |
 
 Per perf plan §3, these add a new performance-relevant subsystem (list paths) that the existing scenarios do not cover; perf plan §5.2 already anticipates inline `feat(perf): add scenario for X` additions. The list scenarios land in PR-011a as part of the comprehensive Tier 1 / Tier 2 harness; the Tier 3 SQLite-level scenarios extend PR-011.
 
 The decision rule for the lock:
 
-- If Option 1 is within the §7.4 performance envelope (suitably extended for the new scenarios) across all list lengths *and* the Option 2 mutate-single-element case is not dramatically faster (>3× speedup on `mutate-single-element-in-list-of-100`, say), **Option 1 is ratified**. The asymmetry is accepted; Phase 2 `@onDelete` cascade pays its own per-element parse cost when the time comes.
-- If Option 2 is materially faster on `mutate-single-element-in-list-of-N` or `read-record-with-list-of-1000-references` *and* the nested-list overhead is bounded, **Option 2 is adopted before PR-012.** A new PR (call it PR-009b) lands the second table, migrating the `list_value` path. Migration is a no-op for end users (drop-and-rebuild migration per ADR 0001 already happens once on 3.0 upgrade; the schema simply lands in its final shape).
-- Edge cases — Option 2 wins single-element edit but loses bulk reads, or vice versa — escalate to the reviewer per execution plan §6 trigger 8.
+- If Option 3's depth-1 reads are within the §7.4 envelope across all list lengths *and* `mutate-element-at-position-K` shows a material speedup over Option 1 (>2× on N=100, say) *and* the depth ≥ 2 indirection cost is bounded (≤ 2× of Option 1's nested-JSON decode on the `[[Int]]` scenarios), **Option 3 is ratified.** A new PR (call it PR-009b) extends the PK and lands the position-aware reader/writer before PR-012. The depth ≥ 2 recursion is added in the same PR.
+- If Option 1 is competitive on every scenario and the asymmetry's only material cost is conceptual, **Option 1 is ratified** as the path-of-least-change. The asymmetry is accepted; Phase 2 `@onDelete` cascade pays its own per-element JSON parse cost when the time comes.
+- Option 2 is ratified only if Option 3's depth ≥ 2 indirection cost is unacceptably high *and* Option 1's nested-JSON decode is also unacceptably high — a narrow case. In that scenario, PR-009b instead lands the sibling table.
+- Edge cases — Option 3 wins single-element edit but loses bulk reads, or any other split outcome — escalate to the reviewer per execution plan §6 trigger 8.
 
 The lock is final by PR-012. After 3.0-alpha tags, changing the list-storage strategy would force a second drop-and-rebuild migration on existing 3.0-alpha installs — the same reason §7.1's `written_at` column is added in PR-008 instead of Phase 1C.
 
@@ -101,21 +121,22 @@ The lock is final by PR-012. After 3.0-alpha tags, changing the list-storage str
 
 ### Positive
 
-- **Empirical grounding for an unmeasured choice.** The current §7.1 wording attributes the row-per-field shape to a published benchmark, but the benchmark does not cover list paths. This ADR closes that gap before the choice becomes hard to reverse.
-- **Decision-relevant scenarios become permanent harness coverage.** Even if Option 1 is ratified, the list-heavy scenarios remain in PR-011a's output. Phase 2 (`@onDelete` cascade, LRU on lists) gets a baseline to regress against from day one.
-- **Nested-list complexity is surfaced and budgeted, not discovered.** Option 2's depth strategy is identified now, when the cost of designing it is a paragraph in this ADR. If the decision had been made silently in favor of Option 2 without surfacing nesting, the discovery would land mid-implementation.
+- **Empirical grounding for an unmeasured choice.** §7.1 attributes the row-per-field shape to a published benchmark, but the benchmark does not cover list paths. This ADR closes that gap before the choice becomes hard to reverse.
+- **The leading-candidate framing accelerates Phase 1A planning.** If Option 3 wins the benchmark, PR-009b is the scoped follow-up; the agent and reviewer can prepare it speculatively without committing.
+- **Decision-relevant scenarios become permanent harness coverage.** Whichever option lands, the list-heavy scenarios remain in PR-011a's output. Phase 2 (`@onDelete` cascade, LRU on lists) gets a baseline to regress against from day one.
+- **Nested-list complexity is surfaced and budgeted, not discovered.** Option 3's depth ≥ 2 recursion path is identified now; if it had been discovered mid-implementation, it would have surfaced as scope creep on a code PR rather than a paragraph in this ADR.
 - **PR-012 gating criteria already accommodate this.** The 3.0-alpha tag is already gated on "no `regressed` verdict in the published dataset"; this ADR adds list scenarios to that dataset without changing the gating mechanic.
 
 ### Negative
 
-- **Phase 1A timeline absorbs a small amount of additional scenario authoring.** PR-011a's estimate (~700 LoC) already includes Tier 1 + Tier 2 scenario coverage; the list-heavy additions are ~150–250 LoC of additional scenario code plus the supporting fixtures. Mitigation: scenario authoring is mechanical and parallelizable with other Phase 1A work; the perf plan §5.2 inline-PR pattern accommodates this without restructuring §8.
-- **Two possible outcomes mean two possible implementation paths in Phase 1A.** If Option 2 wins, a new PR (PR-009b) lands the migration before PR-012; if Option 1 wins, no additional code is required. The agent and reviewer must hold both possibilities open until the benchmark data arrives. Mitigation: the decision rule above is mechanical; the additional PR (if needed) is ~400 LoC of well-scoped storage work, comparable to PR-010 in size.
-- **Deferring the decision means PR-009's encoder remains in production-shape under uncertainty.** The encoder is correct and hardened; if Option 2 wins, parts of it are discarded. Mitigation: the discarded code is a localized JSON encoder path, not architecture; the cost of writing it (already paid) is recovered as test fixtures and as the Option 1 fallback if Option 2 turns out worse than expected at the eleventh hour.
+- **Phase 1A timeline absorbs additional scenario authoring.** PR-011a's estimate (~700 LoC) already includes Tier 1 + Tier 2 scenario coverage; the list-heavy additions are ~200–300 LoC of scenario code plus fixtures. Mitigation: scenario authoring is mechanical and parallelizable; perf plan §5.2 accommodates inline additions without restructuring §8.
+- **Three possible outcomes mean three possible implementation paths.** The agent and reviewer must hold all three open until the benchmark data arrives. Mitigation: the decision rule above is mechanical; Option 3's PR-009b (the expected outcome) is ~300–400 LoC, comparable to PR-010.
+- **Option 3 sentinel semantics add a small reader-side decoder cost.** Every `SELECT` against the records table returns scalar rows interleaved with list-element rows; the decoder must branch on `position = -1`. Mitigation: a single integer comparison per row; negligible vs the JSON-decode cost of Option 1 and the second-`SELECT` cost of Option 2.
 
 ### Neutral
 
-- **No 2.x parity question.** 2.x has no list-storage strategy distinct from its records-blob-as-JSON layout; both options under evaluation are improvements over the 2.x shape. The 2.x baseline dataset (PR-004a, #980) does not measure list paths separately because the 2.x storage layer does not separate them.
-- **The §7.1 wording will need a small editorial pass** once the decision is locked, regardless of outcome — to either (a) cite this ADR and remove the unsourced "JSON-encoded list" claim, or (b) describe the `list_items` table as the locked design.
+- **No 2.x parity question.** 2.x has no list-storage strategy distinct from its records-blob-as-JSON layout; all three options under evaluation are improvements. The 2.x baseline dataset (PR-004a, #980) does not measure list paths separately because the 2.x storage layer does not separate them.
+- **The §7.1 wording will need a small editorial pass** once the decision is locked — to either (a) cite this ADR and remove the unsourced "JSON-encoded list" claim, (b) describe the `list_items` table as the locked design, or (c) describe the extended PK with the `position` sentinel.
 
 ## References
 
@@ -124,7 +145,8 @@ The lock is final by PR-012. After 3.0-alpha tags, changing the list-storage str
 - [Perf plan §3.2, §3.3, §5.2](../cache-rewrite-phase1-perf.md) — Tier 2 / Tier 3 scenario design and the inline `feat(perf): add scenario` pattern
 - [Execution plan §8 PR-011, PR-011a, PR-012](../cache-rewrite-phase1-execution.md) — perf-harness PRs that carry the new list-heavy scenarios and the 3.0-alpha tag gating
 - [ADR 0001 — Major version bump](./0001-major-version-bump.md) — drop-and-rebuild migration policy that constrains the lock to "before PR-012"
-- [ADR 0002 — Record abstraction](./0002-record-abstraction.md) — in-memory `CachedField` shape (independent of this ADR; both options round-trip cleanly to `CachedField`)
+- [ADR 0002 — Record abstraction](./0002-record-abstraction.md) — in-memory `CachedField` shape (independent of this ADR; all three options round-trip cleanly to `CachedField`)
 - [SQLite Performance Benchmarks (Confluence 1585152147)](https://apollographql.atlassian.net/wiki/spaces/ClientDev/pages/1585152147) — origin of the row-per-field shape; the source that does not cover list paths
 - [PR-009 (#1001)](https://github.com/apollographql/apollo-ios-dev/pull/1001) — row-per-field CRUD implementation; review thread that surfaced the asymmetry
 - [`SQLiteFieldEncoding.swift`](../../Sources/ApolloSQLite/SQLiteFieldEncoding.swift) — current JSON-encoded list-path implementation
+- Industry pattern reference for the Option 3 shape: adjacency-list-with-position, with depth bounded by the GraphQL schema rather than handled via closure table / nested set. See discussion of when to combine adjacency list with other models for hierarchical data — e.g., [Djellouli, *Storing Hierarchical Data in Relational Databases with SQL*](https://adamdjellouli.com/articles/databases_notes/03_sql/09_hierarchical_data).

--- a/apollo-ios/Design/adr/0006-list-storage-strategy.md
+++ b/apollo-ios/Design/adr/0006-list-storage-strategy.md
@@ -1,6 +1,6 @@
-# ADR 0006 — List storage strategy: JSON blob, sibling table, or in-place rows with `position`
+# ADR 0006 — List storage strategy: sibling table or in-place rows with `position`
 
-- **Status:** Proposed — Option 3 (in-place rows with `position`) is the **leading candidate**; final lock before PR-012 (3.0-alpha tag) based on PR-011a list-heavy benchmark data
+- **Status:** Proposed — Option 2 (in-place rows with `position`) is the **leading candidate**; final lock before PR-012 (3.0-alpha tag) based on PR-011a list-heavy benchmark data
 - **Date:** 2026-05-28
 - **Phase 1 PR:** Out-of-stack docs follow-up to PR-009
 - **Engineering plan reference:** [cache-rewrite-phase1-plan.md §7.1, §7.4](../cache-rewrite-phase1-plan.md)
@@ -10,26 +10,24 @@
 
 [ADR 0002](./0002-record-abstraction.md) settled the in-memory `Record` shape; engineering plan §7.1 settled the on-disk shape: one row per field, with per-type value columns (`int_value`, `string_value`, `float_value`, `bool_value`, `child_key_value`, `custom_scalar_value`) plus `list_value TEXT` for list-typed fields. Scalars land in their typed column; lists land as a JSON-encoded blob in `list_value`. This asymmetry was flagged in the PR-009 review: scalar fields get a typed, indexable column, but list elements collapse to a single opaque string.
 
-The §7.1 choice traces to Zach's [SQLite Performance Benchmarks](https://apollographql.atlassian.net/wiki/spaces/ClientDev/pages/1585152147) (Confluence page 1585152147), the same source that motivates the row-per-field shape itself. The benchmark's published numbers — and the §7.4 performance gates derived from them — measure exact-key selects, type+selection-set selects, composite-PK updates, single-row inserts, and CTE-join sorts. None of those scenarios exercise list-heavy paths. There is no empirical evidence that JSON-encoded `list_value` is the optimal choice for list-typed fields specifically; the design inherits the choice without having measured the alternative.
+The §7.1 choice traces to Zach's [SQLite Performance Benchmarks](https://apollographql.atlassian.net/wiki/spaces/ClientDev/pages/1585152147) (Confluence page 1585152147), the same source that motivates the row-per-field shape itself. The benchmark's published numbers — and the §7.4 performance gates derived from them — measure exact-key selects, type+selection-set selects, composite-PK updates, single-row inserts, and CTE-join sorts. None of those scenarios exercise list-heavy paths.
 
-PR-009's encoder/decoder already implements the JSON path end-to-end and hardens it (PR-009 review-findings commit: `JSONSerialization.isValidJSONObject` probe, `NSNull` round-trip, `$reference`-wrapper disambiguation, `sortedKeys` for stable on-disk bytes). The implementation is real; what is missing is the *evidence* that this implementation is the right one.
+Separately, the cache is required to support **per-element queries against list-typed fields** — filtering and indexing list elements at the SQL level, observing changes to a specific list element via the watcher, and walking list elements as part of the Phase 2 `@onDelete` cascade. JSON-blob storage forbids all of these at the SQL layer (any operation requires loading and parsing the entire blob in Swift). This is a hard capability requirement, not a performance preference; it eliminates the JSON `list_value` shape from the option space regardless of how it benchmarks.
 
-This ADR scopes the question and the evidence-collection plan that resolves it.
+What remains is choosing between two row-per-element shapes. The benchmark gap from §7.1 still applies — neither shape has been measured against the other — and the lock happens against perf data before PR-012.
+
+PR-009's encoder/decoder implements the JSON path end-to-end and hardens it (PR-009 review-findings commit: `JSONSerialization.isValidJSONObject` probe, `NSNull` round-trip, `$reference`-wrapper disambiguation, `sortedKeys` for stable on-disk bytes). That code is correct but addresses the rejected shape; both options below replace it.
 
 ## Decision
 
-**Defer.** The choice between the three options below is not made by this ADR. The ADR commits to:
+**Defer between the two row-per-element options below.** The ADR commits to:
 
-1. Treating the §7.1 `list_value TEXT` shape as a **provisional default**, not a ratified choice, until list-heavy benchmark data exists.
-2. Naming **Option 3 (in-place rows with `position`)** as the leading candidate, on design-merit grounds. Final ratification still requires the PR-011a numbers.
-3. Adding list-heavy scenarios to the PR-011 / PR-011a performance-measurement harness (see §4, "Deciding evidence").
+1. Treating the §7.1 `list_value TEXT` shape as **rejected** on capability grounds (see Alternatives considered). The PR-009 JSON encoder/decoder is interim code that will be replaced before 3.0-alpha tags.
+2. Naming **Option 2 (in-place rows with `position`)** as the leading candidate, on design-merit grounds. Final ratification still requires the PR-011a numbers.
+3. Adding list-heavy scenarios to the PR-011 / PR-011a performance-measurement harness (see "Deciding evidence").
 4. **Locking the decision before PR-012** — the 3.0-alpha tag. The lock happens by amending this ADR with a Status flip from *Proposed* to *Accepted* and a final §2 Decision paragraph naming the chosen option.
 
-### Option 1 — Ratify JSON-encoded `list_value` (current §7.1 shape)
-
-Each list-typed field stores its elements as a JSON-encoded `TEXT` blob in `list_value`. Nested lists (`[[Int]]`, `[[CacheReference]]`) are handled naturally by JSON's recursive structure — no schema change required.
-
-### Option 2 — Migrate list-typed fields to a sibling `list_items` table
+### Option 1 — Sibling `list_items` table
 
 Lists become a one-to-many relation against a second table:
 
@@ -49,9 +47,9 @@ CREATE TABLE IF NOT EXISTS list_items (
 ) WITHOUT ROWID;
 ```
 
-Reads issue a second `SELECT … WHERE cache_key = ? AND field_name = ? ORDER BY position` for any list-typed field (or a `LEFT JOIN`). Nested lists require an explicit depth strategy — depth column, recursive `list_of_lists` table, or JSON fallback above depth 1.
+Reads issue a second `SELECT … WHERE cache_key = ? AND field_name = ? ORDER BY position` for any list-typed field (or a `LEFT JOIN`). Nested lists (`[[Int]]`, `[[CacheReference]]`) require an explicit depth strategy — depth column, recursive `list_of_lists` table, or per-element `child_key_value` indirection to a record-shaped sub-list. The depth strategy is part of the ratification, not deferred separately.
 
-### Option 3 — In-place rows with `position`; recurse via `child_key_value` for depth ≥ 2 (leading candidate)
+### Option 2 — In-place rows with `position`; recurse via `child_key_value` for depth ≥ 2 (leading candidate)
 
 Extend the records table's PK with a `position` column. Scalars use a sentinel `position = -1`; list elements use `position = 0..N-1`. List-element rows live in the same table as the parent record, at the same `cache_key`. Thanks to `WITHOUT ROWID` clustering, they are physically adjacent to the parent's scalar fields on disk.
 
@@ -77,43 +75,52 @@ Nested lists (`[[Int]]`, `[[CacheReference]]` — the rare case) recurse via the
 
 This is the industry-standard **adjacency-list-with-position** pattern applied to a domain where depth is bounded and known at codegen time. The heavier hierarchical-data patterns (nested set, closure table, materialized path) exist to answer queries we never ask.
 
+## Alternatives considered
+
+### JSON-encoded `list_value` (current §7.1 default — rejected)
+
+Keep the row-per-field layout exactly as specified in engineering plan §7.1. Each list-typed field stores its elements as a JSON-encoded `TEXT` blob in `list_value`. Nested lists handle naturally via JSON's recursive structure.
+
+- *Rejected because:* **list elements stored as a JSON blob cannot be queried at the SQL level.** Filtering a list by element value, indexing on element shape, watching for changes to a single element, and walking list elements during the Phase 2 `@onDelete` cascade all require loading the entire blob into Swift and parsing it — work proportional to list length on every operation, with no opportunity for SQLite's query planner to participate. The asymmetry with scalar fields (which get typed, indexable columns) is the surface symptom; the underlying problem is that JSON storage forecloses an entire class of capabilities the cache is required to support. No benchmark outcome rescues this option, because the constraint is capability rather than cost. The PR-009 encoder/decoder for this shape was correct, but it solves a problem we have decided not to keep.
+
 ## Trade-offs
 
-| Dimension | Option 1 (JSON `list_value`) | Option 2 (`list_items` table) | Option 3 (in-place `position` + indirection) |
-|---|---|---|---|
-| Read cost | One row, but `JSONSerialization` decode cost grows with list length. | Extra `SELECT` or join per list-typed field. | Same `SELECT` as the parent record (clustered via `WITHOUT ROWID`); depth ≥ 2 adds one `SELECT` per outer element. |
-| Write cost | One row UPSERT for full list; full re-encode for any element edit. | N row UPSERTs; single-element edit is one UPSERT at `position`. | N row UPSERTs in the same table; single-element edit is one UPSERT at `position`. |
-| Order preservation | Implicit (JSON arrays are ordered). | Explicit `position INTEGER` column. | Explicit `position INTEGER` column; typed sort, no zero-padding. |
-| Type symmetry with scalars | Asymmetric — scalars typed, list elements collapse to JSON. | Symmetric within the separate table. | Symmetric within the same table. |
-| Nested lists `[[T]]` | Native — JSON nests recursively. | Requires depth strategy (depth column, `list_of_lists` table, or JSON fallback). | Recurses via `child_key_value` to a synthetic sub-record; reuses existing reference indirection; bounded by GraphQL schema depth. |
-| Child-reference indexing (Phase 2 `@onDelete` cascade) | Impossible without parsing JSON to find children. | Each reference element is its own row. | Each reference element is its own row in the same table; existing cascade walker handles it without a second source. |
-| Schema surface + impl effort | One table. Already implemented (PR-009 + review-findings). | Two tables. New encoder, decoder, migration step, transactional contract for write atomicity. | One table with extended PK `(cache_key, field_name, position)` and `DEFAULT -1` sentinel. Position-aware reader/writer plus the depth ≥ 2 recursion path. PR-009's encoder retains most of its current shape. |
+The choice between Option 1 (sibling table) and Option 2 (in-place rows) is what the PR-011a numbers resolve. Both support per-element querying — the capability requirement that eliminated JSON — so the comparison reduces to read locality, schema surface, and the nested-list handling cost.
+
+| Dimension | Option 1 (`list_items` table) | Option 2 (in-place `position` + indirection) |
+|---|---|---|
+| Read cost — depth 1 | Extra `SELECT` or join per list-typed field. | Same `SELECT` as the parent record (clustered via `WITHOUT ROWID`). |
+| Read cost — depth ≥ 2 | Depends on the chosen depth strategy. Recursive `list_of_lists` table: another `SELECT`/join per nesting level. Depth column with self-join: planner-dependent. | One extra `SELECT` per outer element (the `child_key_value` indirection). |
+| Write cost | N row UPSERTs per list; single-element edit is one UPSERT at `position`. | N row UPSERTs per list in the same table; single-element edit is one UPSERT at `position`. |
+| Order preservation | Explicit `position INTEGER` column. | Explicit `position INTEGER` column; typed sort, no zero-padding. |
+| Type symmetry with scalars | Symmetric within the separate table. | Symmetric within the same table. |
+| Child-reference indexing (Phase 2 `@onDelete` cascade) | Each reference element is its own row in `list_items`; cascade walker must read from two tables. | Each reference element is its own row in `records`; existing cascade walker handles it without a second source. |
+| Schema surface + impl effort | Two tables. New encoder, decoder, migration step, transactional contract for write atomicity. Depth strategy adds further design work. | One table with extended PK `(cache_key, field_name, position)` and `DEFAULT -1` sentinel. Position-aware reader/writer plus the depth ≥ 2 recursion path. PR-009's encoder is largely rewritten but the row-per-field harness stays. |
 
 ## Deciding evidence
 
-The PR-011 / PR-011a perf-harness PRs are the right place to collect the missing data. Adding list-heavy scenarios there strengthens the 3.0-alpha published dataset against future regressions, independent of this ADR's outcome.
+The PR-011 / PR-011a perf-harness PRs are the right place to collect the missing data. Adding list-heavy scenarios there strengthens the 3.0-alpha published dataset against future regressions, independent of which option wins.
 
 Scenarios to add (Tier 2 — `NormalizedCache` protocol level — and Tier 3 — direct SQLite operations):
 
 | Scenario | Tier | Purpose |
 |---|---|---|
-| `read-record-with-list-of-N-scalars` (N ∈ {10, 100, 1000}) | 2, 3 | Read cost as list length grows; tests Option 3's clustered-row read |
-| `read-record-with-list-of-N-references` (N ∈ {10, 100, 1000}) | 2, 3 | Reference-typed list cost; relevant to Phase 2 cascade |
-| `write-list-of-N-scalars` (cold + warm) | 2, 3 | Full-list write cost; the per-row vs single-row write head-to-head |
+| `read-record-with-list-of-N-scalars` (N ∈ {10, 100, 1000}) | 2, 3 | Read cost as list length grows; Option 2 clustered-row read vs Option 1 second `SELECT`/join |
+| `read-record-with-list-of-N-references` (N ∈ {10, 100, 1000}) | 2, 3 | Reference-typed list cost; relevant to Phase 2 cascade walker |
+| `write-list-of-N-scalars` (cold + warm) | 2, 3 | Full-list write cost; both options do N row UPSERTs, but to different tables |
 | `write-list-of-N-references` (cold + warm) | 2, 3 | As above with reference elements |
-| `mutate-single-element-in-list-of-N` (N ∈ {10, 100, 1000}) | 2 | Pivotal — Option 1 re-encodes; Options 2 + 3 each UPSERT one row |
-| `mutate-element-at-position-K-in-list-of-N` | 2 | Direct measurement of Option 3's `UPDATE … WHERE position = ?` path vs Option 1's full-JSON rewrite |
-| `read-record-with-nested-list-[[Int]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | Quantifies Option 3's depth ≥ 2 indirection cost vs Option 1's nested-JSON decode |
+| `mutate-element-at-position-K-in-list-of-N` | 2, 3 | Single-row UPSERT at `position`; both options should be close, deciding the floor |
+| `read-record-with-nested-list-[[Int]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | Quantifies Option 2's depth ≥ 2 indirection cost vs Option 1's depth strategy |
 | `read-record-with-nested-list-[[CacheReference]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | As above with the reference shape Phase 2 cares about |
+| `filter-list-elements-by-typed-column` | 2 | Confirms the capability requirement is satisfied; both options should pass; included to lock in coverage |
 
 Per perf plan §3, these add a new performance-relevant subsystem (list paths) that the existing scenarios do not cover; perf plan §5.2 already anticipates inline `feat(perf): add scenario for X` additions. The list scenarios land in PR-011a as part of the comprehensive Tier 1 / Tier 2 harness; the Tier 3 SQLite-level scenarios extend PR-011.
 
 The decision rule for the lock:
 
-- If Option 3's depth-1 reads are within the §7.4 envelope across all list lengths *and* `mutate-element-at-position-K` shows a material speedup over Option 1 (>2× on N=100, say) *and* the depth ≥ 2 indirection cost is bounded (≤ 2× of Option 1's nested-JSON decode on the `[[Int]]` scenarios), **Option 3 is ratified.** A new PR (call it PR-009b) extends the PK and lands the position-aware reader/writer before PR-012. The depth ≥ 2 recursion is added in the same PR.
-- If Option 1 is competitive on every scenario and the asymmetry's only material cost is conceptual, **Option 1 is ratified** as the path-of-least-change. The asymmetry is accepted; Phase 2 `@onDelete` cascade pays its own per-element JSON parse cost when the time comes.
-- Option 2 is ratified only if Option 3's depth ≥ 2 indirection cost is unacceptably high *and* Option 1's nested-JSON decode is also unacceptably high — a narrow case. In that scenario, PR-009b instead lands the sibling table.
-- Edge cases — Option 3 wins single-element edit but loses bulk reads, or any other split outcome — escalate to the reviewer per execution plan §6 trigger 8.
+- If Option 2's depth-1 reads are within the §7.4 envelope across all list lengths *and* the depth ≥ 2 indirection cost is bounded (≤ 2× of a comparable Option 1 depth-strategy read on the `[[Int]]` scenarios), **Option 2 is ratified.** A new PR (call it PR-009b) extends the PK, lands the position-aware reader/writer, and adds the depth ≥ 2 recursion.
+- If Option 2's depth ≥ 2 indirection cost is unacceptably high *and* Option 1's chosen depth strategy is materially better on nested-list reads, **Option 1 is ratified.** PR-009b instead lands the sibling table plus its depth strategy.
+- Edge cases — Option 2 wins single-table-locality but loses badly on nested-list reads, or any other split outcome — escalate to the reviewer per execution plan §6 trigger 8.
 
 The lock is final by PR-012. After 3.0-alpha tags, changing the list-storage strategy would force a second drop-and-rebuild migration on existing 3.0-alpha installs — the same reason §7.1's `written_at` column is added in PR-008 instead of Phase 1C.
 
@@ -121,32 +128,33 @@ The lock is final by PR-012. After 3.0-alpha tags, changing the list-storage str
 
 ### Positive
 
-- **Empirical grounding for an unmeasured choice.** §7.1 attributes the row-per-field shape to a published benchmark, but the benchmark does not cover list paths. This ADR closes that gap before the choice becomes hard to reverse.
-- **The leading-candidate framing accelerates Phase 1A planning.** If Option 3 wins the benchmark, PR-009b is the scoped follow-up; the agent and reviewer can prepare it speculatively without committing.
+- **Capability requirement is documented and locked.** Per-element queryability is now an explicit constraint in this ADR, not a tacit assumption. Any future reconsideration of the storage shape (Phase 2, Phase 3) starts from "must support per-element SQL queries" rather than relitigating the JSON shape.
+- **Empirical grounding for the remaining choice.** §7.1 attributes the row-per-field shape to a published benchmark, but the benchmark does not cover list paths. This ADR closes that gap for the live decision (Option 1 vs Option 2) before the choice becomes hard to reverse.
+- **The leading-candidate framing accelerates Phase 1A planning.** PR-009b can be scoped speculatively against Option 2 while the benchmarks run; if the data flips to Option 1, the scope swap is mechanical.
 - **Decision-relevant scenarios become permanent harness coverage.** Whichever option lands, the list-heavy scenarios remain in PR-011a's output. Phase 2 (`@onDelete` cascade, LRU on lists) gets a baseline to regress against from day one.
-- **Nested-list complexity is surfaced and budgeted, not discovered.** Option 3's depth ≥ 2 recursion path is identified now; if it had been discovered mid-implementation, it would have surfaced as scope creep on a code PR rather than a paragraph in this ADR.
+- **Nested-list complexity is surfaced and budgeted, not discovered.** Option 2's depth ≥ 2 recursion path and Option 1's depth-strategy choice are identified now; if either had been discovered mid-implementation, it would have surfaced as scope creep on a code PR rather than a paragraph in this ADR.
 - **PR-012 gating criteria already accommodate this.** The 3.0-alpha tag is already gated on "no `regressed` verdict in the published dataset"; this ADR adds list scenarios to that dataset without changing the gating mechanic.
 
 ### Negative
 
+- **PR-009's encoder is now interim code.** The JSON-blob path will be replaced by PR-009b regardless of which option wins. The hardening work in the PR-009 review-findings commit (`NSNull`, `$reference`, sortedKeys, etc.) is mostly retained for the `custom_scalar_value` path, but the list-encoding branches are discarded. Mitigation: the discarded code is localized; tests for the JSON path become test fixtures for the new row-per-element encoder.
 - **Phase 1A timeline absorbs additional scenario authoring.** PR-011a's estimate (~700 LoC) already includes Tier 1 + Tier 2 scenario coverage; the list-heavy additions are ~200–300 LoC of scenario code plus fixtures. Mitigation: scenario authoring is mechanical and parallelizable; perf plan §5.2 accommodates inline additions without restructuring §8.
-- **Three possible outcomes mean three possible implementation paths.** The agent and reviewer must hold all three open until the benchmark data arrives. Mitigation: the decision rule above is mechanical; Option 3's PR-009b (the expected outcome) is ~300–400 LoC, comparable to PR-010.
-- **Option 3 sentinel semantics add a small reader-side decoder cost.** Every `SELECT` against the records table returns scalar rows interleaved with list-element rows; the decoder must branch on `position = -1`. Mitigation: a single integer comparison per row; negligible vs the JSON-decode cost of Option 1 and the second-`SELECT` cost of Option 2.
+- **Option 2's sentinel semantics add a small reader-side decoder cost.** Every `SELECT` against `records` returns scalar rows interleaved with list-element rows; the decoder must branch on `position = -1`. Mitigation: a single integer comparison per row; negligible vs Option 1's second-`SELECT` cost.
 
 ### Neutral
 
-- **No 2.x parity question.** 2.x has no list-storage strategy distinct from its records-blob-as-JSON layout; all three options under evaluation are improvements. The 2.x baseline dataset (PR-004a, #980) does not measure list paths separately because the 2.x storage layer does not separate them.
-- **The §7.1 wording will need a small editorial pass** once the decision is locked — to either (a) cite this ADR and remove the unsourced "JSON-encoded list" claim, (b) describe the `list_items` table as the locked design, or (c) describe the extended PK with the `position` sentinel.
+- **No 2.x parity question.** 2.x has no list-storage strategy distinct from its records-blob-as-JSON layout; both options under evaluation are improvements. The 2.x baseline dataset (PR-004a, #980) does not measure list paths separately because the 2.x storage layer does not separate them.
+- **The §7.1 wording will need an editorial pass** once the decision is locked — to either (a) describe the `list_items` table as the locked design or (b) describe the extended PK with the `position` sentinel. The current "JSON-encoded list" claim is removed in either case.
 
 ## References
 
-- [Engineering plan §7.1](../cache-rewrite-phase1-plan.md) — current `list_value TEXT` schema decision being scoped here
+- [Engineering plan §7.1](../cache-rewrite-phase1-plan.md) — current `list_value TEXT` schema decision being replaced
 - [Engineering plan §7.4](../cache-rewrite-phase1-plan.md) — published performance gates (scalar paths only)
 - [Perf plan §3.2, §3.3, §5.2](../cache-rewrite-phase1-perf.md) — Tier 2 / Tier 3 scenario design and the inline `feat(perf): add scenario` pattern
 - [Execution plan §8 PR-011, PR-011a, PR-012](../cache-rewrite-phase1-execution.md) — perf-harness PRs that carry the new list-heavy scenarios and the 3.0-alpha tag gating
 - [ADR 0001 — Major version bump](./0001-major-version-bump.md) — drop-and-rebuild migration policy that constrains the lock to "before PR-012"
-- [ADR 0002 — Record abstraction](./0002-record-abstraction.md) — in-memory `CachedField` shape (independent of this ADR; all three options round-trip cleanly to `CachedField`)
+- [ADR 0002 — Record abstraction](./0002-record-abstraction.md) — in-memory `CachedField` shape (independent of this ADR; both options round-trip cleanly to `CachedField`)
 - [SQLite Performance Benchmarks (Confluence 1585152147)](https://apollographql.atlassian.net/wiki/spaces/ClientDev/pages/1585152147) — origin of the row-per-field shape; the source that does not cover list paths
 - [PR-009 (#1001)](https://github.com/apollographql/apollo-ios-dev/pull/1001) — row-per-field CRUD implementation; review thread that surfaced the asymmetry
-- [`SQLiteFieldEncoding.swift`](../../Sources/ApolloSQLite/SQLiteFieldEncoding.swift) — current JSON-encoded list-path implementation
-- Industry pattern reference for the Option 3 shape: adjacency-list-with-position, with depth bounded by the GraphQL schema rather than handled via closure table / nested set. See discussion of when to combine adjacency list with other models for hierarchical data — e.g., [Djellouli, *Storing Hierarchical Data in Relational Databases with SQL*](https://adamdjellouli.com/articles/databases_notes/03_sql/09_hierarchical_data).
+- [`SQLiteFieldEncoding.swift`](../../Sources/ApolloSQLite/SQLiteFieldEncoding.swift) — current JSON-encoded list-path implementation (interim; replaced by PR-009b)
+- Industry pattern reference for the Option 2 shape: adjacency-list-with-position, with depth bounded by the GraphQL schema rather than handled via closure table / nested set. See discussion of when to combine adjacency list with other models for hierarchical data — e.g., [Djellouli, *Storing Hierarchical Data in Relational Databases with SQL*](https://adamdjellouli.com/articles/databases_notes/03_sql/09_hierarchical_data).

--- a/apollo-ios/Design/adr/0006-list-storage-strategy.md
+++ b/apollo-ios/Design/adr/0006-list-storage-strategy.md
@@ -1,0 +1,130 @@
+# ADR 0006 — List storage strategy: JSON-encoded `list_value` vs sibling `list_items` table
+
+- **Status:** Proposed — decision deferred to PR-011a list-heavy benchmark data; locked before PR-012 (3.0-alpha tag)
+- **Date:** 2026-05-28
+- **Phase 1 PR:** Out-of-stack docs follow-up to PR-009
+- **Engineering plan reference:** [cache-rewrite-phase1-plan.md §7.1, §7.4](../cache-rewrite-phase1-plan.md)
+- **Perf plan reference:** [cache-rewrite-phase1-perf.md](../cache-rewrite-phase1-perf.md) — Tier 3 scenario coverage
+
+## Context
+
+[ADR 0002](./0002-record-abstraction.md) settled the in-memory `Record` shape; engineering plan §7.1 settled the on-disk shape: one row per field, with per-type value columns (`int_value`, `string_value`, `float_value`, `bool_value`, `child_key_value`, `custom_scalar_value`) plus `list_value TEXT` for list-typed fields. Scalars land in their typed column; lists land as a JSON-encoded blob in `list_value`. This asymmetry was flagged in the PR-009 review: scalar fields get a typed, indexable column, but list elements collapse to a single opaque string.
+
+The §7.1 choice traces to Zach's [SQLite Performance Benchmarks](https://apollographql.atlassian.net/wiki/spaces/ClientDev/pages/1585152147) (Confluence page 1585152147), the same source that motivates the row-per-field shape itself. The benchmark's published numbers — and the §7.4 performance gates derived from them — measure exact-key selects, type+selection-set selects, composite-PK updates, single-row inserts, and CTE-join sorts. None of those scenarios exercise list-heavy paths. There is no empirical evidence that JSON-encoded `list_value` is the optimal choice for list-typed fields specifically; the design inherits the choice without having measured the alternative.
+
+PR-009's encoder/decoder already implements the JSON path end-to-end and hardens it (PR-009 review-findings commit: `JSONSerialization.isValidJSONObject` probe, `NSNull` round-trip, `$reference`-wrapper disambiguation, `sortedKeys` for stable on-disk bytes). The implementation is real; what is missing is the *evidence* that this implementation is the right one.
+
+This ADR scopes that question and the evidence-collection plan that resolves it.
+
+## Decision
+
+**Defer.** The choice between the two options below is not made by this ADR. The ADR commits to:
+
+1. Treating the §7.1 `list_value TEXT` shape as a **provisional default**, not a ratified choice, until list-heavy benchmark data exists.
+2. Adding list-heavy scenarios to the PR-011 / PR-011a performance-measurement harness (see §3, "Deciding evidence").
+3. **Locking the decision before PR-012** — the 3.0-alpha tag — based on those numbers. The lock happens by amending this ADR with a Status flip from *Proposed* to *Accepted* and a final §2 Decision paragraph naming the chosen option.
+
+The two options under evaluation are:
+
+### Option 1 — Ratify JSON-encoded `list_value` (current §7.1 shape)
+
+Keep the row-per-field layout exactly as specified in engineering plan §7.1. Each list-typed field stores its elements as a JSON-encoded `TEXT` blob in `list_value`. Nested lists (`[[Int]]`, `[[CacheReference]]`) are handled naturally by JSON's recursive structure — no schema change required.
+
+### Option 2 — Migrate list-typed fields to a sibling `list_items` table
+
+Lists become a one-to-many relation against a second table:
+
+```sql
+CREATE TABLE IF NOT EXISTS list_items (
+  cache_key            TEXT NOT NULL,
+  field_name           TEXT NOT NULL,
+  position             INTEGER NOT NULL,
+  int_value            INTEGER,
+  string_value         TEXT,
+  float_value          REAL,
+  bool_value           INTEGER,
+  child_key_value      TEXT,
+  custom_scalar_value  TEXT,
+  -- nested-list strategy: TBD; see §4 trade-off table
+  PRIMARY KEY (cache_key, field_name, position),
+  FOREIGN KEY (cache_key, field_name) REFERENCES records(cache_key, field_name) ON DELETE CASCADE
+) WITHOUT ROWID;
+```
+
+The `list_value` column in `records` is either dropped or repurposed as a fast-path for very short lists; the design detail is part of the option's evaluation. Reads issue a second `SELECT … WHERE cache_key = ? AND field_name = ? ORDER BY position` for any list-typed field (or a `LEFT JOIN` if the planner prefers).
+
+Nested lists (`[[Int]]`, `[[CacheReference]]`) require an explicit depth strategy under Option 2 — either a `depth` column with a self-referential structure, or a separate `list_of_lists` shape, or a fallback to JSON-encoding for nesting depth > 1. There is no shape that mirrors Option 1's natural recursion without paying additional schema complexity.
+
+## Trade-offs
+
+| Dimension | Option 1 (JSON `list_value`) | Option 2 (`list_items` table) |
+|---|---|---|
+| Read cost — short list | One row, one column. Decode `JSONSerialization` once. | Second `SELECT` or join. Per-element row construction. |
+| Read cost — long list | `JSONSerialization` cost grows with list length. | Per-row dispatch grows with length; potentially better cache locality with `WITHOUT ROWID` clustering. |
+| Write cost — full overwrite | One row UPSERT regardless of list cardinality. | N row UPSERTs for length N. Bulk transaction required for atomicity. |
+| Write cost — single-element edit | Re-encode and re-write the entire list. | One row UPSERT at the relevant `position`. |
+| Order preservation | Implicit (JSON arrays are ordered). | Explicit `position` column on every row. |
+| Type symmetry with scalars | Asymmetric — scalars get typed columns, list elements collapse to JSON. | Symmetric — list elements get the same typed-column layout as scalars in the parent table. |
+| Nested lists (`[[Int]]`, `[[CacheReference]]`) | Native — JSON nests recursively. | Requires depth strategy: recursive `list_of_lists` table, depth column, or JSON-fallback above depth 1. |
+| Child-reference indexing | Impossible without parsing JSON. Blocks per-element FK or sentinel columns for Phase 2 `@onDelete` cascade. | Each `child_key_value` element is a row — directly indexable. Phase 2 cascade can model relationships at the storage layer. |
+| SQL operations on members | Not feasible (opaque blob). | Filter, join, aggregate on list members directly. |
+| Schema surface | One table. | Two tables. Every future schema migration touches both. |
+| Implementation effort to ship | Already complete (PR-009 + review-findings commit). | New encoder, new decoder, new `WITHOUT ROWID` table, new migration step, new transactional contract for write atomicity. |
+
+## Deciding evidence
+
+The PR-011 / PR-011a perf-harness PRs are the right place to collect the missing data. Adding list-heavy scenarios there has the side benefit of strengthening the 3.0-alpha published dataset against future regressions, independent of this ADR's outcome.
+
+Scenarios to add (Tier 2 — `NormalizedCache` protocol level — and Tier 3 — direct SQLite operations):
+
+| Scenario | Tier | Purpose |
+|---|---|---|
+| `read-record-with-list-of-N-scalars` (N ∈ {10, 100, 1000}) | 2, 3 | Read cost as list length grows |
+| `read-record-with-list-of-N-references` (N ∈ {10, 100, 1000}) | 2, 3 | Reference-typed list cost; relevant to Phase 2 cascade |
+| `write-list-of-N-scalars` (cold + warm) | 2, 3 | Full-list write cost; pivotal for Option 1 vs 2 |
+| `write-list-of-N-references` (cold + warm) | 2, 3 | As above with reference elements |
+| `mutate-single-element-in-list-of-N` (N ∈ {10, 100, 1000}) | 2 | Pivotal for the "edit one item" workload that favors Option 2 |
+| `read-record-with-nested-list-[[Int]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | Stresses Option 2's depth strategy |
+| `read-record-with-nested-list-[[CacheReference]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | As above with the reference shape Phase 2 cares about |
+
+Per perf plan §3, these add a new performance-relevant subsystem (list paths) that the existing scenarios do not cover; perf plan §5.2 already anticipates inline `feat(perf): add scenario for X` additions. The list scenarios land in PR-011a as part of the comprehensive Tier 1 / Tier 2 harness; the Tier 3 SQLite-level scenarios extend PR-011.
+
+The decision rule for the lock:
+
+- If Option 1 is within the §7.4 performance envelope (suitably extended for the new scenarios) across all list lengths *and* the Option 2 mutate-single-element case is not dramatically faster (>3× speedup on `mutate-single-element-in-list-of-100`, say), **Option 1 is ratified**. The asymmetry is accepted; Phase 2 `@onDelete` cascade pays its own per-element parse cost when the time comes.
+- If Option 2 is materially faster on `mutate-single-element-in-list-of-N` or `read-record-with-list-of-1000-references` *and* the nested-list overhead is bounded, **Option 2 is adopted before PR-012.** A new PR (call it PR-009b) lands the second table, migrating the `list_value` path. Migration is a no-op for end users (drop-and-rebuild migration per ADR 0001 already happens once on 3.0 upgrade; the schema simply lands in its final shape).
+- Edge cases — Option 2 wins single-element edit but loses bulk reads, or vice versa — escalate to the reviewer per execution plan §6 trigger 8.
+
+The lock is final by PR-012. After 3.0-alpha tags, changing the list-storage strategy would force a second drop-and-rebuild migration on existing 3.0-alpha installs — the same reason §7.1's `written_at` column is added in PR-008 instead of Phase 1C.
+
+## Consequences
+
+### Positive
+
+- **Empirical grounding for an unmeasured choice.** The current §7.1 wording attributes the row-per-field shape to a published benchmark, but the benchmark does not cover list paths. This ADR closes that gap before the choice becomes hard to reverse.
+- **Decision-relevant scenarios become permanent harness coverage.** Even if Option 1 is ratified, the list-heavy scenarios remain in PR-011a's output. Phase 2 (`@onDelete` cascade, LRU on lists) gets a baseline to regress against from day one.
+- **Nested-list complexity is surfaced and budgeted, not discovered.** Option 2's depth strategy is identified now, when the cost of designing it is a paragraph in this ADR. If the decision had been made silently in favor of Option 2 without surfacing nesting, the discovery would land mid-implementation.
+- **PR-012 gating criteria already accommodate this.** The 3.0-alpha tag is already gated on "no `regressed` verdict in the published dataset"; this ADR adds list scenarios to that dataset without changing the gating mechanic.
+
+### Negative
+
+- **Phase 1A timeline absorbs a small amount of additional scenario authoring.** PR-011a's estimate (~700 LoC) already includes Tier 1 + Tier 2 scenario coverage; the list-heavy additions are ~150–250 LoC of additional scenario code plus the supporting fixtures. Mitigation: scenario authoring is mechanical and parallelizable with other Phase 1A work; the perf plan §5.2 inline-PR pattern accommodates this without restructuring §8.
+- **Two possible outcomes mean two possible implementation paths in Phase 1A.** If Option 2 wins, a new PR (PR-009b) lands the migration before PR-012; if Option 1 wins, no additional code is required. The agent and reviewer must hold both possibilities open until the benchmark data arrives. Mitigation: the decision rule above is mechanical; the additional PR (if needed) is ~400 LoC of well-scoped storage work, comparable to PR-010 in size.
+- **Deferring the decision means PR-009's encoder remains in production-shape under uncertainty.** The encoder is correct and hardened; if Option 2 wins, parts of it are discarded. Mitigation: the discarded code is a localized JSON encoder path, not architecture; the cost of writing it (already paid) is recovered as test fixtures and as the Option 1 fallback if Option 2 turns out worse than expected at the eleventh hour.
+
+### Neutral
+
+- **No 2.x parity question.** 2.x has no list-storage strategy distinct from its records-blob-as-JSON layout; both options under evaluation are improvements over the 2.x shape. The 2.x baseline dataset (PR-004a, #980) does not measure list paths separately because the 2.x storage layer does not separate them.
+- **The §7.1 wording will need a small editorial pass** once the decision is locked, regardless of outcome — to either (a) cite this ADR and remove the unsourced "JSON-encoded list" claim, or (b) describe the `list_items` table as the locked design.
+
+## References
+
+- [Engineering plan §7.1](../cache-rewrite-phase1-plan.md) — current `list_value TEXT` schema decision being scoped here
+- [Engineering plan §7.4](../cache-rewrite-phase1-plan.md) — published performance gates (scalar paths only)
+- [Perf plan §3.2, §3.3, §5.2](../cache-rewrite-phase1-perf.md) — Tier 2 / Tier 3 scenario design and the inline `feat(perf): add scenario` pattern
+- [Execution plan §8 PR-011, PR-011a, PR-012](../cache-rewrite-phase1-execution.md) — perf-harness PRs that carry the new list-heavy scenarios and the 3.0-alpha tag gating
+- [ADR 0001 — Major version bump](./0001-major-version-bump.md) — drop-and-rebuild migration policy that constrains the lock to "before PR-012"
+- [ADR 0002 — Record abstraction](./0002-record-abstraction.md) — in-memory `CachedField` shape (independent of this ADR; both options round-trip cleanly to `CachedField`)
+- [SQLite Performance Benchmarks (Confluence 1585152147)](https://apollographql.atlassian.net/wiki/spaces/ClientDev/pages/1585152147) — origin of the row-per-field shape; the source that does not cover list paths
+- [PR-009 (#1001)](https://github.com/apollographql/apollo-ios-dev/pull/1001) — row-per-field CRUD implementation; review thread that surfaced the asymmetry
+- [`SQLiteFieldEncoding.swift`](../../Sources/ApolloSQLite/SQLiteFieldEncoding.swift) — current JSON-encoded list-path implementation

--- a/apollo-ios/Design/adr/0006-list-storage-strategy.md
+++ b/apollo-ios/Design/adr/0006-list-storage-strategy.md
@@ -1,57 +1,23 @@
-# ADR 0006 — List storage strategy: sibling table or in-place rows with `position`
+# ADR 0006 — List storage: in-place row-per-element with `position`
 
-- **Status:** Proposed — Option 2 (in-place rows with `position`) is the **leading candidate**; final lock before PR-012 (3.0-alpha tag) based on PR-011a list-heavy benchmark data
+- **Status:** Accepted
 - **Date:** 2026-05-28
-- **Phase 1 PR:** Out-of-stack docs follow-up to PR-009
-- **Engineering plan reference:** [cache-rewrite-phase1-plan.md §7.1, §7.4](../cache-rewrite-phase1-plan.md)
-- **Perf plan reference:** [cache-rewrite-phase1-perf.md](../cache-rewrite-phase1-perf.md) — Tier 3 scenario coverage
+- **Phase 1 PR:** Out-of-stack docs follow-up to PR-009. Schema implementation lands as part of PR-009's amended scope (see "Implementation impact"); engineering plan §7.1/§7.2 and execution plan §8 are revised in follow-up PRs.
+- **Engineering plan reference:** [cache-rewrite-phase1-plan.md §7.1, §7.2](../cache-rewrite-phase1-plan.md) — to be rewritten per this ADR
 
 ## Context
 
-[ADR 0002](./0002-record-abstraction.md) settled the in-memory `Record` shape; engineering plan §7.1 settled the on-disk shape: one row per field, with per-type value columns (`int_value`, `string_value`, `float_value`, `bool_value`, `child_key_value`, `custom_scalar_value`) plus `list_value TEXT` for list-typed fields. Scalars land in their typed column; lists land as a JSON-encoded blob in `list_value`. This asymmetry was flagged in the PR-009 review: scalar fields get a typed, indexable column, but list elements collapse to a single opaque string.
+[ADR 0002](./0002-record-abstraction.md) settled the in-memory `Record` shape; engineering plan §7.1 settled the on-disk shape as one row per field, with per-type value columns (`int_value`, `string_value`, `float_value`, `bool_value`, `child_key_value`, `custom_scalar_value`) plus `list_value TEXT` for list-typed fields. Scalars land in their typed column; lists land as a JSON-encoded blob.
 
-The §7.1 choice traces to Zach's [SQLite Performance Benchmarks](https://apollographql.atlassian.net/wiki/spaces/ClientDev/pages/1585152147) (Confluence page 1585152147), the same source that motivates the row-per-field shape itself. The benchmark's published numbers — and the §7.4 performance gates derived from them — measure exact-key selects, type+selection-set selects, composite-PK updates, single-row inserts, and CTE-join sorts. None of those scenarios exercise list-heavy paths.
+The PR-009 review flagged the asymmetry: scalar fields get a typed, indexable column, but list elements collapse to a single opaque string. The §7.1 choice traces to Zach's [SQLite Performance Benchmarks](https://apollographql.atlassian.net/wiki/spaces/ClientDev/pages/1585152147) (Confluence 1585152147), but the benchmark measures only exact-key selects, type+selection-set selects, composite-PK updates, single-row inserts, and CTE-join sorts — no list-heavy paths. The JSON shape was inherited without measurement.
 
-Separately, the cache is required to support **per-element queries against list-typed fields** — filtering and indexing list elements at the SQL level, observing changes to a specific list element via the watcher, and walking list elements as part of the Phase 2 `@onDelete` cascade. JSON-blob storage forbids all of these at the SQL layer (any operation requires loading and parsing the entire blob in Swift). This is a hard capability requirement, not a performance preference; it eliminates the JSON `list_value` shape from the option space regardless of how it benchmarks.
+Separately, the cache must support **per-element queries against list-typed fields**: filtering and indexing list elements at the SQL level, watcher observation of single-element changes, and walking list elements during the Phase 2 `@onDelete` cascade. JSON storage forecloses all of these — every per-element operation requires loading and parsing the entire blob in Swift, with no opportunity for SQLite's query planner to participate. This is a capability constraint, not a performance preference.
 
-What remains is choosing between two row-per-element shapes. The benchmark gap from §7.1 still applies — neither shape has been measured against the other — and the lock happens against perf data before PR-012.
-
-PR-009's encoder/decoder implements the JSON path end-to-end and hardens it (PR-009 review-findings commit: `JSONSerialization.isValidJSONObject` probe, `NSNull` round-trip, `$reference`-wrapper disambiguation, `sortedKeys` for stable on-disk bytes). That code is correct but addresses the rejected shape; both options below replace it.
+The capability requirement eliminates JSON from the option space. The remaining choice — between an in-place row-per-element layout and a sibling `list_items` table — decides on design merit. The in-place layout dominates on every dimension that matters; the sibling table only adds indirection and surface area. See "Alternatives considered."
 
 ## Decision
 
-**Defer between the two row-per-element options below.** The ADR commits to:
-
-1. Treating the §7.1 `list_value TEXT` shape as **rejected** on capability grounds (see Alternatives considered). The PR-009 JSON encoder/decoder is interim code that will be replaced before 3.0-alpha tags.
-2. Naming **Option 2 (in-place rows with `position`)** as the leading candidate, on design-merit grounds. Final ratification still requires the PR-011a numbers.
-3. Adding list-heavy scenarios to the PR-011 / PR-011a performance-measurement harness (see "Deciding evidence").
-4. **Locking the decision before PR-012** — the 3.0-alpha tag. The lock happens by amending this ADR with a Status flip from *Proposed* to *Accepted* and a final §2 Decision paragraph naming the chosen option.
-
-### Option 1 — Sibling `list_items` table
-
-Lists become a one-to-many relation against a second table:
-
-```sql
-CREATE TABLE IF NOT EXISTS list_items (
-  cache_key            TEXT NOT NULL,
-  field_name           TEXT NOT NULL,
-  position             INTEGER NOT NULL,
-  int_value            INTEGER,
-  string_value         TEXT,
-  float_value          REAL,
-  bool_value           INTEGER,
-  child_key_value      TEXT,
-  custom_scalar_value  TEXT,
-  PRIMARY KEY (cache_key, field_name, position),
-  FOREIGN KEY (cache_key, field_name) REFERENCES records(cache_key, field_name) ON DELETE CASCADE
-) WITHOUT ROWID;
-```
-
-Reads issue a second `SELECT … WHERE cache_key = ? AND field_name = ? ORDER BY position` for any list-typed field (or a `LEFT JOIN`). Nested lists (`[[Int]]`, `[[CacheReference]]`) require an explicit depth strategy — depth column, recursive `list_of_lists` table, or per-element `child_key_value` indirection to a record-shaped sub-list. The depth strategy is part of the ratification, not deferred separately.
-
-### Option 2 — In-place rows with `position`; recurse via `child_key_value` for depth ≥ 2 (leading candidate)
-
-Extend the records table's PK with a `position` column. Scalars use a sentinel `position = -1`; list elements use `position = 0..N-1`. List-element rows live in the same table as the parent record, at the same `cache_key`. Thanks to `WITHOUT ROWID` clustering, they are physically adjacent to the parent's scalar fields on disk.
+**Each list element becomes its own row in the `records` table, addressed by an extended primary key.** A `position` column joins `cache_key` and `field_name` in the PK; scalars use the sentinel `position = -1`, and list elements use `position = 0..N-1`.
 
 ```sql
 CREATE TABLE IF NOT EXISTS records (
@@ -69,92 +35,86 @@ CREATE TABLE IF NOT EXISTS records (
 ) WITHOUT ROWID;
 ```
 
-The depth-1 case (`[Int]`, `[String]`, `[Friend]` — ~99% of GraphQL list-typed fields in practice) is handled entirely in-place: one `SELECT … WHERE cache_key = ?` returns scalar fields *and* list elements in the same result set, clustered together on disk. No JSON, no second table, no join.
+The `list_value TEXT` column from the §7.1 shape is removed.
 
-Nested lists (`[[Int]]`, `[[CacheReference]]` — the rare case) recurse via the existing `CacheKey` indirection: an outer list's row holds a synthetic `child_key_value` (e.g., `User:1.tags[3]`) pointing to a sub-record, which itself uses the depth-1 layout for the inner list. This reuses the reference machinery the cache already has rather than introducing a new mechanism. Depth is bounded by the GraphQL schema, not unbounded — the executor walks a selection set whose shape is compiled in, so we never need recursive CTEs or "find all descendants" queries.
+**Depth-1 lists** (`[Int]`, `[String]`, `[Friend]` — ~99% of GraphQL list-typed fields in practice) are handled entirely in-place. List-element rows live at the same `cache_key` as the parent record's scalar fields; `WITHOUT ROWID` clustering keeps them physically adjacent on disk. One `SELECT … WHERE cache_key = ?` returns scalar fields and list elements together in the same result set.
 
-This is the industry-standard **adjacency-list-with-position** pattern applied to a domain where depth is bounded and known at codegen time. The heavier hierarchical-data patterns (nested set, closure table, materialized path) exist to answer queries we never ask.
+**Nested lists** (`[[Int]]`, `[[CacheReference]]` — the rare case) recurse via the existing `CacheKey` indirection. An outer list's row holds a synthetic `child_key_value` (e.g., `User:1.tags[3]`) pointing to a sub-record that itself uses the depth-1 layout. This reuses the reference machinery the cache already has rather than introducing a new mechanism. Depth is bounded by the GraphQL schema, known at codegen time, so the executor never needs recursive CTEs or "find all descendants" queries. This is the industry-standard **adjacency-list-with-position** pattern applied to a domain where depth is bounded.
+
+### Implementation impact
+
+The current §7.1 DDL (with `list_value TEXT`) was landed in PR-008 (#1000, merged into the plan branch). The new DDL replaces it. The migration cost is zero on existing 3.0-alpha installs because **3.0-alpha has not tagged** — the §7.1 schema has only ever existed on the long-lived plan branch and in development databases. The drop-and-rebuild path on first 3.0 launch (per [ADR 0001](./0001-major-version-bump.md)) carries this ADR's schema, not the rejected one.
+
+PR-009 (#1001, open) implemented row-per-field CRUD against the old `list_value` shape. Its scope is amended:
+- The PK extension and `position` sentinel land as part of PR-009 (or a follow-up PR-009b, depending on review preference).
+- The JSON list-encoding branches in `SQLiteFieldEncoding.swift` are replaced with position-aware row writers.
+- The decoder's row-grouping logic gets a `position = -1` branch for scalar rows and a `position >= 0` branch that accumulates ordered list elements.
+- The depth ≥ 2 recursion path adds a small `CacheKey` factory for synthetic sub-record keys.
+
+The PR-009 review-findings hardening (`NSNull` round-trip, `$reference`-wrapper disambiguation, `sortedKeys`, `JSONSerialization.isValidJSONObject` probe) is retained where it applies to the `custom_scalar_value` path. The list-encoding branches are discarded.
+
+Engineering plan §7.1 (DDL) and §7.2 (operations) are rewritten in a separate follow-up doc PR to match this ADR. Execution plan §8 is amended in the same follow-up to reflect the PR-009 scope change and any new PR slots that result.
+
+The performance-harness PRs (PR-011, PR-011a) still receive the list-heavy scenarios discussed during this ADR's drafting — `read-record-with-list-of-N`, `write-list-of-N`, `mutate-element-at-position-K-in-list-of-N`, the nested `[[T]]` reads, and `filter-list-elements-by-typed-column` — but as permanent regression coverage of the chosen design, not as decision-gating evidence.
 
 ## Alternatives considered
 
-### JSON-encoded `list_value` (current §7.1 default — rejected)
+### A. JSON-encoded `list_value` (the §7.1 default)
 
-Keep the row-per-field layout exactly as specified in engineering plan §7.1. Each list-typed field stores its elements as a JSON-encoded `TEXT` blob in `list_value`. Nested lists handle naturally via JSON's recursive structure.
+Each list-typed field stores its elements as a JSON-encoded `TEXT` blob in `list_value`. Nested lists handle naturally via JSON's recursive structure.
 
-- *Rejected because:* **list elements stored as a JSON blob cannot be queried at the SQL level.** Filtering a list by element value, indexing on element shape, watching for changes to a single element, and walking list elements during the Phase 2 `@onDelete` cascade all require loading the entire blob into Swift and parsing it — work proportional to list length on every operation, with no opportunity for SQLite's query planner to participate. The asymmetry with scalar fields (which get typed, indexable columns) is the surface symptom; the underlying problem is that JSON storage forecloses an entire class of capabilities the cache is required to support. No benchmark outcome rescues this option, because the constraint is capability rather than cost. The PR-009 encoder/decoder for this shape was correct, but it solves a problem we have decided not to keep.
+- *Rejected because:* **list elements stored as a JSON blob cannot be queried at the SQL level.** Filtering by element value, indexing on element shape, single-element watcher observation, and the Phase 2 `@onDelete` cascade walk all require loading and parsing the entire blob in Swift — work proportional to list length on every operation, with no opportunity for SQLite's query planner to participate. The asymmetry with scalar fields (typed, indexable columns) is the surface symptom; the underlying problem is that JSON storage forecloses an entire class of capabilities the cache is required to support. No benchmark outcome rescues this option because the constraint is capability rather than cost.
 
-## Trade-offs
+### B. Sibling `list_items` table
 
-The choice between Option 1 (sibling table) and Option 2 (in-place rows) is what the PR-011a numbers resolve. Both support per-element querying — the capability requirement that eliminated JSON — so the comparison reduces to read locality, schema surface, and the nested-list handling cost.
+Lists move to a second table:
 
-| Dimension | Option 1 (`list_items` table) | Option 2 (in-place `position` + indirection) |
-|---|---|---|
-| Read cost — depth 1 | Extra `SELECT` or join per list-typed field. | Same `SELECT` as the parent record (clustered via `WITHOUT ROWID`). |
-| Read cost — depth ≥ 2 | Depends on the chosen depth strategy. Recursive `list_of_lists` table: another `SELECT`/join per nesting level. Depth column with self-join: planner-dependent. | One extra `SELECT` per outer element (the `child_key_value` indirection). |
-| Write cost | N row UPSERTs per list; single-element edit is one UPSERT at `position`. | N row UPSERTs per list in the same table; single-element edit is one UPSERT at `position`. |
-| Order preservation | Explicit `position INTEGER` column. | Explicit `position INTEGER` column; typed sort, no zero-padding. |
-| Type symmetry with scalars | Symmetric within the separate table. | Symmetric within the same table. |
-| Child-reference indexing (Phase 2 `@onDelete` cascade) | Each reference element is its own row in `list_items`; cascade walker must read from two tables. | Each reference element is its own row in `records`; existing cascade walker handles it without a second source. |
-| Schema surface + impl effort | Two tables. New encoder, decoder, migration step, transactional contract for write atomicity. Depth strategy adds further design work. | One table with extended PK `(cache_key, field_name, position)` and `DEFAULT -1` sentinel. Position-aware reader/writer plus the depth ≥ 2 recursion path. PR-009's encoder is largely rewritten but the row-per-field harness stays. |
+```sql
+CREATE TABLE IF NOT EXISTS list_items (
+  cache_key TEXT NOT NULL, field_name TEXT NOT NULL, position INTEGER NOT NULL,
+  int_value INTEGER, string_value TEXT, float_value REAL, bool_value INTEGER,
+  child_key_value TEXT, custom_scalar_value TEXT,
+  PRIMARY KEY (cache_key, field_name, position),
+  FOREIGN KEY (cache_key, field_name) REFERENCES records(cache_key, field_name) ON DELETE CASCADE
+) WITHOUT ROWID;
+```
 
-## Deciding evidence
+Reads issue a second `SELECT` or `LEFT JOIN` for any list-typed field. Nested lists require an explicit depth strategy — depth column, recursive `list_of_lists` table, or per-element indirection.
 
-The PR-011 / PR-011a perf-harness PRs are the right place to collect the missing data. Adding list-heavy scenarios there strengthens the 3.0-alpha published dataset against future regressions, independent of which option wins.
-
-Scenarios to add (Tier 2 — `NormalizedCache` protocol level — and Tier 3 — direct SQLite operations):
-
-| Scenario | Tier | Purpose |
-|---|---|---|
-| `read-record-with-list-of-N-scalars` (N ∈ {10, 100, 1000}) | 2, 3 | Read cost as list length grows; Option 2 clustered-row read vs Option 1 second `SELECT`/join |
-| `read-record-with-list-of-N-references` (N ∈ {10, 100, 1000}) | 2, 3 | Reference-typed list cost; relevant to Phase 2 cascade walker |
-| `write-list-of-N-scalars` (cold + warm) | 2, 3 | Full-list write cost; both options do N row UPSERTs, but to different tables |
-| `write-list-of-N-references` (cold + warm) | 2, 3 | As above with reference elements |
-| `mutate-element-at-position-K-in-list-of-N` | 2, 3 | Single-row UPSERT at `position`; both options should be close, deciding the floor |
-| `read-record-with-nested-list-[[Int]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | Quantifies Option 2's depth ≥ 2 indirection cost vs Option 1's depth strategy |
-| `read-record-with-nested-list-[[CacheReference]]` (outer ∈ {10, 100}, inner ∈ {10, 100}) | 2, 3 | As above with the reference shape Phase 2 cares about |
-| `filter-list-elements-by-typed-column` | 2 | Confirms the capability requirement is satisfied; both options should pass; included to lock in coverage |
-
-Per perf plan §3, these add a new performance-relevant subsystem (list paths) that the existing scenarios do not cover; perf plan §5.2 already anticipates inline `feat(perf): add scenario for X` additions. The list scenarios land in PR-011a as part of the comprehensive Tier 1 / Tier 2 harness; the Tier 3 SQLite-level scenarios extend PR-011.
-
-The decision rule for the lock:
-
-- If Option 2's depth-1 reads are within the §7.4 envelope across all list lengths *and* the depth ≥ 2 indirection cost is bounded (≤ 2× of a comparable Option 1 depth-strategy read on the `[[Int]]` scenarios), **Option 2 is ratified.** A new PR (call it PR-009b) extends the PK, lands the position-aware reader/writer, and adds the depth ≥ 2 recursion.
-- If Option 2's depth ≥ 2 indirection cost is unacceptably high *and* Option 1's chosen depth strategy is materially better on nested-list reads, **Option 1 is ratified.** PR-009b instead lands the sibling table plus its depth strategy.
-- Edge cases — Option 2 wins single-table-locality but loses badly on nested-list reads, or any other split outcome — escalate to the reviewer per execution plan §6 trigger 8.
-
-The lock is final by PR-012. After 3.0-alpha tags, changing the list-storage strategy would force a second drop-and-rebuild migration on existing 3.0-alpha installs — the same reason §7.1's `written_at` column is added in PR-008 instead of Phase 1C.
+- *Rejected because:* the chosen layout dominates on every dimension. **Read locality:** the chosen layout's list-element rows are physically clustered with their parent record's scalar rows via `WITHOUT ROWID`; the sibling-table layout requires a second `SELECT` or join regardless of list size. **Schema surface:** the chosen layout is one table; the sibling table doubles the migration surface for every future schema change. **Nested lists:** the chosen layout reuses the `CacheKey` indirection the cache already has; the sibling table requires a new depth strategy with no existing mechanism to lean on. **Phase 2 `@onDelete` cascade:** the chosen layout's cascade walker reads from one source; the sibling-table walker reads from two. There is no scenario where the second table produces a capability or performance advantage the chosen layout lacks. Even hypothetical edge cases (e.g., wildly disproportionate list-vs-scalar sizes biasing index pressure) are bounded by `WITHOUT ROWID` clustering in the chosen layout.
 
 ## Consequences
 
 ### Positive
 
-- **Capability requirement is documented and locked.** Per-element queryability is now an explicit constraint in this ADR, not a tacit assumption. Any future reconsideration of the storage shape (Phase 2, Phase 3) starts from "must support per-element SQL queries" rather than relitigating the JSON shape.
-- **Empirical grounding for the remaining choice.** §7.1 attributes the row-per-field shape to a published benchmark, but the benchmark does not cover list paths. This ADR closes that gap for the live decision (Option 1 vs Option 2) before the choice becomes hard to reverse.
-- **The leading-candidate framing accelerates Phase 1A planning.** PR-009b can be scoped speculatively against Option 2 while the benchmarks run; if the data flips to Option 1, the scope swap is mechanical.
-- **Decision-relevant scenarios become permanent harness coverage.** Whichever option lands, the list-heavy scenarios remain in PR-011a's output. Phase 2 (`@onDelete` cascade, LRU on lists) gets a baseline to regress against from day one.
-- **Nested-list complexity is surfaced and budgeted, not discovered.** Option 2's depth ≥ 2 recursion path and Option 1's depth-strategy choice are identified now; if either had been discovered mid-implementation, it would have surfaced as scope creep on a code PR rather than a paragraph in this ADR.
-- **PR-012 gating criteria already accommodate this.** The 3.0-alpha tag is already gated on "no `regressed` verdict in the published dataset"; this ADR adds list scenarios to that dataset without changing the gating mechanic.
+- **Per-element queries are SQL-native.** Filtering, indexing, observing changes, and cascade-walking list elements all happen at the storage layer. No JSON parsing on hot paths.
+- **Read locality wins for the common case.** `WITHOUT ROWID` clusters list-element rows next to their parent's scalar rows. A single record read returns the entire record — scalars and lists — in one query, with rows arriving contiguous in the result set.
+- **One table, one migration surface.** Every future schema change (Phase 2 LRU `lastAccessedAt`, `@onDelete` cascade fields, additional typed columns) touches `records` only. The sibling-table alternative would have doubled the migration burden.
+- **Nested lists reuse existing reference indirection.** No new mechanism for depth ≥ 2; `child_key_value` to a synthetic sub-record is just another use of the indirection the cache already has for object references.
+- **PR-009's row-per-field harness is preserved.** The CRUD infrastructure landed in PR-009 (#1001) — query construction, transaction handling, result-row grouping — extends naturally to position-keyed rows. Only the encoder/decoder branches for list values change.
 
 ### Negative
 
-- **PR-009's encoder is now interim code.** The JSON-blob path will be replaced by PR-009b regardless of which option wins. The hardening work in the PR-009 review-findings commit (`NSNull`, `$reference`, sortedKeys, etc.) is mostly retained for the `custom_scalar_value` path, but the list-encoding branches are discarded. Mitigation: the discarded code is localized; tests for the JSON path become test fixtures for the new row-per-element encoder.
-- **Phase 1A timeline absorbs additional scenario authoring.** PR-011a's estimate (~700 LoC) already includes Tier 1 + Tier 2 scenario coverage; the list-heavy additions are ~200–300 LoC of scenario code plus fixtures. Mitigation: scenario authoring is mechanical and parallelizable; perf plan §5.2 accommodates inline additions without restructuring §8.
-- **Option 2's sentinel semantics add a small reader-side decoder cost.** Every `SELECT` against `records` returns scalar rows interleaved with list-element rows; the decoder must branch on `position = -1`. Mitigation: a single integer comparison per row; negligible vs Option 1's second-`SELECT` cost.
+- **PR-009's JSON list-encoding paths are interim code that gets replaced.** The hardening work in the PR-009 review-findings commit is mostly retained for the `custom_scalar_value` path, but the list-encoding branches in `SQLiteFieldEncoding.swift` are discarded. Mitigation: the discarded surface is localized; existing tests of those paths become test fixtures for the new row-per-element encoder.
+- **Decoder branches on the sentinel.** Every `SELECT` against `records` returns scalar rows interleaved with list-element rows; the decoder must branch on `position = -1` for every row. Mitigation: a single integer comparison per row, negligible against the I/O cost of the underlying query.
+- **Synthetic-key naming convention must be collision-safe.** The depth ≥ 2 indirection produces keys like `User:1.tags[3]`. The naming convention must be guaranteed not to collide with legitimate cache keys produced by the schema's key-field resolution. Mitigation: the `.field[N]` suffix form has no legitimate use in GraphQL field names, and the brackets are already part of cache-key syntax; a reserved-character audit lands with PR-009.
+- **Engineering plan §7.1, §7.2 and execution plan §8 need follow-up doc updates** to match this ADR. Mitigation: those updates are mechanical and land as a single follow-up doc PR; this ADR is the source of truth in the meantime.
 
 ### Neutral
 
-- **No 2.x parity question.** 2.x has no list-storage strategy distinct from its records-blob-as-JSON layout; both options under evaluation are improvements. The 2.x baseline dataset (PR-004a, #980) does not measure list paths separately because the 2.x storage layer does not separate them.
-- **The §7.1 wording will need an editorial pass** once the decision is locked — to either (a) describe the `list_items` table as the locked design or (b) describe the extended PK with the `position` sentinel. The current "JSON-encoded list" claim is removed in either case.
+- **The PR-011 / PR-011a list-heavy scenarios still get added** — but as permanent regression coverage, not as decision-gating evidence. Tier 3 `read-record-with-list-of-N`, `write-list-of-N`, `mutate-element-at-position-K`, the nested-list scenarios, and `filter-list-elements-by-typed-column` (capability-coverage) all land in PR-011a's standing output.
+- **The 2.x baseline dataset (PR-004a, #980) does not measure list paths separately** because the 2.x storage layer does not separate them. The alpha-vs-2.x comparison reports list-path numbers as new data without a 2.x baseline; this is documented in the comparison reporter's output (per perf plan §5).
+- **3.0-alpha tag gating is unaffected.** The list-storage shape is no longer a separate "decision lock before PR-012" item; PR-012's existing gating (SQLite performance gates + no `regressed` verdict in the published dataset) covers regression detection against the chosen layout going forward.
 
 ## References
 
-- [Engineering plan §7.1](../cache-rewrite-phase1-plan.md) — current `list_value TEXT` schema decision being replaced
-- [Engineering plan §7.4](../cache-rewrite-phase1-plan.md) — published performance gates (scalar paths only)
-- [Perf plan §3.2, §3.3, §5.2](../cache-rewrite-phase1-perf.md) — Tier 2 / Tier 3 scenario design and the inline `feat(perf): add scenario` pattern
-- [Execution plan §8 PR-011, PR-011a, PR-012](../cache-rewrite-phase1-execution.md) — perf-harness PRs that carry the new list-heavy scenarios and the 3.0-alpha tag gating
-- [ADR 0001 — Major version bump](./0001-major-version-bump.md) — drop-and-rebuild migration policy that constrains the lock to "before PR-012"
-- [ADR 0002 — Record abstraction](./0002-record-abstraction.md) — in-memory `CachedField` shape (independent of this ADR; both options round-trip cleanly to `CachedField`)
+- [Engineering plan §7.1, §7.2](../cache-rewrite-phase1-plan.md) — DDL and operations (to be rewritten per this ADR)
+- [Engineering plan §7.4](../cache-rewrite-phase1-plan.md) — published performance gates (unchanged)
+- [Perf plan §3.2, §3.3, §5.2](../cache-rewrite-phase1-perf.md) — Tier 2 / Tier 3 scenario design and the inline `feat(perf): add scenario` pattern (used for the list-heavy scenarios as permanent coverage)
+- [Execution plan §8](../cache-rewrite-phase1-execution.md) — PR list (PR-009 scope amended; PR list updated in follow-up)
+- [ADR 0001 — Major version bump](./0001-major-version-bump.md) — drop-and-rebuild migration policy that absorbs the schema change at zero cost while 3.0-alpha is untagged
+- [ADR 0002 — Record abstraction](./0002-record-abstraction.md) — in-memory `CachedField` shape; this ADR is the on-disk counterpart for list-typed fields
 - [SQLite Performance Benchmarks (Confluence 1585152147)](https://apollographql.atlassian.net/wiki/spaces/ClientDev/pages/1585152147) — origin of the row-per-field shape; the source that does not cover list paths
-- [PR-009 (#1001)](https://github.com/apollographql/apollo-ios-dev/pull/1001) — row-per-field CRUD implementation; review thread that surfaced the asymmetry
-- [`SQLiteFieldEncoding.swift`](../../Sources/ApolloSQLite/SQLiteFieldEncoding.swift) — current JSON-encoded list-path implementation (interim; replaced by PR-009b)
-- Industry pattern reference for the Option 2 shape: adjacency-list-with-position, with depth bounded by the GraphQL schema rather than handled via closure table / nested set. See discussion of when to combine adjacency list with other models for hierarchical data — e.g., [Djellouli, *Storing Hierarchical Data in Relational Databases with SQL*](https://adamdjellouli.com/articles/databases_notes/03_sql/09_hierarchical_data).
+- [PR-009 (#1001)](https://github.com/apollographql/apollo-ios-dev/pull/1001) — row-per-field CRUD implementation; scope amended per this ADR
+- [`SQLiteFieldEncoding.swift`](../../Sources/ApolloSQLite/SQLiteFieldEncoding.swift) — encoder/decoder file affected by the schema change
+- Industry pattern reference: adjacency-list-with-position, with depth bounded by the GraphQL schema rather than handled via closure table / nested set. See [Djellouli, *Storing Hierarchical Data in Relational Databases with SQL*](https://adamdjellouli.com/articles/databases_notes/03_sql/09_hierarchical_data) for the general pattern.


### PR DESCRIPTION
## Summary

ADR 0006 ratifies the on-disk shape for list-typed cache fields: **each list element becomes its own row in the `records` table, addressed by an extended primary key with a `position` column.** Scalars use the sentinel `position = -1`; list elements use `position = 0..N-1`. Nested lists (`[[Int]]`, `[[CacheReference]]`) recurse via the existing `CacheKey` indirection — depth ≥ 2 is the only path that incurs an extra `SELECT`. Industry-standard adjacency-list-with-position, applied to a domain where depth is bounded and known at codegen time.

**Status:** Accepted.

The §7.1 DDL (with `list_value TEXT`) is replaced. The `list_value` column is removed; `PRIMARY KEY (cache_key, field_name)` becomes `PRIMARY KEY (cache_key, field_name, position)`. The new shape is in §2 of the ADR.

### Why JSON `list_value` is rejected

The cache must support per-element queries against list-typed fields — filtering and indexing list elements at the SQL level, watcher observation of single-element changes, and walking list elements during the Phase 2 `@onDelete` cascade. JSON-blob storage forecloses all of these (every per-element operation requires loading and parsing the entire blob in Swift). This is a capability constraint, not a performance preference; no benchmark outcome rescues the JSON shape.

### Why the sibling `list_items` table is rejected

The chosen in-place layout dominates the sibling table on every dimension that matters — read locality (clustered with parent via `WITHOUT ROWID`), schema surface (one table vs. two), nested-list handling (reuses existing `CacheKey` indirection vs. requires a new depth strategy), Phase 2 cascade walker source (one table vs. two). There is no scenario where the second table produces a capability or performance advantage the chosen layout lacks. Both rejected alternatives sit under "Alternatives considered."

### Implementation impact

- **§7.1 (DDL) and §7.2 (operations)** need a follow-up doc PR. The column shape, PK, and operations descriptions all change.
- **PR-009 (#1001, open) scope is amended.** The JSON list-encoding branches in `SQLiteFieldEncoding.swift` are replaced with position-aware row writers; the decoder grows a `position = -1` / `position >= 0` split. The PR-009 review-findings hardening (`NSNull`, `$reference`, `sortedKeys`, `JSONSerialization.isValidJSONObject`) is retained where it applies to `custom_scalar_value`.
- **3.0-alpha is untagged**, so the schema change carries zero migration cost on end-user installs — the drop-and-rebuild path on first 3.0 launch carries this ADR's schema directly.
- **Execution plan §8** needs an amendment to reflect the PR-009 scope change and any new PR slots.

### Performance coverage

The list-heavy benchmark scenarios discussed during this ADR's drafting (`read-record-with-list-of-N`, `write-list-of-N`, `mutate-element-at-position-K-in-list-of-N`, nested `[[T]]` reads, and `filter-list-elements-by-typed-column`) still land in PR-011 / PR-011a — but as **permanent regression coverage of the chosen design**, not as decision-gating evidence. The 3.0-alpha tag's existing gating (SQLite gates + no `regressed` verdict in the published dataset) absorbs them without any new lock criterion.

120 lines. Follow-up to [#1001](https://github.com/apollographql/apollo-ios-dev/pull/1001) (PR-009). Stacks directly on `cache-rewrite/phase-1-plan`, not on the PR-009 stack — this is an out-of-stack governance/docs PR per the "Supporting PRs" pattern.

### Revision history

- **`b056afded`** — initial draft with two options (JSON `list_value` vs sibling `list_items` table), decision deferred to PR-011a perf data.
- **`272cd70bb`** — added in-place rows with `position` as a third option (leading candidate); revised trade-off table to three columns; added `mutate-element-at-position-K` scenario; expanded decision rule to three branches.
- **`e16bbd844`** — JSON `list_value` rejected on capability grounds (per-element queryability) and moved to "Alternatives considered"; remaining options renumbered (sibling table = new Option 1; in-place position = new Option 2, still leading candidate); trade-off table shrunk to two columns; decision rule reduced to two branches.
- **`89774cfd1`** — ratified. Status flipped to Accepted; sibling table moved into "Alternatives considered" alongside the JSON rejection; restructured to the canonical ADR format used by ADR 0001-0005; Trade-offs and Deciding evidence sections collapsed into the Decision rationale and Alternatives rejections. Implementation impact documented inline.

## Test plan

- [ ] Docs-only PR — no build/test gates required (per execution plan §5).
- [ ] Reviewer ratifies the capability-requirement framing (per-element queryability) and the "no benchmark rescues JSON" rejection.
- [ ] Reviewer ratifies the design-merit dominance of the chosen in-place layout over the sibling-table alternative.
- [ ] Follow-up doc PR to rewrite engineering plan §7.1, §7.2 to match the new schema — to be opened after this PR merges.
- [ ] Follow-up doc PR to amend execution plan §8 (PR-009 scope; possibly new PR slots) — same or separate PR, depending on review preference.
- [ ] PR-009 (#1001) amendment / replacement — implementation work; out of scope for this docs PR but flagged for the reviewer's planning.
- [ ] PR #967 progress tracker already updated to add this PR to "Supporting PRs (governance / docs)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
