### PR TITLE
Fix WebSocketTransport retain cycle in receive loop

### DIFF
--- a/Tests/ApolloTests/WebSocket/WebSocketTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTests.swift
@@ -2672,6 +2672,31 @@ class WebSocketTests: XCTestCase, MockResponseProvider {
       expect(error).to(beAKindOf(FailingWriteCache.WriteError.self))
     }
   }
+
+  // MARK: - Memory Management
+
+  func testTransport__whenSubscriptionCompletedAndAllReferencesDropped__shouldDeallocate() async throws {
+    mockTask.emit(.connectionAck(payload: nil))
+
+    let (subscription, operationID) = try await subscribe(on: mockTask, using: client)
+
+    mockTask.emit(.next(
+      id: operationID,
+      payload: Self.reviewAddedPayload(stars: 5, commentary: "Great")
+    ))
+    _ = try await subscription.stream.first(where: { _ in true })
+
+    mockTask.emit(.complete(id: operationID))
+
+    weak let weakTransport = networkTransport
+    networkTransport = nil
+    client = nil
+
+    XCTAssertTrueEventually(
+      weakTransport == nil,
+      message: "WebSocketTransport should be deallocated after subscriptions complete and all external references are dropped"
+    )
+  }
 }
 
 // MARK: - Test Helpers

--- a/Tests/ApolloTests/WebSocket/WebSocketTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTests.swift
@@ -2694,7 +2694,103 @@ class WebSocketTests: XCTestCase, MockResponseProvider {
 
     XCTAssertTrueEventually(
       weakTransport == nil,
+      timeout: 3.0,
       message: "WebSocketTransport should be deallocated after subscriptions complete and all external references are dropped"
+    )
+  }
+
+  func testTransport__whenPausedAndAllReferencesDropped__shouldDeallocate() async throws {
+    mockTask.emit(.connectionAck(payload: nil))
+
+    let (subscription, _) = try await subscribe(on: mockTask, using: client)
+
+    // Consume in a cancellable task — pause() leaves subscriptions alive on the registry,
+    // so the consumer must cancel to release the inner Task's strong self reference.
+    let consumeTask = Task {
+      for try await _ in subscription {}
+    }
+    await expect { await self.networkTransport.subscriberCount }.toEventually(equal(1))
+
+    // Pause — closes the underlying WebSocket and exits the receive loop without
+    // triggering auto-reconnection.
+    await networkTransport.pause()
+
+    consumeTask.cancel()
+    await expect { await self.networkTransport.subscriberCount }.toEventually(equal(0))
+
+    weak let weakTransport = networkTransport
+    networkTransport = nil
+    client = nil
+
+    XCTAssertTrueEventually(
+      weakTransport == nil,
+      timeout: 3.0,
+      message: "WebSocketTransport should be deallocated after pause() and all external references are dropped"
+    )
+  }
+
+  func testTransport__whenSubscriberCancelsMidStreamAndAllReferencesDropped__shouldDeallocate() async throws {
+    mockTask.emit(.connectionAck(payload: nil))
+
+    let (subscription, operationID) = try await subscribe(on: mockTask, using: client)
+
+    // Deliver one value mid-stream — server never sends complete.
+    mockTask.emit(.next(
+      id: operationID,
+      payload: Self.reviewAddedPayload(stars: 5, commentary: "Mid-stream")
+    ))
+
+    let consumeTask = Task {
+      for try await _ in subscription {}
+    }
+    await expect { await self.networkTransport.subscriberCount }.toEventually(equal(1))
+
+    // Cancel the consumer mid-stream — should trigger onTermination → complete to server,
+    // unregister the subscriber, and let the inner Task release its strong self reference.
+    consumeTask.cancel()
+    await expect { await self.networkTransport.subscriberCount }.toEventually(equal(0))
+
+    weak let weakTransport = networkTransport
+    networkTransport = nil
+    client = nil
+
+    XCTAssertTrueEventually(
+      weakTransport == nil,
+      timeout: 3.0,
+      message: "WebSocketTransport should be deallocated after subscriber cancels mid-stream and all external references are dropped"
+    )
+  }
+
+  func testTransport__whenReconnectedAndAllReferencesDropped__shouldDeallocate() async throws {
+    let task1 = MockWebSocketTask()
+    let task2 = MockWebSocketTask()
+    try setUpTransport(tasks: [task1, task2], configuration: .init(reconnectionInterval: 0))
+
+    // Establish initial connection on task1.
+    task1.emit(.connectionAck(payload: nil))
+    let (subscription, operationID) = try await subscribe(on: task1, using: client)
+
+    // Disconnect task1 — triggers auto-reconnect onto task2.
+    task1.finish()
+    task2.emit(.connectionAck(payload: nil))
+
+    // Wait for the resubscribe on the new connection to confirm the reconnect cycle completed.
+    // Both the old and new receive-loop Tasks should hold only weak self references.
+    await expect(task2.clientSentMessages(ofType: "subscribe").count).toEventually(equal(1))
+
+    // Complete the subscription on the new connection so the inner Task exits and releases self.
+    task2.emit(.complete(id: operationID))
+    await expect { await self.networkTransport.subscriberCount }.toEventually(equal(0))
+
+    weak let weakTransport = networkTransport
+    networkTransport = nil
+    client = nil
+    _ = subscription
+
+    XCTAssertTrueEventually(
+      weakTransport == nil,
+      timeout: 3.0,
+      message: "WebSocketTransport should be deallocated after a reconnection cycle and all external references are dropped"
     )
   }
 }

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -164,6 +164,11 @@ public actor WebSocketTransport: SubscriptionNetworkTransport, NetworkTransport 
     )
   }
 
+  deinit {
+    pingTimerTask?.cancel()
+    connection.close()
+  }
+
   // MARK: - Request Setup
 
   private static func createURLRequest(
@@ -228,21 +233,21 @@ public actor WebSocketTransport: SubscriptionNetworkTransport, NetworkTransport 
       connectingPayload: configuration.connectingPayload
     )
 
-    Task {
+    Task { [weak self] in
       do {
         for try await message in connectionStream {
-          didReceive(message: message)
+          await self?.didReceive(message: message)
         }
 
-        guard self.connection === loopConnection else { return }
-        await handleDisconnection()
+        guard await self?.connection === loopConnection else { return }
+        await self?.handleDisconnection()
       } catch {
-        guard self.connection === loopConnection else { return }
+        guard await self?.connection === loopConnection else { return }
         // Use Task.isCancelled to distinguish genuine task cancellation from
         // connection errors. The WebSocket task's receive() may throw errors
         // (including CancellationError) when the connection closes, which should
         // be treated as a disconnection — not as task cancellation.
-        await handleDisconnection(error: Task.isCancelled ? nil : error)
+        await self?.handleDisconnection(error: Task.isCancelled ? nil : error)
       }
     }
   }


### PR DESCRIPTION
This pull request fixes a retain cycle in `WebSocketTransport` that prevents it from ever being deallocated once a connection is established. The receive loop Task in `startConnectionReceiveLoop()` captures `self` strongly, keeping the actor alive even after all external references are dropped.

The connection needs to be closed manually in deinit because the receive loop Task outlives the transport. Even with `[weak self]`, the Task still holds the connection stream and keeps iterating it. Closing the connection ends the stream and lets the Task exit.

Includes a test that verifies the transport deallocates after a subscription completes and all references are dropped.