### PR TITLE
Prune findInXcode directory walk (skip hidden dirs & package descendants)

### DIFF
--- a/Tests/CodegenCLITests/VersionCheckerTests.swift
+++ b/Tests/CodegenCLITests/VersionCheckerTests.swift
@@ -299,6 +299,29 @@ class VersionCheckerTests: XCTestCase {
     }
   }
 
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileNestedInHiddenDirectory_returnsNoApolloVersionFound() async throws {
+    // given
+    for packageVersion in packageResolvedVersion.allCases {
+      try await testPackageResolvedFile(
+        packageVersion: packageVersion,
+        inDirectory: ".hidden/MyProject.xcworkspace/xcshareddata/swiftpm",
+        apolloVersion: Constants.CLIVersion
+      ) {
+
+        // when
+        let result = try await VersionChecker.matchCLIVersionToApolloVersion(
+          projectRootURL: fileManager.directoryURL
+        )
+
+        // then
+        // The search skips hidden directories, so a project nested inside one is intentionally
+        // not discovered. This is what keeps the search from recursively walking large hidden
+        // trees (`.build`, `.git`, git worktrees, …) that never hold the user's project.
+        expect(result).to(equal(.noApolloVersionFound))
+      }
+    }
+  }
+
 }
 
 // MARK: - Helpers

--- a/apollo-ios-codegen/Sources/CodegenCLI/Extensions/VersionChecker.swift
+++ b/apollo-ios-codegen/Sources/CodegenCLI/Extensions/VersionChecker.swift
@@ -51,8 +51,18 @@ enum VersionChecker {
       packagePath: String,
       excludeFilePathComponents: [String] = []
     ) -> PackageResolvedModel? {
-      let projectEnumerator = fileManager.base.enumerator(atPath: projectRootURL?.path ?? ".")
-      enumeratorLoop: while let file = projectEnumerator?.nextObject() as? String {
+      // Skip hidden directories (e.g. `.git`, `.build`, `.swiftpm`) and the contents of
+      // package bundles (e.g. the `.xcodeproj`/`.xcworkspace`/`.framework` we don't need to
+      // descend into). Without this, the enumerator recursively walks every file under the
+      // project root — which is catastrophic in checkouts that nest large trees such as build
+      // artifacts or git worktrees, costing tens of seconds before the first match is found.
+      let enumeratorURL = projectRootURL ?? URL(fileURLWithPath: fileManager.base.currentDirectoryPath)
+      let projectEnumerator = fileManager.base.enumerator(
+        at: enumeratorURL,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles, .skipsPackageDescendants, .producesRelativePathURLs]
+      )
+      enumeratorLoop: while let file = (projectEnumerator?.nextObject() as? URL)?.relativePath {
         if file.hasSuffix(fileSuffix) {
           //check if this file should be ignored
           for component in excludeFilePathComponents {


### PR DESCRIPTION
### Summary

`VersionChecker.findInXcode` locates the project's `Package.resolved` by recursively enumerating **every descendant** of the project root to find the first `.xcworkspace`/`.xcodeproj`, with no pruning. In checkouts that nest large trees under the root — build artifacts (`.build`), `.git`, vendored dependencies, or git worktrees — this walks hundreds of thousands of files on **every** `generate`/`fetch-schema` invocation, before codegen even begins.

It's especially bad because the first pass searches for a standalone apollo-dependent `.xcworkspace`. Projects that use an `.xcodeproj` (no top-level workspace) have **no match** for that pass, so it can't early-exit — it exhausts the entire tree just to conclude "none", then runs the `.xcodeproj` pass.

Measured on a repo with ~150k files under a hidden directory:

| | wall | system time |
|---|---|---|
| before | ~30 s | ~15.5 s |
| after | ~0.2 s | ~0.1 s |

### Fix

Switch the path-based `enumerator(atPath:)` to the URL-based `enumerator(at:includingPropertiesForKeys:options:)` with:

- `.skipsHiddenFiles` — don't descend into `.git`, `.build`, `.swiftpm`, worktree dirs, etc.
- `.skipsPackageDescendants` — don't descend into the bundles we're searching *for* (`.xcworkspace`/`.xcodeproj`/`.framework`); we only need the bundle path itself, then read its nested `Package.resolved` directly.
- `.producesRelativePathURLs` — so `url.relativePath` yields the same project-root-relative string the old `atPath` API returned, preserving the existing path construction in `apolloDependantPackage`.

Same lazy first-match behavior; only the set of directories visited changes.

### Behavior change

A project located **inside a hidden directory** is no longer discovered. This is intentional — a real Xcode project living under a dotfile directory is pathological, and skipping those dirs is exactly what avoids the pathological walk.

### Testing

All existing `VersionCheckerTests` pass. Added a regression test (`...givenPackageResolvedFileNestedInHiddenDirectory_returnsNoApolloVersionFound`) that asserts a workspace nested in a hidden directory is not discovered — it returns `.versionMatch` on the old code and `.noApolloVersionFound` with this change.
