### PR TITLE
refactor(cache): NormalizedCache adopts field projection (PR-009c)

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockApolloStore.swift
+++ b/Tests/ApolloInternalTestHelpers/MockApolloStore.swift
@@ -1,4 +1,4 @@
-import Apollo
+@_spi(Execution) import Apollo
 import ApolloAPI
 
 extension ApolloStore {

--- a/Tests/ApolloTests/Cache/LoadFieldsTests.swift
+++ b/Tests/ApolloTests/Cache/LoadFieldsTests.swift
@@ -1,0 +1,263 @@
+@_spi(Execution) import ApolloInternalTestHelpers
+@testable @_spi(Execution) import Apollo
+import Foundation
+import Nimble
+import XCTest
+
+class LoadFieldsTests: XCTestCase, CacheDependentTesting {
+  var cacheType: any TestCacheProvider.Type {
+    InMemoryTestCacheProvider.self
+  }
+
+  // CacheDependentTesting requires a `store` to share infrastructure with
+  // other cache-dependent tests, but loadFields is a cache-level method
+  // that the store doesn't expose yet (per ADR 0007's plan, the store
+  // adopts the new API in PR-009e). These tests exercise the cache
+  // directly via `makeNormalizedCache()`; the `store` slot stays nil.
+  var store: ApolloStore!
+
+  // MARK: - Empty input
+
+  func test__loadFields__givenEmptyProjections__returnsEmptyDictionary() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: ["name": CachedField(value: "Alice", writtenAt: 0)])
+    ])
+
+    let result = try await cache.loadFields([])
+    expect(result.isEmpty) == true
+  }
+
+  func test__loadFields__givenEmptyCache__returnsEmptyDictionary() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "User:1", fieldName: "name",
+                      columnShape: .string, cardinality: .scalar)
+    ])
+    expect(result.isEmpty) == true
+  }
+
+  func test__loadFields__givenProjectionsForOnlyMissingKeys__returnsEmptyDictionary() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: ["name": CachedField(value: "Alice", writtenAt: 0)])
+    ])
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "User:2", fieldName: "name",
+                      columnShape: .string, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:3", fieldName: "name",
+                      columnShape: .string, cardinality: .scalar),
+    ])
+    expect(result.isEmpty) == true
+  }
+
+  // MARK: - Field projection (the core promise)
+
+  func test__loadFields__givenProjectionForOneField__returnsOnlyThatField() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: [
+        "name": CachedField(value: "Alice", writtenAt: 0),
+        "age": CachedField(value: 30, writtenAt: 0),
+        "email": CachedField(value: "alice@example.com", writtenAt: 0),
+      ])
+    ])
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "User:1", fieldName: "name",
+                      columnShape: .string, cardinality: .scalar)
+    ])
+
+    expect(result.count) == 1
+    let record = try XCTUnwrap(result["User:1"])
+    expect(record.fields.keys.sorted()) == ["name"]
+    expect(record["name"] as? String) == "Alice"
+  }
+
+  func test__loadFields__givenMultipleProjectionsOnSameKey__returnsRequestedFieldsCombined() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: [
+        "name": CachedField(value: "Alice", writtenAt: 0),
+        "age": CachedField(value: 30, writtenAt: 0),
+        "email": CachedField(value: "alice@example.com", writtenAt: 0),
+      ])
+    ])
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "User:1", fieldName: "name",
+                      columnShape: .string, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:1", fieldName: "age",
+                      columnShape: .int, cardinality: .scalar),
+    ])
+
+    expect(result.count) == 1
+    let record = try XCTUnwrap(result["User:1"])
+    expect(record.fields.keys.sorted()) == ["age", "name"]
+    expect(record["name"] as? String) == "Alice"
+    expect(record["age"] as? Int) == 30
+    // "email" was not requested even though it exists in storage.
+    expect(record["email"]).to(beNil())
+  }
+
+  func test__loadFields__givenProjectionsAcrossMultipleKeys__partitionsByKey() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: [
+        "name": CachedField(value: "Alice", writtenAt: 0),
+        "age": CachedField(value: 30, writtenAt: 0),
+      ]),
+      Record(key: "User:2", fields: [
+        "name": CachedField(value: "Bob", writtenAt: 0),
+        "email": CachedField(value: "bob@example.com", writtenAt: 0),
+      ]),
+    ])
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "User:1", fieldName: "name",
+                      columnShape: .string, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:2", fieldName: "email",
+                      columnShape: .string, cardinality: .scalar),
+    ])
+
+    expect(result.count) == 2
+    let user1 = try XCTUnwrap(result["User:1"])
+    expect(user1.fields.keys.sorted()) == ["name"]
+    expect(user1["name"] as? String) == "Alice"
+
+    let user2 = try XCTUnwrap(result["User:2"])
+    expect(user2.fields.keys.sorted()) == ["email"]
+    expect(user2["email"] as? String) == "bob@example.com"
+  }
+
+  // MARK: - Partial-presence behavior
+
+  func test__loadFields__givenMixedPresentAndMissingKeys__returnsOnlyPresentKeys() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: ["name": CachedField(value: "Alice", writtenAt: 0)])
+    ])
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "User:1", fieldName: "name",
+                      columnShape: .string, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:99", fieldName: "name",
+                      columnShape: .string, cardinality: .scalar),
+    ])
+
+    expect(result.count) == 1
+    expect(result["User:1"]).toNot(beNil())
+    expect(result["User:99"]).to(beNil())
+  }
+
+  func test__loadFields__givenFieldMissingFromPresentRecord__omitsKeyFromResult() async throws {
+    // A cache key whose record exists, but the *requested* field doesn't.
+    // The result should omit the key entirely — per the doc on
+    // `loadFields(_:)`, a key only appears if at least one requested
+    // field was found.
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: ["name": CachedField(value: "Alice", writtenAt: 0)])
+    ])
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "User:1", fieldName: "nonExistentField",
+                      columnShape: .string, cardinality: .scalar)
+    ])
+
+    expect(result.isEmpty) == true
+  }
+
+  func test__loadFields__givenSomeFieldsPresentAndSomeAbsent__returnsOnlyPresentFields() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: ["name": CachedField(value: "Alice", writtenAt: 0)])
+    ])
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "User:1", fieldName: "name",
+                      columnShape: .string, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:1", fieldName: "missing",
+                      columnShape: .string, cardinality: .scalar),
+    ])
+
+    let record = try XCTUnwrap(result["User:1"])
+    expect(record.fields.keys.sorted()) == ["name"]
+  }
+
+  // MARK: - Deduplication tolerance
+
+  func test__loadFields__givenDuplicateProjections__coalescesIntoSingleFieldEntry() async throws {
+    // The doc explicitly tolerates duplicate projections. The result
+    // should have one entry per `(cacheKey, fieldName)` regardless of
+    // how many times the same projection was supplied.
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: ["name": CachedField(value: "Alice", writtenAt: 0)])
+    ])
+
+    let projection = FieldProjection(
+      cacheKey: "User:1", fieldName: "name",
+      columnShape: .string, cardinality: .scalar
+    )
+
+    let result = try await cache.loadFields([projection, projection, projection])
+
+    expect(result.count) == 1
+    let record = try XCTUnwrap(result["User:1"])
+    expect(record.fields.count) == 1
+    expect(record["name"] as? String) == "Alice"
+  }
+
+  // MARK: - List + reference fields round-trip
+
+  func test__loadFields__givenListField__returnsArrayValue() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "User:1", fields: [
+        "tags": CachedField(value: ["swift", "graphql"] as Record.Value, writtenAt: 0)
+      ])
+    ])
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "User:1", fieldName: "tags",
+                      columnShape: .string, cardinality: .list)
+    ])
+
+    let record = try XCTUnwrap(result["User:1"])
+    let tags = try XCTUnwrap(record["tags"] as? [String])
+    expect(tags) == ["swift", "graphql"]
+  }
+
+  func test__loadFields__givenCacheReferenceField__returnsReference() async throws {
+    let (cache, _) = await cacheType.makeNormalizedCache()
+    try await seed(cache: cache, records: [
+      Record(key: "Query.viewer", fields: [
+        "user": CachedField(value: CacheReference("User:1") as Record.Value, writtenAt: 0)
+      ])
+    ])
+
+    let result = try await cache.loadFields([
+      FieldProjection(cacheKey: "Query.viewer", fieldName: "user",
+                      columnShape: .childKey, cardinality: .scalar)
+    ])
+
+    let record = try XCTUnwrap(result["Query.viewer"])
+    expect(record["user"] as? CacheReference) == CacheReference("User:1")
+  }
+
+  // MARK: - Helpers
+
+  /// Writes the given records into the cache so they are observable to
+  /// `loadFields`. Wraps `merge(records:)` so individual test bodies
+  /// stay focused on the assertion.
+  private func seed(
+    cache: any NormalizedCache,
+    records: [Record]
+  ) async throws {
+    let recordSet = RecordSet(records: records)
+    _ = try await cache.merge(records: recordSet)
+  }
+}

