### PR TITLE
refactor(cache): extract shared SelectionWalker (PR-009d-iv)

### DIFF
--- a/apollo-ios/Sources/Apollo/Execution/FieldProjectionCollector.swift
+++ b/apollo-ios/Sources/Apollo/Execution/FieldProjectionCollector.swift
@@ -88,162 +88,81 @@ public enum FieldProjectionCollector {
     responsePath: ResponsePath = []
   ) throws -> Set<FieldProjection> {
     var projections: Set<FieldProjection> = []
-    try walk(
+    // `SelectionWalker` owns the case dispatch — see PR-009d-iv. The
+    // projection path differs from `DefaultFieldSelectionCollector` only
+    // in the per-field action and the policy choices:
+    //
+    //  - `inlineFragmentPolicy`: when the receiving record's
+    //    `__typename` isn't yet loaded (typical on the projection-time
+    //    pre-pass driven by `CacheDataExecutionSource`), the caller
+    //    passes `includeAllInlineFragments: true`, which selects
+    //    `.includeAll`. The resulting projection set over-fetches every
+    //    type case's fields; the executor's later, type-aware traversal
+    //    surfaces only the matching type case to the response. PR-009g
+    //    will narrow this at the SQL layer.
+    //
+    //  - `deferredFragmentPolicy: .eager` because the cache path has no
+    //    incremental delivery channel — `CacheDataExecutionSource` sets
+    //    `shouldAttemptDeferredFragmentExecution = true` and the
+    //    executor eagerly resolves deferred fragments on cache reads.
+    //
+    // No fragment-tracking callbacks: the projection set carries
+    // everything downstream needs by `(cacheKey, fieldName)`. The
+    // fulfilled/deferred-fragment bookkeeping that the resolve path
+    // maintains is irrelevant here.
+    try SelectionWalker.walk(
       selections,
-      into: &projections,
-      cacheKey: cacheKey,
       variables: variables,
       resolveRuntimeType: resolveRuntimeType,
-      includeAllInlineFragments: includeAllInlineFragments,
-      schema: schema,
-      responsePath: responsePath
-    )
-    return projections
-  }
-
-  // MARK: - Selection walk
-
-  /// Mirrors the `Selection` case handling in
-  /// `DefaultFieldSelectionCollector.collectFields(...)` so the
-  /// upfront-projection path and the lazy-resolution path always agree
-  /// on which fields each Selection case contributes. Differences from
-  /// the default collector:
-  ///
-  /// - The output is a flat `Set<FieldProjection>` keyed by
-  ///   `(cacheKey, fieldName, columnShape, cardinality)`, not a
-  ///   `FieldSelectionGrouping` of `FieldExecutionInfo`. The collector
-  ///   doesn't need response-key grouping because cache rows are
-  ///   keyed by cache-field-key, not by response key, and the cache
-  ///   read doesn't need to know about fragment fulfillment state.
-  /// - There's no separate "fulfilled fragment" bookkeeping. The
-  ///   collector enters every fulfilled fragment and inline fragment
-  ///   to collect its inner fields; downstream callers don't need a
-  ///   fulfilled-set output because the projections themselves carry
-  ///   the necessary `(cacheKey, fieldName)` pairs.
-  /// - `.deferred` fragments are handled identically to the cache's
-  ///   existing executor behavior: the executor sets
-  ///   `shouldAttemptDeferredFragmentExecution = true` for
-  ///   `CacheDataExecutionSource`, so all deferred fragments are
-  ///   eagerly entered here (subject to the deferred condition).
-  ///   This keeps cache reads complete on a cold read; the executor
-  ///   ignores deferred-fragment incrementality on the cache path.
-  private static func walk(
-    _ selections: [Selection],
-    into projections: inout Set<FieldProjection>,
-    cacheKey: CacheKey,
-    variables: GraphQLOperation.Variables?,
-    resolveRuntimeType: () -> Object?,
-    includeAllInlineFragments: Bool,
-    schema: (any SchemaMetadata.Type)?,
-    responsePath: ResponsePath
-  ) throws {
-    for selection in selections {
-      switch selection {
-      case .field(let field):
-        // `Selection.Field.cacheReadStrategy` is the shared helper that
-        // also drives `CacheDataExecutionSource.resolveCacheKey` — both
-        // call sites compute the same strategy for the same
-        // `(field, variables, schema, responsePath)`. The projection's
-        // `fieldName` matches what the resolver will subscript on the
-        // loaded parent record.
-        //
-        // For `@fieldPolicy`-redirected fields (`.policyReference` /
-        // `.policyReferenceList`), the reader does NOT subscript the
-        // parent record — it produces `CacheReference`s directly from
-        // the field's arguments. No parent-record projection is needed
-        // for those cases; the next level of the read loads the
-        // policy-referenced records via their canonical keys.
-        let strategy = try field.cacheReadStrategy(
-          variables: variables,
-          schema: schema,
-          responsePath: responsePath
-        )
-        switch strategy {
-        case .parentRecordKey(let name):
-          projections.insert(FieldProjection(
-            cacheKey: cacheKey,
-            fieldName: name,
-            outputType: field.type
-          ))
-        case .policyReference, .policyReferenceList:
-          // No parent-record projection: the field's value is a direct
-          // `CacheReference` derived from the field's arguments.
-          break
-        }
-
-      case .conditional(let conditions, let nested):
-        if conditions.evaluate(with: variables) {
-          try walk(
-            nested,
-            into: &projections,
-            cacheKey: cacheKey,
-            variables: variables,
-            resolveRuntimeType: resolveRuntimeType,
-            includeAllInlineFragments: includeAllInlineFragments,
-            schema: schema,
-            responsePath: responsePath
-          )
-        }
-
-      case .fragment(let fragmentType):
-        try walk(
-          fragmentType.__selections,
+      inlineFragmentPolicy: includeAllInlineFragments ? .includeAll : .byRuntimeType,
+      deferredFragmentPolicy: .eager,
+      onField: { field in
+        try collectField(
+          field,
           into: &projections,
           cacheKey: cacheKey,
           variables: variables,
-          resolveRuntimeType: resolveRuntimeType,
-          includeAllInlineFragments: includeAllInlineFragments,
-          schema: schema,
-          responsePath: responsePath
-        )
-
-      case .inlineFragment(let typeCase):
-        let shouldEnter: Bool
-        if includeAllInlineFragments {
-          shouldEnter = true
-        } else if let runtimeType = resolveRuntimeType(),
-                  typeCase.__parentType.canBeConverted(from: runtimeType) {
-          shouldEnter = true
-        } else {
-          shouldEnter = false
-        }
-        if shouldEnter {
-          try walk(
-            typeCase.__selections,
-            into: &projections,
-            cacheKey: cacheKey,
-            variables: variables,
-            resolveRuntimeType: resolveRuntimeType,
-            includeAllInlineFragments: includeAllInlineFragments,
-            schema: schema,
-            responsePath: responsePath
-          )
-        }
-
-      case .deferred(_, let typeCase, _):
-        // The cache executor path treats deferred fragments as fully
-        // fulfilled regardless of the `@defer(if:)` condition: it
-        // has no incremental delivery channel to honor `@defer`, so
-        // `CacheDataExecutionSource` sets
-        // `shouldAttemptDeferredFragmentExecution = true` and
-        // `GraphQLExecutor` eagerly executes the deferred fragment's
-        // selections after the normal grouping pass. Mirror that
-        // behavior here so the collected projection set is complete
-        // for the level — every deferred fragment's fields are
-        // projected. The `if:` condition only controls *whether* the
-        // fragment is deferred (yes/no); under the cache path the
-        // fields are read in either branch.
-        try walk(
-          typeCase.__selections,
-          into: &projections,
-          cacheKey: cacheKey,
-          variables: variables,
-          resolveRuntimeType: resolveRuntimeType,
-          includeAllInlineFragments: includeAllInlineFragments,
           schema: schema,
           responsePath: responsePath
         )
       }
+    )
+    return projections
+  }
+
+  // MARK: - Per-field projection
+
+  /// Emits the projection(s) for one `.field` selection. For fields
+  /// resolved via `@fieldPolicy` (`.policyReference` /
+  /// `.policyReferenceList`), no parent-record projection is needed —
+  /// the reader returns a direct `CacheReference` and the next-level
+  /// read loads the policy-referenced record under its canonical key.
+  /// See `CacheDataExecutionSource.resolveCacheKey` for the matching
+  /// resolve-time switch.
+  private static func collectField(
+    _ field: Selection.Field,
+    into projections: inout Set<FieldProjection>,
+    cacheKey: CacheKey,
+    variables: GraphQLOperation.Variables?,
+    schema: (any SchemaMetadata.Type)?,
+    responsePath: ResponsePath
+  ) throws {
+    let strategy = try field.cacheReadStrategy(
+      variables: variables,
+      schema: schema,
+      responsePath: responsePath
+    )
+    switch strategy {
+    case .parentRecordKey(let name):
+      projections.insert(FieldProjection(
+        cacheKey: cacheKey,
+        fieldName: name,
+        outputType: field.type
+      ))
+    case .policyReference, .policyReferenceList:
+      // No parent-record projection: the field's value is a direct
+      // `CacheReference` derived from the field's arguments.
+      break
     }
   }
 

--- a/apollo-ios/Sources/Apollo/Execution/FieldSelectionCollector.swift
+++ b/apollo-ios/Sources/Apollo/Execution/FieldSelectionCollector.swift
@@ -102,65 +102,29 @@ public struct DefaultFieldSelectionCollector: FieldSelectionCollector {
     resolveRuntimeType: () -> Object?,
     info: ObjectExecutionInfo
   ) throws {
-    for selection in selections {
-      switch selection {
-      case let .field(field):
-        groupedFields.append(field: field, withInfo: info)
-
-      case let .conditional(conditions, conditionalSelections):
-        if conditions.evaluate(with: info.variables) {
-          try collectFields(from: conditionalSelections,
-                            into: &groupedFields,
-                            resolveRuntimeType: resolveRuntimeType,
-                            info: info)
-        }
-
-      case let .deferred(condition, typeCase, _):
-        // In Apollo's implementation (Router + Server) of deferSpec=20220824 ALL defer directives
-        // will be honoured and sent as separate incremental responses. This means deferred
-        // selection fields only need to be collected when they are parsed with the incremental
-        // data, at which time they are no longer deferred. The deferred fragment identifiers still
-        // need to be collected becuase that is how the user determines the state of the deferred
-        // fragment via the @Deferred property wrapper.
-        //
-        // If the defer condition evaluates to false though, the fragment is considered to be fulfilled
-        // and and the fields must be collected.
-        let isDeferred: Bool = {
-          if let condition, !condition.evaluate(with: info.variables) {
-            return false
-          }
-          return true
-        }()
-
-        if isDeferred {
-          groupedFields.addDeferredFragment(typeCase)
-
-        } else {
-          groupedFields.addFulfilledFragment(typeCase)
-          try collectFields(from: typeCase.__selections,
-                            into: &groupedFields,
-                            resolveRuntimeType: resolveRuntimeType,
-                            info: info)
-        }
-
-      case let .fragment(fragment):
-        groupedFields.addFulfilledFragment(fragment)
-        try collectFields(from: fragment.__selections,
-                          into: &groupedFields,
-                          resolveRuntimeType: resolveRuntimeType,
-                          info: info)
-
-      case let .inlineFragment(typeCase):
-        if let runtimeType = resolveRuntimeType(),
-           typeCase.__parentType.canBeConverted(from: runtimeType) {
-          groupedFields.addFulfilledFragment(typeCase)
-          try collectFields(from: typeCase.__selections,
-                            into: &groupedFields,
-                            resolveRuntimeType: resolveRuntimeType,
-                            info: info)
-        }
-      }
-    }
+    // Selection-case dispatch is delegated to `SelectionWalker` so this
+    // collector and `FieldProjectionCollector` share one walk
+    // implementation. Per the Apollo Router + Server's deferSpec=20220824
+    // implementation, every `@defer` is honored — deferred selection
+    // fields are only collected when parsed with the incremental
+    // response, at which point they're no longer deferred. The
+    // deferred-fragment identifiers still need recording so the
+    // `@Deferred` property wrapper can surface the fragment's state.
+    // When a `@defer(if:)` condition evaluates to `false`, the fragment
+    // is considered fulfilled rather than deferred and the walker
+    // recurses into its selections.
+    try SelectionWalker.walk(
+      selections,
+      variables: info.variables,
+      resolveRuntimeType: resolveRuntimeType,
+      inlineFragmentPolicy: .byRuntimeType,
+      deferredFragmentPolicy: .respectDeferCondition,
+      onField: { groupedFields.append(field: $0, withInfo: info) },
+      onFragmentEntered: { groupedFields.addFulfilledFragment($0) },
+      onInlineFragmentEntered: { groupedFields.addFulfilledFragment($0) },
+      onDeferredFragmentEntered: { groupedFields.addFulfilledFragment($0) },
+      onDeferredFragmentSkipped: { groupedFields.addDeferredFragment($0) }
+    )
   }
 }
 

--- a/apollo-ios/Sources/Apollo/Execution/SelectionWalker.swift
+++ b/apollo-ios/Sources/Apollo/Execution/SelectionWalker.swift
@@ -1,0 +1,219 @@
+@_spi(Execution) import ApolloAPI
+
+/// Shared dispatch over a `[Selection]` tree, parameterized by per-case
+/// policies. Both `DefaultFieldSelectionCollector` (the resolve path)
+/// and `FieldProjectionCollector` (the projection path) traverse the
+/// same `Selection` shape with the same conditional/fragment/inline-
+/// fragment/deferred branches — they differ only in:
+///
+/// 1. What they do per `.field` (append to a grouping vs emit a
+///    `FieldProjection`).
+/// 2. Whether `.inlineFragment` requires runtime-type matching
+///    (`byRuntimeType`) or enters unconditionally (`includeAll`, the
+///    cache projection's over-fetch strategy — the executor's later
+///    selection-set traversal still uses the loaded `__typename` to
+///    pick the matching type case).
+/// 3. Whether `.deferred` honors its `@defer(if:)` condition
+///    (`respectDeferCondition`, the normal resolve path) or always
+///    enters (`eager`, the cache path where there's no incremental
+///    delivery to honor).
+///
+/// `SelectionWalker.walk(_:)` collapses the dispatch into one place;
+/// callers supply policies and per-event closures. Tracking side
+/// effects (fulfilled/deferred fragment sets, projection accumulators)
+/// happen inside the caller-supplied closures, which capture whatever
+/// state the caller needs.
+///
+/// All closure parameters are non-escaping so callers can mutate
+/// `inout` accumulators from within them; pass `{ _ in }` for entry
+/// events the caller doesn't need to observe.
+///
+/// # See Also
+///
+/// - [ADR 0007 — Selection-set-aware cache reads](../../../Design/adr/0007-selection-aware-cache-reads.md)
+///   PR-009d-iv (this extraction); lands before PR-009f so the
+///   dependency tracker's invalidation walk can use the unified helper.
+enum SelectionWalker {
+
+  /// Gating policy for `.inlineFragment` cases.
+  enum InlineFragmentPolicy {
+    /// Enter the inline fragment only when the receiving object's
+    /// runtime type can be converted to the fragment's parent type.
+    /// `resolveRuntimeType()` is called lazily once an inline fragment
+    /// is encountered; if it returns `nil`, the fragment is skipped.
+    case byRuntimeType
+
+    /// Enter every inline fragment unconditionally. Used by the cache
+    /// projection path when the receiving object's `__typename` is not
+    /// yet loaded: every type case's fields are projected. The
+    /// executor's later, type-aware traversal still picks the matching
+    /// type case from the loaded data.
+    case includeAll
+  }
+
+  /// Gating policy for `.deferred` cases.
+  enum DeferredFragmentPolicy {
+    /// Honor the `@defer(if:)` condition. When the condition is `nil`
+    /// (no `if:`) or evaluates to `true`, the fragment is *deferred*:
+    /// the walker calls `onDeferredFragmentSkipped` and does not
+    /// recurse into the fragment's selections. When it evaluates to
+    /// `false`, the fragment is treated as fulfilled:
+    /// `onDeferredFragmentEntered` is called and the walker recurses.
+    case respectDeferCondition
+
+    /// Treat every deferred fragment as if `@defer` did not apply —
+    /// always call `onDeferredFragmentEntered` and recurse. Used by
+    /// the cache path: `CacheDataExecutionSource` sets
+    /// `shouldAttemptDeferredFragmentExecution = true`, so reads
+    /// surface every deferred fragment eagerly.
+    case eager
+  }
+
+  /// Walks `selections` and dispatches each case. Recursion is
+  /// internal; callers are not expected to call `walk` again from
+  /// their closures.
+  ///
+  /// - Parameters:
+  ///   - selections: The selection tree to walk at this level.
+  ///   - variables: Operation variables. Used to evaluate
+  ///     `.conditional`'s `@include`/`@skip` and `.deferred`'s
+  ///     `@defer(if:)` conditions.
+  ///   - resolveRuntimeType: Lazily resolves the receiving object's
+  ///     runtime `Object` type, used by `.byRuntimeType` to gate
+  ///     `.inlineFragment` entry. Not called under `.includeAll`.
+  ///   - inlineFragmentPolicy: See ``InlineFragmentPolicy``.
+  ///   - deferredFragmentPolicy: See ``DeferredFragmentPolicy``.
+  ///   - onField: Called once per `.field` selection reached.
+  ///   - onFragmentEntered: Called immediately before recursing into
+  ///     a named `.fragment`'s selections. Pass `{ _ in }` if the
+  ///     dispatch is fragment-tracking-agnostic.
+  ///   - onInlineFragmentEntered: Called immediately before recursing
+  ///     into an `.inlineFragment`'s selections — only after the
+  ///     policy gate has approved entry.
+  ///   - onDeferredFragmentEntered: Called immediately before
+  ///     recursing into a `.deferred` fragment's selections — only
+  ///     when the policy decides to enter (always under `.eager`, or
+  ///     when the condition evaluates to `false` under
+  ///     `.respectDeferCondition`).
+  ///   - onDeferredFragmentSkipped: Called when a `.deferred` fragment
+  ///     is encountered but recursion is skipped because the policy
+  ///     treats it as still-deferred. Only fires under
+  ///     `.respectDeferCondition` when the condition holds.
+  static func walk(
+    _ selections: [Selection],
+    variables: GraphQLOperation.Variables?,
+    resolveRuntimeType: () -> Object?,
+    inlineFragmentPolicy: InlineFragmentPolicy,
+    deferredFragmentPolicy: DeferredFragmentPolicy,
+    onField: (Selection.Field) throws -> Void,
+    onFragmentEntered: (any Fragment.Type) throws -> Void = { _ in },
+    onInlineFragmentEntered: (any InlineFragment.Type) throws -> Void = { _ in },
+    onDeferredFragmentEntered: (any Deferrable.Type) throws -> Void = { _ in },
+    onDeferredFragmentSkipped: (any Deferrable.Type) throws -> Void = { _ in }
+  ) throws {
+    for selection in selections {
+      switch selection {
+      case let .field(field):
+        try onField(field)
+
+      case let .conditional(conditions, nested):
+        if conditions.evaluate(with: variables) {
+          try walk(
+            nested,
+            variables: variables,
+            resolveRuntimeType: resolveRuntimeType,
+            inlineFragmentPolicy: inlineFragmentPolicy,
+            deferredFragmentPolicy: deferredFragmentPolicy,
+            onField: onField,
+            onFragmentEntered: onFragmentEntered,
+            onInlineFragmentEntered: onInlineFragmentEntered,
+            onDeferredFragmentEntered: onDeferredFragmentEntered,
+            onDeferredFragmentSkipped: onDeferredFragmentSkipped
+          )
+        }
+
+      case let .fragment(fragment):
+        try onFragmentEntered(fragment)
+        try walk(
+          fragment.__selections,
+          variables: variables,
+          resolveRuntimeType: resolveRuntimeType,
+          inlineFragmentPolicy: inlineFragmentPolicy,
+          deferredFragmentPolicy: deferredFragmentPolicy,
+          onField: onField,
+          onFragmentEntered: onFragmentEntered,
+          onInlineFragmentEntered: onInlineFragmentEntered,
+          onDeferredFragmentEntered: onDeferredFragmentEntered,
+          onDeferredFragmentSkipped: onDeferredFragmentSkipped
+        )
+
+      case let .inlineFragment(typeCase):
+        let shouldEnter: Bool
+        switch inlineFragmentPolicy {
+        case .includeAll:
+          shouldEnter = true
+        case .byRuntimeType:
+          if let runtimeType = resolveRuntimeType(),
+             typeCase.__parentType.canBeConverted(from: runtimeType) {
+            shouldEnter = true
+          } else {
+            shouldEnter = false
+          }
+        }
+        if shouldEnter {
+          try onInlineFragmentEntered(typeCase)
+          try walk(
+            typeCase.__selections,
+            variables: variables,
+            resolveRuntimeType: resolveRuntimeType,
+            inlineFragmentPolicy: inlineFragmentPolicy,
+            deferredFragmentPolicy: deferredFragmentPolicy,
+            onField: onField,
+            onFragmentEntered: onFragmentEntered,
+            onInlineFragmentEntered: onInlineFragmentEntered,
+            onDeferredFragmentEntered: onDeferredFragmentEntered,
+            onDeferredFragmentSkipped: onDeferredFragmentSkipped
+          )
+        }
+
+      case let .deferred(condition, typeCase, _):
+        let shouldEnter: Bool
+        switch deferredFragmentPolicy {
+        case .eager:
+          shouldEnter = true
+        case .respectDeferCondition:
+          // The Apollo Router + Server implementation of deferSpec
+          // 20220824 honors every `@defer`. When the condition is
+          // present and evaluates to `false`, the fragment is
+          // considered fulfilled rather than deferred — the walker
+          // enters it. When the condition is absent or evaluates
+          // to `true`, the fragment stays deferred and the walker
+          // skips recursion (the caller can still record it as
+          // deferred via `onDeferredFragmentSkipped`).
+          if let condition, !condition.evaluate(with: variables) {
+            shouldEnter = true
+          } else {
+            shouldEnter = false
+          }
+        }
+        if shouldEnter {
+          try onDeferredFragmentEntered(typeCase)
+          try walk(
+            typeCase.__selections,
+            variables: variables,
+            resolveRuntimeType: resolveRuntimeType,
+            inlineFragmentPolicy: inlineFragmentPolicy,
+            deferredFragmentPolicy: deferredFragmentPolicy,
+            onField: onField,
+            onFragmentEntered: onFragmentEntered,
+            onInlineFragmentEntered: onInlineFragmentEntered,
+            onDeferredFragmentEntered: onDeferredFragmentEntered,
+            onDeferredFragmentSkipped: onDeferredFragmentSkipped
+          )
+        } else {
+          try onDeferredFragmentSkipped(typeCase)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PR-009d-iv in the ADR 0007 implementation sequence. Pure refactor: deduplicates the `Selection`-case dispatch logic shared between [`DefaultFieldSelectionCollector`](apollo-ios/Sources/Apollo/Execution/FieldSelectionCollector.swift) (resolve path) and [`FieldProjectionCollector`](apollo-ios/Sources/Apollo/Execution/FieldProjectionCollector.swift) (projection path) into a single new [`SelectionWalker`](apollo-ios/Sources/Apollo/Execution/SelectionWalker.swift). No behavior change, no public API change.

## What's new

`SelectionWalker` exposes one `walk(_:)` entry point parameterized by:

- **`InlineFragmentPolicy`** — `.byRuntimeType` (resolve path) or `.includeAll` (cache projection's over-fetch strategy when `__typename` isn't loaded yet).
- **`DeferredFragmentPolicy`** — `.respectDeferCondition` (honors `@defer(if:)` per Apollo Router + Server's deferSpec=20220824) or `.eager` (cache path, no incremental delivery).
- **Non-escaping closures** for per-case events: `onField`, `onFragmentEntered`, `onInlineFragmentEntered`, `onDeferredFragmentEntered`, `onDeferredFragmentSkipped`. All have no-op defaults so callers override only what they need. Non-escaping lets callers capture `inout` accumulators directly.

## How the callers map

| | `DefaultFieldSelectionCollector` | `FieldProjectionCollector` |
|---|---|---|
| `inlineFragmentPolicy` | `.byRuntimeType` | `includeAllInlineFragments ? .includeAll : .byRuntimeType` |
| `deferredFragmentPolicy` | `.respectDeferCondition` | `.eager` |
| `onField` | `groupedFields.append(field:withInfo:)` | switch `cacheReadStrategy`, emit `FieldProjection` for `.parentRecordKey` only |
| `onFragmentEntered` / `onInlineFragmentEntered` / `onDeferredFragmentEntered` | `groupedFields.addFulfilledFragment(_:)` | (no-op) |
| `onDeferredFragmentSkipped` | `groupedFields.addDeferredFragment(_:)` | (no-op) |

Two callers, one walk implementation.

## Why now

PR-009f (GraphQLDependencyTracker consumes field projections) needs a selection-set walk to compute the dirty set on writes. Pre-extracting `SelectionWalker` means the dependency tracker can reuse the same dispatch with its own policy mix instead of becoming a third copy of the same `switch`.

## Diff size

3 files changed, +303 / -201. New file is mostly doc comments + the single dispatch loop.

## Tests

- Full \`Apollo-UnitTestPlan\`: 1116 passed, 0 failed, 11 not-run (pre-existing environment-dependent tests, same status as \`main\`).
- FieldPolicyTests (21), ReadWriteFromStoreTests, LoadFieldsTests, watcher/cache-dependent suites, deferred-fragment tests — all green.
- The policy enums fully exercise both the resolve and projection paths' behaviors.

## Stack position

\`\`\`
phase-1-plan
└── phase-1a-row-per-field-crud (PR #1001)
    └── phase-1a-field-projection (PR #1008, PR-009b)
        └── phase-1a-cache-load-fields (PR #1009, PR-009c)
            └── phase-1a-executor-upfront-projection (PR #1012, PR-009d-i)
                └── phase-1a-executor-upfront-projection-ii (PR-009d-ii)
                    └── phase-1a-cache-field-key-memo (PR #1016, PR-009d-iii)
                        └── phase-1a-selection-walker (PR-009d-iv ← this PR)
\`\`\`

## Test plan

- [x] Builds clean.
- [x] Full Apollo-UnitTestPlan: 1116/1116 enabled tests pass.
- [x] No behavior change — the policy enums cover every prior branch identically.
- [ ] Reviewer to verify the walker's recursion still respects every prior case's recursion behavior.
- [ ] Reviewer to verify the closure non-escaping contract works for both `inout` accumulators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)