### PR TITLE
refactor(cache): code-review follow-ups (PR-009e-bis)

### DIFF
--- a/Tests/ApolloTests/Cache/FieldPolicyTests.swift
+++ b/Tests/ApolloTests/Cache/FieldPolicyTests.swift
@@ -1559,6 +1559,245 @@ final class FieldPolicyTests: XCTestCase, CacheDependentTesting, @unchecked Send
     XCTAssertEqual(data.hero?.name, "Luke")
   }
 
+  /// Variant of the round-trip test where the cache was populated by a
+  /// *different* mechanism (e.g., a sibling query that wrote the
+  /// canonical record via `@typePolicy`) and the QUERY_ROOT entry under
+  /// the field's normalized name does NOT exist. This exercises the
+  /// `loadObject` empty-projection short-circuit: the executor must
+  /// resolve the `@fieldPolicy` redirect into a direct `CacheReference`
+  /// without requiring the parent record to be present.
+  ///
+  /// Matches Apollo Kotlin's `FieldPolicyCacheResolver` semantic: a
+  /// policy-resolved field does not require the parent record to exist.
+  func test_fieldPolicy_givenEmptyParentRecordButPolicyTargetExists_resolvesViaDirectReference() async throws {
+    class HeroSelectionSet: AbstractMockSelectionSet<NoFragments, FieldPolicySchemaMetadata>, @unchecked Sendable {
+      override class var __selections: [Selection] { [
+        .field("hero", Hero.self, arguments: ["name": .variable("name")], fieldPolicy: .init(keyArgs: ["name"]))
+      ]}
+
+      class Hero: AbstractMockSelectionSet<NoFragments, FieldPolicySchemaMetadata>, @unchecked Sendable {
+        override class var __parentType: any ParentType {
+          Object(typename: "Hero", implementedInterfaces: [], keyFields: ["name"])
+        }
+        override class var __selections: [Selection] { [
+          .field("__typename", String.self),
+          .field("name", String.self),
+        ]}
+      }
+    }
+
+    await FieldPolicySchemaMetadata.stub_objectTypeForTypeName { typename in
+      typename == "Hero"
+        ? Object(typename: "Hero", implementedInterfaces: [], keyFields: ["name"])
+        : nil
+    }
+
+    // Stage only the canonical Hero record. QUERY_ROOT does NOT exist —
+    // simulating a cross-query cache hit where some other code path
+    // populated "Hero:Luke" but this query has never been fetched.
+    try await store.publish(records: [
+      "Hero:Luke": [
+        "__typename": "Hero",
+        "name": "Luke",
+      ]
+    ])
+
+    let query = MockQuery<HeroSelectionSet>()
+    query.__variables = ["name": "Luke"]
+
+    let cacheResult = try await client.fetch(query: query, cachePolicy: .cacheOnly)
+
+    XCTAssertEqual(cacheResult?.source, .cache)
+    XCTAssertNil(cacheResult?.errors)
+    let data = try XCTUnwrap(cacheResult?.data, "Cache read must succeed via the @fieldPolicy redirect even though QUERY_ROOT has no entry for the field")
+    XCTAssertEqual(data.hero?.name, "Luke")
+  }
+
+  /// `@fieldPolicy` with a programmatic `FieldPolicy.Provider` (vs the
+  /// directive). Round-trips network → cache via the same provider that
+  /// drives the read.
+  func test_fieldPolicyProvider_withMatchingTypePolicy_networkFetchPopulatesCache_andCacheReadResolves() async throws {
+    class HeroSelectionSet: AbstractMockSelectionSet<NoFragments, FieldPolicySchemaMetadata>, @unchecked Sendable {
+      override class var __selections: [Selection] { [
+        .field("hero", Hero.self, arguments: ["name": .variable("name")])
+      ]}
+
+      class Hero: AbstractMockSelectionSet<NoFragments, FieldPolicySchemaMetadata>, @unchecked Sendable {
+        override class var __parentType: any ParentType {
+          Object(typename: "Hero", implementedInterfaces: [], keyFields: ["name"])
+        }
+        override class var __selections: [Selection] { [
+          .field("__typename", String.self),
+          .field("name", String.self),
+        ]}
+      }
+    }
+
+    await FieldPolicySchemaMetadata.stub_objectTypeForTypeName { typename in
+      typename == "Hero"
+        ? Object(typename: "Hero", implementedInterfaces: [], keyFields: ["name"])
+        : nil
+    }
+    await FieldPolicySchemaMetadata.stub_cacheKeyForField_SingleReturn { _, inputData, _ in
+      guard let name = inputData["name"] as? String else { return nil }
+      return CacheKeyInfo(id: name)
+    }
+
+    let query = MockQuery<HeroSelectionSet>()
+    query.__variables = ["name": "Luke"]
+
+    let serverExpectation = await server.expect(MockQuery<HeroSelectionSet>.self) { _ in
+      [
+        "data": [
+          "hero": [
+            "__typename": "Hero",
+            "name": "Luke",
+          ]
+        ]
+      ]
+    }
+
+    let networkResult = try await client.fetch(query: query, cachePolicy: .networkOnly)
+    XCTAssertEqual(networkResult.data?.hero?.name, "Luke")
+    await fulfillment(of: [serverExpectation], timeout: Self.defaultWaitTimeout)
+
+    let cacheResult = try await client.fetch(query: query, cachePolicy: .cacheOnly)
+    XCTAssertEqual(cacheResult?.source, .cache)
+    let data = try XCTUnwrap(cacheResult?.data)
+    XCTAssertEqual(data.hero?.name, "Luke")
+  }
+
+  /// `@fieldPolicy` with a `uniqueKeyGroup` (vs the default typename
+  /// formatter). The CacheKeyInfo's `uniqueKeyGroup` produces a key
+  /// shape of `"\(uniqueKeyGroup):\(id)"` rather than `"\(typename):\(id)"`,
+  /// and the matching `@typePolicy` must produce the same key.
+  func test_fieldPolicyProvider_withUniqueKeyGroup_andMatchingTypePolicy_roundTrips() async throws {
+    class HeroSelectionSet: AbstractMockSelectionSet<NoFragments, FieldPolicySchemaMetadata>, @unchecked Sendable {
+      override class var __selections: [Selection] { [
+        .field("hero", Hero.self, arguments: ["name": .variable("name")])
+      ]}
+
+      class Hero: AbstractMockSelectionSet<NoFragments, FieldPolicySchemaMetadata>, @unchecked Sendable {
+        override class var __parentType: any ParentType {
+          Object(typename: "Hero", implementedInterfaces: [])
+        }
+        override class var __selections: [Selection] { [
+          .field("__typename", String.self),
+          .field("name", String.self),
+        ]}
+      }
+    }
+
+    await FieldPolicySchemaMetadata.stub_objectTypeForTypeName { _ in
+      Object(typename: "Hero", implementedInterfaces: [])
+    }
+    // The configuration's cacheKeyInfo(for:object:) acts as the
+    // @typePolicy substitute: writes resolve "Hero" data via this hook,
+    // producing "Character:Luke" (uniqueKeyGroup overrides typename).
+    await FieldPolicySchemaMetadata.stub_cacheKeyInfoForType_Object { _, object in
+      guard let name = object["name"] as? String else { return nil }
+      return CacheKeyInfo(id: name, uniqueKeyGroup: "Character")
+    }
+    // FieldPolicy.Provider must produce the same uniqueKeyGroup so reads
+    // match writes.
+    await FieldPolicySchemaMetadata.stub_cacheKeyForField_SingleReturn { _, inputData, _ in
+      guard let name = inputData["name"] as? String else { return nil }
+      return CacheKeyInfo(id: name, uniqueKeyGroup: "Character")
+    }
+
+    let query = MockQuery<HeroSelectionSet>()
+    query.__variables = ["name": "Luke"]
+
+    let serverExpectation = await server.expect(MockQuery<HeroSelectionSet>.self) { _ in
+      [
+        "data": [
+          "hero": [
+            "__typename": "Hero",
+            "name": "Luke",
+          ]
+        ]
+      ]
+    }
+
+    let networkResult = try await client.fetch(query: query, cachePolicy: .networkOnly)
+    XCTAssertEqual(networkResult.data?.hero?.name, "Luke")
+    await fulfillment(of: [serverExpectation], timeout: Self.defaultWaitTimeout)
+
+    // Verify the writer keyed the canonical record under "Character:Luke",
+    // not "Hero:Luke" — uniqueKeyGroup overrides typename.
+    try await store.withinReadTransaction { transaction in
+      let records = try await transaction.readOnlyCache.loadRecords(
+        forKeys: ["Character:Luke", "Hero:Luke"]
+      )
+      XCTAssertNotNil(records["Character:Luke"], "Writer keyed the record under uniqueKeyGroup, not typename")
+      XCTAssertNil(records["Hero:Luke"], "No fallback typename key when uniqueKeyGroup overrides")
+    }
+
+    let cacheResult = try await client.fetch(query: query, cachePolicy: .cacheOnly)
+    let data = try XCTUnwrap(cacheResult?.data)
+    XCTAssertEqual(data.hero?.name, "Luke")
+  }
+
+  /// List-typed `@fieldPolicy` (`.policyReferenceList`) round-trip. Each
+  /// list element resolves to its own policy-derived `CacheReference`;
+  /// the matching `@typePolicy` keys each element under the same canonical
+  /// key.
+  func test_fieldPolicyProvider_listReturn_withMatchingTypePolicy_roundTrips() async throws {
+    class HeroesSelectionSet: AbstractMockSelectionSet<NoFragments, FieldPolicySchemaMetadata>, @unchecked Sendable {
+      override class var __selections: [Selection] { [
+        .field("heroes", [Hero].self, arguments: ["names": .variable("names")])
+      ]}
+      var heroes: [Hero] { __data["heroes"] }
+
+      class Hero: AbstractMockSelectionSet<NoFragments, FieldPolicySchemaMetadata>, @unchecked Sendable {
+        override class var __parentType: any ParentType {
+          Object(typename: "Hero", implementedInterfaces: [], keyFields: ["name"])
+        }
+        override class var __selections: [Selection] { [
+          .field("__typename", String.self),
+          .field("name", String.self),
+        ]}
+      }
+    }
+
+    await FieldPolicySchemaMetadata.stub_objectTypeForTypeName { typename in
+      typename == "Hero"
+        ? Object(typename: "Hero", implementedInterfaces: [], keyFields: ["name"])
+        : nil
+    }
+    await FieldPolicySchemaMetadata.stub_cacheKeyForField_ListReturn { _, inputData, _ in
+      guard let names = inputData["names"] as? [String] else { return nil }
+      return names.map { CacheKeyInfo(id: $0) }
+    }
+
+    let query = MockQuery<HeroesSelectionSet>()
+    query.__variables = ["names": ["Anakin", "Obi-Wan"]]
+
+    let serverExpectation = await server.expect(MockQuery<HeroesSelectionSet>.self) { _ in
+      [
+        "data": [
+          "heroes": [
+            ["__typename": "Hero", "name": "Anakin"],
+            ["__typename": "Hero", "name": "Obi-Wan"],
+          ]
+        ]
+      ]
+    }
+
+    let networkResult = try await client.fetch(query: query, cachePolicy: .networkOnly)
+    XCTAssertEqual(networkResult.data?.heroes.count, 2)
+    XCTAssertEqual(networkResult.data?.heroes[0].name, "Anakin")
+    XCTAssertEqual(networkResult.data?.heroes[1].name, "Obi-Wan")
+    await fulfillment(of: [serverExpectation], timeout: Self.defaultWaitTimeout)
+
+    let cacheResult = try await client.fetch(query: query, cachePolicy: .cacheOnly)
+    XCTAssertEqual(cacheResult?.source, .cache)
+    let data = try XCTUnwrap(cacheResult?.data)
+    XCTAssertEqual(data.heroes.count, 2)
+    XCTAssertEqual(data.heroes[0].name, "Anakin")
+    XCTAssertEqual(data.heroes[1].name, "Obi-Wan")
+  }
+
 }
 
 class FieldPolicySchemaMetadata: SchemaMetadata {

--- a/Tests/ApolloTests/Cache/FieldProjectionTests.swift
+++ b/Tests/ApolloTests/Cache/FieldProjectionTests.swift
@@ -186,6 +186,28 @@ final class FieldProjectionTests: XCTestCase {
     expect(FieldProjection.columnShape(of: outputType)) == .childKey
   }
 
+  func test__columnShape__givenAsymmetricNestedList_nullableOuterNonNullInner__returnsChildKey() {
+    // `[[Int!]]` — GraphQL allows the outer list to be nullable while
+    // the inner list (and its elements) remain non-null. Codegen
+    // typically emits the fully-non-null wrapping, but the underlying
+    // type system permits this asymmetric shape. The nested-list rule
+    // (depth ≥ 2 → `.childKey`) must hold regardless of which wrapper
+    // layers are `.nonNull`-wrapped.
+    let outputType: Selection.Field.OutputType =
+      .list(.nonNull(.list(.nonNull(.scalar(Int.self)))))
+    expect(FieldProjection.columnShape(of: outputType)) == .childKey
+    expect(FieldProjection.cardinality(of: outputType)) == .list
+  }
+
+  func test__columnShape__givenAsymmetricNestedList_nonNullOuterNullableInner__returnsChildKey() {
+    // `[[Int]!]` — outer list non-null, inner list nullable. Mirror
+    // of the above case, asserting the rule is direction-agnostic.
+    let outputType: Selection.Field.OutputType =
+      .nonNull(.list(.list(.scalar(Int.self))))
+    expect(FieldProjection.columnShape(of: outputType)) == .childKey
+    expect(FieldProjection.cardinality(of: outputType)) == .list
+  }
+
   func test__columnShape__givenSingleListOfScalars__doesNotApplyNestingRule() {
     // `[Int]` — one `.list` wrapper. Inner-typed column applies.
     let outputType: Selection.Field.OutputType =

--- a/Tests/ApolloTests/Execution/FieldProjectionCollectorTests.swift
+++ b/Tests/ApolloTests/Execution/FieldProjectionCollectorTests.swift
@@ -163,6 +163,10 @@ final class FieldProjectionCollectorTests: XCTestCase {
 
   func test__collect__givenConditionalSkipTrue__skipsConditional() throws {
     let selections: [Selection] = [
+      // Unconditional sibling that MUST survive — guards against the
+      // (otherwise-tautological) "empty input produces empty output"
+      // case the test would silently degenerate into without it.
+      .field("__typename", String.self),
       .include(if: !"skipAge", .field("age", Int.self)),
     ]
 
@@ -173,7 +177,11 @@ final class FieldProjectionCollectorTests: XCTestCase {
       resolveRuntimeType: { nil }
     )
 
-    expect(projections.isEmpty) == true
+    expect(projections.contains(where: { $0.fieldName == "age" })) == false
+    // The unconditional sibling proves the walk ran and produced output
+    // — the conditional's `age` field was specifically dropped, not
+    // accidentally short-circuited along with everything else.
+    expect(projections.contains(where: { $0.fieldName == "__typename" })) == true
   }
 
   // MARK: - Fragment selections

--- a/Tests/ApolloTests/Execution/SelectionWalkerTests.swift
+++ b/Tests/ApolloTests/Execution/SelectionWalkerTests.swift
@@ -1,0 +1,368 @@
+@testable @_spi(Execution) import Apollo
+@_spi(Execution) @_spi(Unsafe) @_spi(Internal) import ApolloAPI
+@_spi(Execution) @_spi(Unsafe) import ApolloInternalTestHelpers
+import Foundation
+import Nimble
+import XCTest
+
+/// Tests for `SelectionWalker.walk(_:)` — focuses on the policy switches
+/// that distinguish the resolve path (`.byRuntimeType` /
+/// `.respectDeferCondition`) from the projection path (`.includeAll` /
+/// `.eager`). The walker is the shared dispatch surface for both
+/// `DefaultFieldSelectionCollector` and `FieldProjectionCollector`
+/// (extracted in PR-009d-iv); these tests cover behaviors the two
+/// collectors share at the policy layer rather than at their own
+/// case-handling layer.
+final class SelectionWalkerTests: XCTestCase {
+
+  // MARK: - Test scaffold
+
+  /// Captures the events the walker emits, keyed by event type. Tests
+  /// inspect this to verify dispatch + ordering.
+  private struct EventLog {
+    var fields: [String] = []
+    var fragmentsEntered: [String] = []
+    var inlineFragmentsEntered: [String] = []
+    var deferredEntered: [String] = []
+    var deferredSkipped: [String] = []
+  }
+
+  private func runWalker(
+    selections: [Selection],
+    variables: GraphQLOperation.Variables? = nil,
+    runtimeType: Object? = nil,
+    inlineFragmentPolicy: SelectionWalker.InlineFragmentPolicy = .byRuntimeType,
+    deferredFragmentPolicy: SelectionWalker.DeferredFragmentPolicy = .respectDeferCondition
+  ) throws -> EventLog {
+    var log = EventLog()
+    try SelectionWalker.walk(
+      selections,
+      variables: variables,
+      resolveRuntimeType: { runtimeType },
+      inlineFragmentPolicy: inlineFragmentPolicy,
+      deferredFragmentPolicy: deferredFragmentPolicy,
+      onField: { field in log.fields.append(field.name) },
+      onFragmentEntered: { type in log.fragmentsEntered.append(String(describing: type)) },
+      onInlineFragmentEntered: { type in log.inlineFragmentsEntered.append(String(describing: type)) },
+      onDeferredFragmentEntered: { type in log.deferredEntered.append(String(describing: type)) },
+      onDeferredFragmentSkipped: { type in log.deferredSkipped.append(String(describing: type)) }
+    )
+    return log
+  }
+
+  // MARK: - DeferredFragmentPolicy.respectDeferCondition
+
+  /// Closes the review-flagged gap: `FieldProjectionCollectorTests`'
+  /// deferred tests all use the `.eager` policy and therefore can't
+  /// verify the `@defer(if:)` condition is actually evaluated. This
+  /// test uses `.respectDeferCondition` and confirms the condition
+  /// branch is wired: when the condition evaluates to `false`, the
+  /// walker *enters* the fragment (treating it as fulfilled, not
+  /// deferred).
+  func test__walk__withRespectDeferCondition__whenIfConditionEvaluatesFalse__entersFragment() throws {
+    class GivenDeferred: MockTypeCase, @unchecked Sendable {
+      override class var __selections: [Selection] { [
+        .field("nickname", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .field("__typename", String.self),
+      .deferred(if: "doDefer", GivenDeferred.self, label: "given"),
+    ]
+
+    // Condition false → fragment is NOT deferred → walker enters it.
+    let log = try runWalker(
+      selections: selections,
+      variables: ["doDefer": false],
+      deferredFragmentPolicy: .respectDeferCondition
+    )
+
+    expect(log.fields).to(contain(["__typename", "nickname"]))
+    expect(log.deferredEntered).to(haveCount(1))
+    expect(log.deferredSkipped).to(beEmpty())
+  }
+
+  /// Mirror: condition `true` → fragment stays deferred → walker calls
+  /// `onDeferredFragmentSkipped` and does NOT recurse into the
+  /// fragment's selections. Together with the previous test, this
+  /// proves the `if:` evaluation actually drives the branch.
+  func test__walk__withRespectDeferCondition__whenIfConditionEvaluatesTrue__skipsFragment() throws {
+    class GivenDeferred: MockTypeCase, @unchecked Sendable {
+      override class var __selections: [Selection] { [
+        .field("nickname", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .field("__typename", String.self),
+      .deferred(if: "doDefer", GivenDeferred.self, label: "given"),
+    ]
+
+    let log = try runWalker(
+      selections: selections,
+      variables: ["doDefer": true],
+      deferredFragmentPolicy: .respectDeferCondition
+    )
+
+    expect(log.fields) == ["__typename"]
+    expect(log.deferredEntered).to(beEmpty())
+    expect(log.deferredSkipped).to(haveCount(1))
+  }
+
+  /// When no `if:` condition is present, `.respectDeferCondition`
+  /// treats the fragment as deferred (the default semantic).
+  func test__walk__withRespectDeferCondition__whenNoIfCondition__skipsFragment() throws {
+    class GivenDeferred: MockTypeCase, @unchecked Sendable {
+      override class var __selections: [Selection] { [
+        .field("nickname", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .deferred(GivenDeferred.self, label: "given"),
+    ]
+
+    let log = try runWalker(
+      selections: selections,
+      deferredFragmentPolicy: .respectDeferCondition
+    )
+
+    expect(log.deferredEntered).to(beEmpty())
+    expect(log.deferredSkipped).to(haveCount(1))
+    expect(log.fields).to(beEmpty())
+  }
+
+  // MARK: - DeferredFragmentPolicy.eager
+
+  /// `.eager` ignores `@defer(if:)` entirely — every deferred fragment's
+  /// selections are walked. Confirms the cache path's projection
+  /// behavior at the policy layer (vs. the indirect tests in
+  /// `FieldProjectionCollectorTests`).
+  func test__walk__withEagerDeferredPolicy__entersEveryDeferredFragment_regardlessOfCondition() throws {
+    class GivenDeferred: MockTypeCase, @unchecked Sendable {
+      override class var __selections: [Selection] { [
+        .field("nickname", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .deferred(if: "doDefer", GivenDeferred.self, label: "given"),
+    ]
+
+    // Condition true under `.eager` still enters — the eager policy
+    // disregards the condition altogether.
+    let log = try runWalker(
+      selections: selections,
+      variables: ["doDefer": true],
+      deferredFragmentPolicy: .eager
+    )
+
+    expect(log.fields) == ["nickname"]
+    expect(log.deferredEntered).to(haveCount(1))
+    expect(log.deferredSkipped).to(beEmpty())
+  }
+
+  // MARK: - InlineFragmentPolicy.byRuntimeType
+
+  /// Inline fragment whose parent type matches the runtime type → entered.
+  /// `canBeConverted(from:)` returns true for identical Objects.
+  func test__walk__withByRuntimeType__whenRuntimeTypeMatches__entersInlineFragment() throws {
+    let droidType = Object(typename: "Droid", implementedInterfaces: [])
+
+    class AsDroid: MockTypeCase, @unchecked Sendable {
+      override class var __parentType: any ParentType {
+        Object(typename: "Droid", implementedInterfaces: [])
+      }
+      override class var __selections: [Selection] { [
+        .field("primaryFunction", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .inlineFragment(AsDroid.self),
+    ]
+
+    let log = try runWalker(
+      selections: selections,
+      runtimeType: droidType,
+      inlineFragmentPolicy: .byRuntimeType
+    )
+
+    expect(log.fields) == ["primaryFunction"]
+    expect(log.inlineFragmentsEntered).to(haveCount(1))
+  }
+
+  /// Inline fragment whose parent type does NOT match the runtime type
+  /// → skipped. The fragment's selections must not be walked.
+  func test__walk__withByRuntimeType__whenRuntimeTypeMismatches__skipsInlineFragment() throws {
+    let humanType = Object(typename: "Human", implementedInterfaces: [])
+
+    class AsDroid: MockTypeCase, @unchecked Sendable {
+      override class var __parentType: any ParentType {
+        Object(typename: "Droid", implementedInterfaces: [])
+      }
+      override class var __selections: [Selection] { [
+        .field("primaryFunction", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .inlineFragment(AsDroid.self),
+    ]
+
+    let log = try runWalker(
+      selections: selections,
+      runtimeType: humanType,
+      inlineFragmentPolicy: .byRuntimeType
+    )
+
+    expect(log.fields).to(beEmpty())
+    expect(log.inlineFragmentsEntered).to(beEmpty())
+  }
+
+  /// When `resolveRuntimeType` returns nil (e.g. the receiving object's
+  /// `__typename` isn't yet loaded), `.byRuntimeType` skips. Distinct
+  /// from `.includeAll` which would enter anyway.
+  func test__walk__withByRuntimeType__whenRuntimeTypeIsNil__skipsInlineFragment() throws {
+    class AsDroid: MockTypeCase, @unchecked Sendable {
+      override class var __parentType: any ParentType {
+        Object(typename: "Droid", implementedInterfaces: [])
+      }
+      override class var __selections: [Selection] { [
+        .field("primaryFunction", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .inlineFragment(AsDroid.self),
+    ]
+
+    let log = try runWalker(
+      selections: selections,
+      runtimeType: nil,
+      inlineFragmentPolicy: .byRuntimeType
+    )
+
+    expect(log.fields).to(beEmpty())
+    expect(log.inlineFragmentsEntered).to(beEmpty())
+  }
+
+  /// Inline fragment whose `__parentType` is an `Interface` and the
+  /// runtime type is a concrete `Object` that implements the interface
+  /// → entered. `canBeConverted(from:)` consults the Object's
+  /// `implementedInterfaces` list, which is the more common GraphQL
+  /// pattern (e.g. `fragment ... on Character` matching `Droid`).
+  func test__walk__withByRuntimeType__whenInterfaceParentMatchedByImplementingObject__entersInlineFragment() throws {
+    let characterInterface = Interface(
+      name: "Character",
+      keyFields: nil,
+      implementingObjects: ["Droid", "Human"]
+    )
+    let droidType = Object(
+      typename: "Droid",
+      implementedInterfaces: [characterInterface]
+    )
+
+    class AsCharacter: MockTypeCase, @unchecked Sendable {
+      static let givenInterface = Interface(
+        name: "Character",
+        keyFields: nil,
+        implementingObjects: ["Droid", "Human"]
+      )
+      override class var __parentType: any ParentType { givenInterface }
+      override class var __selections: [Selection] { [
+        .field("name", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .inlineFragment(AsCharacter.self),
+    ]
+
+    let log = try runWalker(
+      selections: selections,
+      runtimeType: droidType,
+      inlineFragmentPolicy: .byRuntimeType
+    )
+
+    expect(log.fields) == ["name"]
+    expect(log.inlineFragmentsEntered).to(haveCount(1))
+  }
+
+  /// Mirror: an `Object` whose `implementedInterfaces` does NOT include
+  /// the fragment's interface parent type → skipped. Confirms the
+  /// interface-conversion path correctly rejects non-implementing
+  /// types.
+  func test__walk__withByRuntimeType__whenInterfaceParentNotMatchedByObject__skipsInlineFragment() throws {
+    // `Vehicle` does not implement `Character`.
+    let vehicleType = Object(
+      typename: "Vehicle",
+      implementedInterfaces: []
+    )
+
+    class AsCharacter: MockTypeCase, @unchecked Sendable {
+      static let givenInterface = Interface(
+        name: "Character",
+        keyFields: nil,
+        implementingObjects: ["Droid", "Human"]
+      )
+      override class var __parentType: any ParentType { givenInterface }
+      override class var __selections: [Selection] { [
+        .field("name", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .inlineFragment(AsCharacter.self),
+    ]
+
+    let log = try runWalker(
+      selections: selections,
+      runtimeType: vehicleType,
+      inlineFragmentPolicy: .byRuntimeType
+    )
+
+    expect(log.fields).to(beEmpty())
+    expect(log.inlineFragmentsEntered).to(beEmpty())
+  }
+
+  // MARK: - InlineFragmentPolicy.includeAll
+
+  /// `.includeAll` enters every inline fragment regardless of
+  /// `resolveRuntimeType` (the closure is never even called under this
+  /// policy).
+  func test__walk__withIncludeAll__entersEveryInlineFragment_regardlessOfRuntimeType() throws {
+    class AsDroid: MockTypeCase, @unchecked Sendable {
+      override class var __parentType: any ParentType {
+        Object(typename: "Droid", implementedInterfaces: [])
+      }
+      override class var __selections: [Selection] { [
+        .field("primaryFunction", String.self),
+      ]}
+    }
+    class AsHuman: MockTypeCase, @unchecked Sendable {
+      override class var __parentType: any ParentType {
+        Object(typename: "Human", implementedInterfaces: [])
+      }
+      override class var __selections: [Selection] { [
+        .field("homePlanet", String.self),
+      ]}
+    }
+
+    let selections: [Selection] = [
+      .inlineFragment(AsDroid.self),
+      .inlineFragment(AsHuman.self),
+    ]
+
+    let log = try runWalker(
+      selections: selections,
+      runtimeType: nil,  // never consulted under .includeAll
+      inlineFragmentPolicy: .includeAll
+    )
+
+    expect(log.fields).to(contain(["primaryFunction", "homePlanet"]))
+    expect(log.inlineFragmentsEntered).to(haveCount(2))
+  }
+
+}

--- a/apollo-ios/Sources/Apollo/Caching/FieldProjection.swift
+++ b/apollo-ios/Sources/Apollo/Caching/FieldProjection.swift
@@ -253,17 +253,22 @@ public struct FieldProjection: Hashable, Sendable {
       return .childKey
     case .nonNull, .list:
       // Unreachable: `peelToNamedType` is the only caller path
-      // and it strips every wrapper. Guard defensively.
-      return .customScalar
+      // and it strips every wrapper before passing the result here.
+      // If this case is ever entered, the invariant has broken — fail
+      // loudly rather than silently routing to `.customScalar`, which
+      // would produce wrong-column reads at runtime.
+      preconditionFailure(
+        "columnShape(ofNamedType:) reached a wrapper type (\(namedType)); peelToNamedType invariant violated"
+      )
     }
   }
 
   /// Maps a built-in `ScalarType` metatype to its column slot. The
   /// five GraphQL primitive scalars route to their typed columns;
-  /// any other type would fall through to `.customScalar`, but
-  /// codegen never emits a non-built-in metatype here (it uses the
-  /// `.customScalar` case for those), so the fallthrough is
-  /// defensive only.
+  /// any other type would be a codegen invariant violation (codegen
+  /// emits non-built-in scalar types through the `.customScalar` case,
+  /// not `.scalar`), so the fallthrough crashes rather than silently
+  /// routing to a wrong column.
   private static func columnShape(
     forBuiltInScalarType scalarType: any ScalarType.Type
   ) -> ColumnShape {
@@ -271,6 +276,8 @@ public struct FieldProjection: Hashable, Sendable {
     if scalarType == Int.self || scalarType == Int32.self { return .int }
     if scalarType == Bool.self { return .bool }
     if scalarType == Float.self || scalarType == Double.self { return .float }
-    return .customScalar
+    preconditionFailure(
+      "columnShape(forBuiltInScalarType:) received an unrecognized ScalarType (\(scalarType)); custom scalars must route through `.customScalar`, not `.scalar`"
+    )
   }
 }

--- a/apollo-ios/Sources/Apollo/Caching/NormalizedCache.swift
+++ b/apollo-ios/Sources/Apollo/Caching/NormalizedCache.swift
@@ -72,6 +72,26 @@ public protocol ReadOnlyNormalizedCache: AnyObject {
   ///     a `cacheKey` to request different fields on the same record.
   ///     Duplicate projections are tolerated; their results coalesce.
   ///
+  ///     **Precondition:** the caller must not supply two projections
+  ///     with the same `(cacheKey, fieldName)` but a different
+  ///     `columnShape` or `cardinality`. The cache backend stores each
+  ///     field under a single column-shape (determined at write time
+  ///     by the field's GraphQL type) and cannot answer two
+  ///     incompatible projections for the same row. ``FieldProjection``'s
+  ///     `Hashable` conformance hashes by the full tuple, so the
+  ///     pending set in `ProjectionLoader` won't dedupe such conflicts
+  ///     — they will reach the backend as two separate projections
+  ///     that ask for inconsistent answers. The
+  ///     `FieldProjectionCollector` path derives `columnShape` /
+  ///     `cardinality` from `Selection.Field.OutputType`, which GraphQL
+  ///     validation guarantees is identical for every selection of the
+  ///     same `(cacheKey, fieldName)`, so this can only happen when
+  ///     callers hand-construct projections via the direct
+  ///     ``FieldProjection/init(cacheKey:fieldName:columnShape:cardinality:)``
+  ///     initializer. PR-009g's SQL projection path enforces the
+  ///     precondition implicitly by picking one storage column per
+  ///     field.
+  ///
   /// - Returns: A dictionary of cache keys to partial records. A cache
   ///   key appears in the result if and only if the *record* exists in
   ///   the cache — independent of whether the specific projected
@@ -104,6 +124,14 @@ extension ReadOnlyNormalizedCache {
   /// and filtering in Swift. Custom cache implementors get the same
   /// behavior without a forced API migration; they may override the
   /// method with a projection-aware path when they're ready.
+  ///
+  /// **Performance:** this default is `O(records.count * filteredFields.count)`
+  /// with one new dict allocation per surfaced record (the `record.fields.filter`
+  /// closure produces a fresh `[CacheKey: CachedField]`). That's fine for the
+  /// in-memory backend, which is already paying the dict-walk cost. Backends
+  /// where the inherited behavior would surface as a regression versus a
+  /// hand-rolled `loadRecords`-backed path (e.g. when a partial-row read is
+  /// significantly cheaper than a full-row read) should override.
   public func loadFields(_ projections: [FieldProjection]) async throws -> [CacheKey: Record] {
     guard !projections.isEmpty else { return [:] }
 

--- a/apollo-ios/Sources/Apollo/Execution/ExecutionSources/CacheDataExecutionSource.swift
+++ b/apollo-ios/Sources/Apollo/Execution/ExecutionSources/CacheDataExecutionSource.swift
@@ -62,7 +62,7 @@ struct CacheDataExecutionSource: GraphQLExecutionSource {
     let strategy = try info.cacheReadStrategy()
 
     switch strategy {
-    case .parentRecordKey(let name):
+    case .parentRecordField(let name):
       // Standard non-policy read: the field's value lives on the
       // parent record under its normalized name (the same name the
       // writer used in `GraphQLResultNormalizer`). Subscript to get

--- a/apollo-ios/Sources/Apollo/Execution/FieldProjectionCollector.swift
+++ b/apollo-ios/Sources/Apollo/Execution/FieldProjectionCollector.swift
@@ -153,7 +153,7 @@ public enum FieldProjectionCollector {
       responsePath: responsePath
     )
     switch strategy {
-    case .parentRecordKey(let name):
+    case .parentRecordField(let name):
       projections.insert(FieldProjection(
         cacheKey: cacheKey,
         fieldName: name,

--- a/apollo-ios/Sources/Apollo/Execution/GraphQLExecutor.swift
+++ b/apollo-ios/Sources/Apollo/Execution/GraphQLExecutor.swift
@@ -185,8 +185,22 @@ public class FieldExecutionInfo {
     self.responsePath = info.responsePath
     self.responseKeyForField = info.responseKeyForField
     self.cachePath = info.cachePath
+    // `_normalizedFieldName` doesn't depend on `responsePath`, so copying
+    // it is safe.
     self._normalizedFieldName = info._normalizedFieldName
-    self._cacheReadStrategy = info._cacheReadStrategy
+    // `_cacheReadStrategy` is deliberately NOT copied. The strategy is
+    // computed from `(field, variables, schema, responsePath)`; the only
+    // caller of `copy()` is the executor's list-element traversal in
+    // `GraphQLExecutor.complete(fields:withValue:asType:)`, which appends
+    // the element index to the copy's `responsePath` after construction.
+    // Carrying the parent's memo would silently return a stale strategy
+    // for any future `FieldPolicy.Provider` implementation that consults
+    // its `path:` argument. Today no provider uses path nontrivially, so
+    // this is preventive; the cost is one extra evaluation per copy on
+    // first call, which is amortized to zero since the memo is currently
+    // only ever queried once per info (see ADR 0007 PR-009g-bis for the
+    // cross-phase sharing that would actually exercise re-queries).
+    self._cacheReadStrategy = nil
   }
 
 }

--- a/apollo-ios/Sources/Apollo/Internal Utilities/Selection.Field+CacheReadStrategy.swift
+++ b/apollo-ios/Sources/Apollo/Internal Utilities/Selection.Field+CacheReadStrategy.swift
@@ -10,8 +10,9 @@
 ///
 /// The three cases capture this asymmetry explicitly:
 ///
-/// - ``parentRecordKey(_:)`` — Standard, non-policy resolution. Subscript
-///   the parent record under `name`; the value is whatever the writer
+/// - ``parentRecordField(_:)`` — Standard, non-policy resolution. The
+///   associated value is the field's name on the parent record;
+///   subscript the parent under that name to get whatever the writer
 ///   stored (a `CacheReference`, a scalar, a list, etc.).
 /// - ``policyReference(_:)`` — `@fieldPolicy` applied. The reader
 ///   produces a `CacheReference(key)` directly. No parent-record
@@ -30,10 +31,11 @@
 /// `DefaultCacheResolver` (no policy) performs parent-record lookup.
 /// This enum encodes the same distinction in the Swift cache executor.
 enum CacheReadStrategy {
-  /// Standard read: subscript the parent record by `name`. Used for
-  /// every field that does not have a `@fieldPolicy` /
-  /// `FieldPolicy.Provider` redirect.
-  case parentRecordKey(String)
+  /// Standard read: the associated value is the field's name on the
+  /// parent record. The resolver subscripts `parent[name]` to fetch
+  /// whatever the writer stored. Used for every field that does not
+  /// have a `@fieldPolicy` / `FieldPolicy.Provider` redirect.
+  case parentRecordField(String)
 
   /// `@fieldPolicy` redirect: the field's value is a single
   /// `CacheReference(key)`, resolved directly from the field's
@@ -60,7 +62,7 @@ extension Selection.Field {
   ///    `@fieldPolicy` directive second), return ``CacheReadStrategy/policyReference(_:)``
   ///    or ``CacheReadStrategy/policyReferenceList(_:)`` with the
   ///    policy-derived key(s) formatted as `"\(uniqueKeyGroup ?? typename):\(id)"`.
-  /// 2. Otherwise, return ``CacheReadStrategy/parentRecordKey(_:)`` with
+  /// 2. Otherwise, return ``CacheReadStrategy/parentRecordField(_:)`` with
   ///    `try cacheKey(with: variables)` — the field's normalized name on
   ///    its parent record (matches what the writer wrote).
   ///
@@ -93,7 +95,7 @@ extension Selection.Field {
         return .policyReferenceList(infos.map { formatPolicyCacheKey(info: $0, typename: typename) })
       }
     }
-    return .parentRecordKey(try cacheKey(with: variables))
+    return .parentRecordField(try cacheKey(with: variables))
   }
 
   /// The typename used to format a policy-derived cache field name.


### PR DESCRIPTION
## Summary

Bundles the **medium-** and **low-severity items** surfaced by the code review of the cache-rewrite phase-1a stack (PRs #1008-#1018). No behavior changes outside one `copy()` memo-invalidation fix and one `preconditionFailure` swap; mostly doc updates, test additions, and a small naming rename.

The high-severity items from the review already landed:
- ✅ `ProjectionLoader` absence-memoization bug (fixed on PR #1018)
- ✅ PR #1016 bundling concerns (acknowledgment comment posted)
- ✅ `ProjectionLoaderTests` audit gaps (covered on PR #1018)

## What's in here

### Medium-severity

**A. Invalidate `_cacheReadStrategy` in `FieldExecutionInfo.copy()`** — The strategy is computed from `(field, variables, schema, responsePath)`, but `copy()` is only called by the executor's list-element traversal, which appends the element index to `responsePath` after construction. Carrying the parent's memo would silently return a stale strategy for any future `FieldPolicy.Provider` that consults `path:`. Dormant today (no provider uses path nontrivially); preventive.

**B + G. Doc updates on `loadFields(_:)`** — Precondition on column-shape uniqueness (PR-009g will rely on it); performance note on the default impl's `O(records × filteredFields)` allocation pattern.

**C. Test: empty-projection short-circuit with empty parent record** — Stages only the canonical `Hero:Luke` record (no `QUERY_ROOT`) and verifies the `@fieldPolicy` redirect resolves successfully via the `loadObject` short-circuit. Matches Apollo Kotlin's `FieldPolicyCacheResolver` semantic.

**D. Expanded `@fieldPolicy` round-trip coverage** — Three new tests: programmatic `FieldPolicy.Provider` (vs directive-based), `CacheKeyInfo(uniqueKeyGroup:)` non-nil branch, list-typed `@fieldPolicy` (`.policyReferenceList`).

**E. Fix tautological conditional-skip test** — `FieldProjectionCollectorTests.test__collect__givenConditionalSkipTrue__skipsConditional` previously asserted "empty result," which a never-walked input would also satisfy. Added an unconditional sibling that must survive.

**F. New `SelectionWalkerTests`** — `FieldProjectionCollector`'s deferred-fragment tests all use `.eager`, which ignores `@defer(if:)`. New focused file exercises the walker's policy switches directly: `respectDeferCondition` × {if-true / if-false / no-condition}, `eager` ignores condition, `byRuntimeType` × {match / mismatch / nil runtime}, `includeAll` enters regardless.

### Low-severity

**H. Replace `.customScalar` defensive fallbacks with `preconditionFailure`** — In `FieldProjection.columnShape(ofNamedType:)` and `columnShape(forBuiltInScalarType:)`, the `.nonNull/.list` and unknown-scalar fallbacks previously returned `.customScalar`. The `.customScalar` route happens to be a sensible-looking but wrong destination — if the upstream invariants ever broke (they can't today, but refactoring is forever), every wrapper-typed field would silently get `.customScalar` and the cache would read from the wrong column. Now those branches `preconditionFailure` loudly with a descriptive message. Zero runtime change today since the branches are unreachable.

**I. Asymmetric nested-list `columnShape` tests** — `[[Int!]]` (nullable outer, non-null inner) and `[[Int]!]` (non-null outer, nullable inner) are valid GraphQL types per the spec, even though codegen typically emits the fully-non-null shape. Two new `FieldProjectionTests` cases assert the nested-list rule (depth ≥ 2 → `.childKey`, cardinality `.list`) holds regardless of which wrapper layers are `.nonNull`-wrapped.

**J. Interface-typed inline-fragment test in `SelectionWalkerTests`** — `canBeConverted(from:)` has two paths: object-equality (used in existing tests) and `Object.implements(Interface)` (the more common GraphQL pattern, e.g. `fragment ... on Character` matching `Droid`). Two new tests cover the interface path with matching and non-matching runtime types.

**L. Rename `CacheReadStrategy.parentRecordKey` → `parentRecordField`** — The old name read like "a key referring to a different record." The new name makes the parallel structure clearer at every call site: it's a field on the parent record, not a key for another record. Touches the enum definition + 2 switch sites + 1 constructor + doc comments.

## Diff size

10 files, +707 / -19. Net new lines are mostly tests + doc text.

## Tests

- All cache + execution + projection tests pass.
- Test count: 1136 → 1152 (+16 new tests).
- Full Apollo-UnitTestPlan: 0 failed, 11 not-run (environment-dependent file I/O / concurrency stress tests; same as `main`).

## Stack position

```
phase-1-plan
└── phase-1a-row-per-field-crud (PR #1001)
    └── phase-1a-field-projection (PR #1008, PR-009b)
        └── phase-1a-cache-load-fields (PR #1009, PR-009c)
            └── phase-1a-executor-upfront-projection (PR #1012, PR-009d-i)
                └── phase-1a-executor-upfront-projection-ii (PR #1013, PR-009d-ii)
                    └── phase-1a-cache-field-key-memo (PR #1016, PR-009d-iii)
                        └── phase-1a-selection-walker (PR #1017, PR-009d-iv)
                            └── phase-1a-store-load-projection (PR #1018, PR-009e)
                                └── phase-1a-review-followups (PR-009e-bis ← this PR)
```

## Items deliberately not addressed here

- **K.** List-element `responsePath` shared across elements — pre-existing behavior in `CacheDataExecutionSource.deferredResolve`; no production provider exercises it; fix is fiddly. Tracked for future if/when a provider consults path indices.
- **M.** `BatchRecorder` actor / Nimble-vs-XCTest consistency nits in `ProjectionLoaderTests` — pure style, no bugs.
- `_cacheReadStrategy` memo is currently dormant (called once per `resolveField`). PR-009g-bis (profile-gated) covers the cross-phase sharing that would actually exercise the memo. Agreed to defer earlier in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)