--- a/Tests/ApolloTests/Cache/SQLite/SQLiteLoadFieldsTests.swift
+++ b/Tests/ApolloTests/Cache/SQLite/SQLiteLoadFieldsTests.swift
@@ -1,0 +1,11 @@
+import Foundation
+import ApolloInternalTestHelpers
+
+// Inherits every test in `LoadFieldsTests` and runs them against the
+// SQLite-backed cache. Together with the InMemory-targeted parent
+// class this gives PR-009c coverage on both backends in one place.
+class SQLiteLoadFieldsTests: LoadFieldsTests {
+  override var cacheType: any TestCacheProvider.Type {
+    SQLiteTestCacheProvider.self
+  }
+}

--- a/apollo-ios/Sources/Apollo/Caching/NormalizedCache.swift
+++ b/apollo-ios/Sources/Apollo/Caching/NormalizedCache.swift
@@ -57,4 +57,63 @@ public protocol ReadOnlyNormalizedCache: AnyObject {
   /// - Returns: A dictionary of cache keys to records containing the records that have been found.
   func loadRecords(forKeys keys: Set<CacheKey>) async throws -> [CacheKey: Record]
 
+  /// Loads the field values described by `projections`, returning each
+  /// requested record's fields as a partial `Record` containing only the
+  /// fields the caller asked for. Per ADR 0007 this is the projection-
+  /// aware replacement for ``loadRecords(forKeys:)``; the executor
+  /// (PR-009d) and `ApolloStore` (PR-009e) migrate to this method
+  /// during sub-phase 1A.5, and PR-009g lands SQL-level column
+  /// projection on the SQLite backend.
+  ///
+  /// - Parameters:
+  ///   - projections: The set of fields to read. Each
+  ///     ``FieldProjection`` identifies one `(cacheKey, fieldName)`
+  ///     pair plus its storage shape. Multiple projections may share
+  ///     a `cacheKey` to request different fields on the same record.
+  ///     Duplicate projections are tolerated; their results coalesce.
+  ///
+  /// - Returns: A dictionary of cache keys to partial records. A cache
+  ///   key appears in the result only if at least one of its requested
+  ///   fields was found in the cache. The returned `Record.fields` is
+  ///   restricted to the requested field names that were present in
+  ///   the cache; unrequested fields on the same record are excluded
+  ///   even if they exist in storage.
+  @_spi(Execution)
+  func loadFields(_ projections: [FieldProjection]) async throws -> [CacheKey: Record]
+
+}
+
+@_spi(Execution)
+extension ReadOnlyNormalizedCache {
+
+  /// Default implementation. Delegates to ``loadRecords(forKeys:)`` to
+  /// fetch the full records for the projections' cache keys, then
+  /// filters each record's `fields` to the requested field names.
+  ///
+  /// This is the "fallback" path the ADR 0007 table references for the
+  /// SQLite backend during the 1A.5 transition: until PR-009g lands
+  /// SQL-level column projection, every backend that conforms to
+  /// ``ReadOnlyNormalizedCache`` automatically inherits a correct (if
+  /// unoptimized) `loadFields` implementation by reading whole records
+  /// and filtering in Swift. Custom cache implementors get the same
+  /// behavior without a forced API migration; they may override the
+  /// method with a projection-aware path when they're ready.
+  public func loadFields(_ projections: [FieldProjection]) async throws -> [CacheKey: Record] {
+    guard !projections.isEmpty else { return [:] }
+
+    let projectionsByKey = Dictionary(grouping: projections, by: \.cacheKey)
+    let keys = Set(projectionsByKey.keys)
+    let records = try await loadRecords(forKeys: keys)
+
+    var result: [CacheKey: Record] = [:]
+    for (key, fieldProjections) in projectionsByKey {
+      guard let record = records[key] else { continue }
+      let requestedFieldNames = Set(fieldProjections.map(\.fieldName))
+      let filteredFields = record.fields.filter { requestedFieldNames.contains($0.key) }
+      if !filteredFields.isEmpty {
+        result[key] = Record(key: key, fields: filteredFields)
+      }
+    }
+    return result
+  }
 }

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Apollo
+@_spi(Execution) import Apollo
 
 public enum SQLiteNormalizedCacheError: Error {
   case invalidRecordEncoding(record: String)  


### PR DESCRIPTION
Adds `loadFields(_:)` to `ReadOnlyNormalizedCache` (and via inheritance to `NormalizedCache`) — the projection-aware read entry point that [ADR 0007](https://github.com/apollographql/apollo-ios-dev/blob/cache-rewrite/phase-1-plan/apollo-ios/Design/adr/0007-selection-aware-cache-reads.md) commits to.

This is **PR-009c** in sub-phase 1A.5. Stacked on PR #1008 (FieldProjection types). Per the ADR table:

> breaking protocol change; `InMemoryNormalizedCache` implements; `SQLiteNormalizedCache` falls back to the PR-009 read path during transition

## What's in the PR

- `loadFields(_:)` requirement on `ReadOnlyNormalizedCache` (and inherited by `NormalizedCache`).
- Default implementation in an `@_spi(Execution) extension` that delegates to `loadRecords(forKeys:)` and filters fields in Swift.
- Two import upgrades: `SQLiteNormalizedCache.swift` and `Tests/ApolloInternalTestHelpers/MockApolloStore.swift` switch `import Apollo` → `@_spi(Execution) import Apollo` so they can see the SPI-bracketed default impl and stay conforming.
- 12 cache-level tests in `LoadFieldsTests`, plus a one-line subclass `SQLiteLoadFieldsTests` that runs the same 12 against the SQLite backend.

## The mapping rule

```swift
@_spi(Execution)
func loadFields(_ projections: [FieldProjection]) async throws -> [CacheKey: Record]
```

- Group projections by `cacheKey`.
- Fetch full records via `loadRecords`.
- For each cache key, return a `Record` containing only the requested field names that were found in storage.
- Cache keys with no found fields are absent from the result.
- Duplicate projections coalesce.

## Visibility and migration story

The protocol requirement and the default implementation are both `@_spi(Execution)` to keep the new surface private while sub-phase 1A.5 iterates. PR-009c is the first PR that puts `FieldProjection` (from PR-009b) into the public protocol surface; the SPI bracketing matches the existing convention used by `CacheReference`.

Downstream cache implementors:
- Automatically inherit the default. No code changes required to keep conforming.
- May override `loadFields(_:)` with a projection-aware path when ready (this is exactly what PR-009g does for `ApolloSQLiteDatabase`).

Internal callers (executor, `ApolloStore`, dependency tracker) don't use the new method yet — that's PR-009d/e/f. The method exists and is tested; the rest of sub-phase 1A.5 migrates consumers to it.

PR-009e/f will drop the SPI bracketing once the read-API shape is locked.

## Tests

12 tests defined in `LoadFieldsTests`, inherited by `SQLiteLoadFieldsTests` for the SQLite backend (24 total). Coverage:

- **Empty input**: empty projections, empty cache, projections for only missing keys.
- **Projection**: single field, multi-field same key, multi-key partitioning.
- **Partial presence**: mixed present/missing keys, requested field absent from present record, some-present-some-absent.
- **Deduplication**: duplicate projections coalesce.
- **Value shapes**: list field round-trip, cache-reference field round-trip.

**Full Apollo-UnitTestPlan: 1098 passed, 0 failed.**

## References

- [ADR 0007 — Selection-set-aware cache reads](https://github.com/apollographql/apollo-ios-dev/blob/cache-rewrite/phase-1-plan/apollo-ios/Design/adr/0007-selection-aware-cache-reads.md)
- PR #1001 (PR-009 — row-per-element CRUD; transitively in this PR's base)
- PR #1008 (PR-009b — FieldProjection types; this PR's direct base)
- PR #1007 (cascade-delete; also stacked on #1001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)