### PR TITLE
refactor(cache): GraphQLDependencyTracker emits structured CacheDependentKey (PR-009f)

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockApolloStore.swift
+++ b/Tests/ApolloInternalTestHelpers/MockApolloStore.swift
@@ -19,8 +19,8 @@ public class NoCache: NormalizedCache {
     return [:]
   }
 
-  public func merge(records: RecordSet) throws -> Set<String> {
-    return Set()
+  public func merge(records: RecordSet) throws -> Set<CacheDependentKey> {
+    return []
   }
 
   public func removeRecord(for key: String) throws { }

--- a/Tests/ApolloTests/ApolloClientOperationTests.swift
+++ b/Tests/ApolloTests/ApolloClientOperationTests.swift
@@ -34,7 +34,7 @@ final class ApolloClientOperationTests: XCTestCase {
 
   class MockCache: InMemoryNormalizedCache {
     var publishedRecordSets: [RecordSet] = []
-    override func merge(records newRecords: RecordSet) throws -> Set<CacheKey> {
+    override func merge(records newRecords: RecordSet) throws -> Set<CacheDependentKey> {
       publishedRecordSets.append(newRecords)
       return try super.merge(records: newRecords)
     }

--- a/Tests/ApolloTests/ApolloStore_BatchedLoadTests.swift
+++ b/Tests/ApolloTests/ApolloStore_BatchedLoadTests.swift
@@ -31,7 +31,7 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
     records.removeRecords(matching: pattern)
   }
 
-  func merge(records: RecordSet) async throws -> Set<CacheKey> {
+  func merge(records: RecordSet) async throws -> Set<CacheDependentKey> {
     try await Task.sleep(nanoseconds: 1_000_000)
     return self.records.merge(records: records)
   }

--- a/Tests/ApolloTests/Cache/CacheDependentKeyTests.swift
+++ b/Tests/ApolloTests/Cache/CacheDependentKeyTests.swift
@@ -1,0 +1,54 @@
+@testable @_spi(Execution) import Apollo
+import Foundation
+import Nimble
+import XCTest
+
+final class CacheDependentKeyTests: XCTestCase {
+
+  // MARK: - Equatable / Hashable
+
+  func test__equality__givenSameCacheKeyAndFieldName__returnsTrue() {
+    let a = CacheDependentKey(cacheKey: "Human:1000", fieldName: "name")
+    let b = CacheDependentKey(cacheKey: "Human:1000", fieldName: "name")
+    expect(a) == b
+  }
+
+  func test__equality__givenDifferentCacheKey__returnsFalse() {
+    let a = CacheDependentKey(cacheKey: "Human:1000", fieldName: "name")
+    let b = CacheDependentKey(cacheKey: "Human:1001", fieldName: "name")
+    expect(a) != b
+  }
+
+  func test__equality__givenDifferentFieldName__returnsFalse() {
+    let a = CacheDependentKey(cacheKey: "Human:1000", fieldName: "name")
+    let b = CacheDependentKey(cacheKey: "Human:1000", fieldName: "homePlanet")
+    expect(a) != b
+  }
+
+  func test__hashable__equalValuesProduceEqualHashes() {
+    let a = CacheDependentKey(cacheKey: "Human:1000", fieldName: "name")
+    let b = CacheDependentKey(cacheKey: "Human:1000", fieldName: "name")
+    expect(a.hashValue) == b.hashValue
+  }
+
+  func test__hashable__usableInSet__deduplicatesEqualValues() {
+    let key = CacheDependentKey(cacheKey: "Human:1000", fieldName: "name")
+    let set: Set<CacheDependentKey> = [key, key]
+    expect(set).to(haveCount(1))
+  }
+
+  // MARK: - CustomStringConvertible
+
+  func test__description__formatsAsCacheKeyDotFieldName() {
+    let key = CacheDependentKey(cacheKey: "Human:1000", fieldName: "name")
+    expect(key.description) == "Human:1000.name"
+  }
+
+  func test__description__preservesEmbeddedRecordPath() {
+    // Embedded sub-objects synthesize a multi-segment record key
+    // (the writer joins the response path with `.`); the description
+    // round-trips that verbatim.
+    let key = CacheDependentKey(cacheKey: "QUERY_ROOT.animal", fieldName: "genus")
+    expect(key.description) == "QUERY_ROOT.animal.genus"
+  }
+}

--- a/Tests/ApolloTests/Cache/RecordSetMergeTests.swift
+++ b/Tests/ApolloTests/Cache/RecordSetMergeTests.swift
@@ -1,0 +1,93 @@
+@testable @_spi(Execution) import Apollo
+import Foundation
+import Nimble
+import XCTest
+
+/// Verifies the structured-dependency-key surface of `RecordSet.merge`
+/// — the set the cache emits to subscribers when a publish lands.
+/// This is the writer-side counterpart of the dependency-tracker tests:
+/// PR-009f's correctness rests on both producers emitting matching
+/// `(cacheKey, fieldName)` pairs.
+final class RecordSetMergeTests: XCTestCase {
+
+  // MARK: - New record
+
+  func test__merge__givenNewRecord__returnsEveryFieldAsChanged() {
+    var set = RecordSet()
+    let changed = set.merge(record: Record(
+      key: "Human:1000",
+      ["__typename": "Human", "name": "Luke"]
+    ))
+
+    expect(changed) == [
+      CacheDependentKey(cacheKey: "Human:1000", fieldName: "__typename"),
+      CacheDependentKey(cacheKey: "Human:1000", fieldName: "name"),
+    ]
+  }
+
+  // MARK: - Existing record, unchanged value
+
+  func test__merge__givenExistingRecord_unchangedValue__omitsFieldFromChangedSet() {
+    var set = RecordSet()
+    _ = set.merge(record: Record(
+      key: "Human:1000",
+      ["__typename": "Human", "name": "Luke"]
+    ))
+
+    let changed = set.merge(record: Record(
+      key: "Human:1000",
+      ["__typename": "Human", "name": "Luke"]
+    ))
+
+    expect(changed).to(beEmpty())
+  }
+
+  // MARK: - Existing record, changed value
+
+  func test__merge__givenExistingRecord_singleFieldChanged__returnsOnlyThatField() {
+    var set = RecordSet()
+    _ = set.merge(record: Record(
+      key: "Human:1000",
+      ["__typename": "Human", "name": "Luke"]
+    ))
+
+    let changed = set.merge(record: Record(
+      key: "Human:1000",
+      ["__typename": "Human", "name": "Han"]
+    ))
+
+    expect(changed) == [CacheDependentKey(cacheKey: "Human:1000", fieldName: "name")]
+  }
+
+  // MARK: - Multiple records
+
+  func test__merge__givenMultipleNewRecords__returnsEveryFieldAcrossAllRecords() {
+    var set = RecordSet()
+    let changed = set.merge(records: RecordSet(records: [
+      Record(key: "Human:1000", ["name": "Luke"]),
+      Record(key: "Human:1002", ["name": "Han"]),
+    ]))
+
+    expect(changed) == [
+      CacheDependentKey(cacheKey: "Human:1000", fieldName: "name"),
+      CacheDependentKey(cacheKey: "Human:1002", fieldName: "name"),
+    ]
+  }
+
+  // MARK: - Embedded sub-object record key
+
+  func test__merge__givenEmbeddedSubObjectRecord__preservesDotInCacheKey() {
+    // The writer normalizes an embedded sub-object (no `@typePolicy`)
+    // to a record whose key carries the response path joined with `.`.
+    // The merge surface preserves that boundary verbatim — `fieldName`
+    // is the storage-layer field name only, never inheriting prefix
+    // segments from the record key.
+    var set = RecordSet()
+    let changed = set.merge(record: Record(
+      key: "QUERY_ROOT.animal",
+      ["genus": "Canis"]
+    ))
+
+    expect(changed) == [CacheDependentKey(cacheKey: "QUERY_ROOT.animal", fieldName: "genus")]
+  }
+}

--- a/Tests/ApolloTests/Cache/StoreSubscriptionTests.swift
+++ b/Tests/ApolloTests/Cache/StoreSubscriptionTests.swift
@@ -20,7 +20,10 @@ class StoreSubscriptionTests: XCTestCase {
   // MARK: - Tests
 
   func testSubscriberIsNotifiedOfStoreUpdate() async throws {
-    let expectedChangeKeySet: Set<String> = ["QUERY_ROOT.__typename", "QUERY_ROOT.name"]
+    let expectedChangeKeySet: Set<CacheDependentKey> = [
+      CacheDependentKey(cacheKey: "QUERY_ROOT", fieldName: "__typename"),
+      CacheDependentKey(cacheKey: "QUERY_ROOT", fieldName: "name"),
+    ]
     let subscriber = SimpleSubscriber(expectedChangeKeySet)
 
     let subscriptionToken = await store.subscribe(subscriber)
@@ -51,9 +54,9 @@ class StoreSubscriptionTests: XCTestCase {
   }
 
   internal actor SimpleSubscriber: ApolloStoreSubscriber {
-    var changeSet: Set<String>
+    var changeSet: Set<CacheDependentKey>
 
-    init(_ changeSet: Set<String>) {
+    init(_ changeSet: Set<CacheDependentKey>) {
       self.changeSet = changeSet
     }
 
@@ -61,7 +64,7 @@ class StoreSubscriptionTests: XCTestCase {
       block(self)
     }
 
-    nonisolated func store(_ store: ApolloStore, didChangeKeys changedKeys: Set<CacheKey>) {
+    nonisolated func store(_ store: ApolloStore, didChangeKeys changedKeys: Set<CacheDependentKey>) {
       Task(priority: .high) {
         await self.isolatedDo {
           $0.changeSet.subtract(changedKeys)

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -1748,7 +1748,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting, @unchecked Sendable {
           "Human:1000.name",
           "QUERY_ROOT.hero",
         ]
-        let actualDependentKeys = try XCTUnwrap(graphQLResult.dependentKeys)
+        let actualDependentKeys = Set(try XCTUnwrap(graphQLResult.dependentKeys).map(\.description))
         expect(actualDependentKeys).to(equal(expectedDependentKeys))
       }
     }
@@ -1788,7 +1788,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting, @unchecked Sendable {
           "Human:1002.name",
           "QUERY_ROOT.hero",
         ]
-        let actualDependentKeys = try XCTUnwrap(graphQLResult.dependentKeys)
+        let actualDependentKeys = Set(try XCTUnwrap(graphQLResult.dependentKeys).map(\.description))
         expect(actualDependentKeys).to(equal(expectedDependentKeys))
       }
     }
@@ -1894,7 +1894,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting, @unchecked Sendable {
           "Human:1000.name",
           "QUERY_ROOT.hero",
         ]
-        let actualDependentKeys = try XCTUnwrap(graphQLResult.dependentKeys)
+        let actualDependentKeys = Set(try XCTUnwrap(graphQLResult.dependentKeys).map(\.description))
         XCTAssertEqual(actualDependentKeys, expectedDependentKeys)
       }
     }
@@ -1951,7 +1951,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting, @unchecked Sendable {
           "Human:1002.name",
           "QUERY_ROOT.hero",
         ]
-        let actualDependentKeys = try XCTUnwrap(graphQLResult.dependentKeys)
+        let actualDependentKeys = Set(try XCTUnwrap(graphQLResult.dependentKeys).map(\.description))
         XCTAssertEqual(actualDependentKeys, expectedDependentKeys)
       }
     }
@@ -2056,7 +2056,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting, @unchecked Sendable {
           "Human:1000.name",
           "QUERY_ROOT.hero",
         ]
-        let actualDependentKeys = try XCTUnwrap(graphQLResult.dependentKeys)
+        let actualDependentKeys = Set(try XCTUnwrap(graphQLResult.dependentKeys).map(\.description))
         XCTAssertEqual(actualDependentKeys, expectedDependentKeys)
       }
     }

--- a/Tests/ApolloTests/GraphQLResultTests.swift
+++ b/Tests/ApolloTests/GraphQLResultTests.swift
@@ -291,7 +291,7 @@ final class GraphQLResultTests: XCTestCase {
       extensions: nil,
       errors: nil,
       source: .server,
-      dependentKeys: [try CacheKey(_jsonValue: "SomeKey")]
+      dependentKeys: [CacheDependentKey(cacheKey: "SomeKey", fieldName: "field")]
     )
 
     let incremental = IncrementalGraphQLResult(
@@ -300,14 +300,14 @@ final class GraphQLResultTests: XCTestCase {
       data: nil,
       extensions: nil,
       errors: nil,
-      dependentKeys: [try CacheKey(_jsonValue: "AnotherKey")]
+      dependentKeys: [CacheDependentKey(cacheKey: "AnotherKey", fieldName: "field")]
     )
 
     let merged = try result.merging(incremental)
 
-    let expected: Set<CacheKey> = [
-      try CacheKey(_jsonValue: "SomeKey"),
-      try CacheKey(_jsonValue: "AnotherKey"),
+    let expected: Set<CacheDependentKey> = [
+      CacheDependentKey(cacheKey: "SomeKey", fieldName: "field"),
+      CacheDependentKey(cacheKey: "AnotherKey", fieldName: "field"),
     ]
 
     // then

--- a/Tests/ApolloTests/JSONResponseParser_IncrementalResponseParsingTests.swift
+++ b/Tests/ApolloTests/JSONResponseParser_IncrementalResponseParsingTests.swift
@@ -445,6 +445,8 @@ final class JSONResponseParser_IncrementalResponseParsingTests: XCTestCase {
     let result = try await iterator.next()
     let dependentKeys = result?.result.dependentKeys
     expect(dependentKeys).toNot(beNil())
-    expect(dependentKeys).to(contain(CacheKey("QUERY_ROOT.animal.genus")))
+    expect(dependentKeys).to(
+      contain(CacheDependentKey(cacheKey: "QUERY_ROOT.animal", fieldName: "genus"))
+    )
   }
 }

--- a/Tests/ApolloTests/WebSocket/WebSocketTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTests.swift
@@ -2903,7 +2903,7 @@ private final class FailingWriteCache: NormalizedCache, @unchecked Sendable {
     return [:]
   }
 
-  func merge(records: RecordSet) async throws -> Set<CacheKey> {
+  func merge(records: RecordSet) async throws -> Set<CacheDependentKey> {
     throw WriteError()
   }
 

--- a/apollo-ios/Sources/Apollo/Caching/ApolloStore.swift
+++ b/apollo-ios/Sources/Apollo/Caching/ApolloStore.swift
@@ -5,12 +5,16 @@ import Foundation
 /// This protocol is available for advanced use cases only. Most users will prefer using `ApolloClient.watch(query:)`.
 public protocol ApolloStoreSubscriber: AnyObject, Sendable {
 
-  /// This function will be called when keys are changed within the database.
+  /// This function will be called when fields are changed within the cache.
   ///
   /// - Parameters:
-  ///   - store: The ``ApolloStore`` which made the changes
-  ///   - changedKeys: The set of changed keys
-  func store(_ store: ApolloStore, didChangeKeys changedKeys: Set<CacheKey>)
+  ///   - store: The ``ApolloStore`` which made the changes.
+  ///   - changedKeys: The set of ``CacheDependentKey``s identifying each
+  ///     `(cacheKey, fieldName)` pair whose stored value changed in the
+  ///     underlying cache. Subscribers can intersect this set with the
+  ///     dependent-key set recorded on their last read to detect
+  ///     whether the change is relevant.
+  func store(_ store: ApolloStore, didChangeKeys changedKeys: Set<CacheDependentKey>)
 }
 
 /// The ``ApolloStore`` class manages access to a local cache for reading/writing normalized GraphQL results.
@@ -52,7 +56,7 @@ public final class ApolloStore: Sendable {
     self.cache = cache
   }
 
-  fileprivate func didChangeKeys(_ changedKeys: Set<CacheKey>) {
+  fileprivate func didChangeKeys(_ changedKeys: Set<CacheDependentKey>) {
     for subscriber in self.subscribers.values {
       subscriber.store(self, didChangeKeys: changedKeys)
     }
@@ -359,7 +363,7 @@ public final class ApolloStore: Sendable {
     /// It is safe to directly operate on the raw record data of the cache from within the transaction block.
     public var cache: any NormalizedCache { _cache }
     
-    fileprivate var updateChangedKeysFunc: ((Set<CacheKey>) -> Void)?
+    fileprivate var updateChangedKeysFunc: ((Set<CacheDependentKey>) -> Void)?
 
     override init(store: ApolloStore) {
       self.updateChangedKeysFunc = store.didChangeKeys

--- a/apollo-ios/Sources/Apollo/Caching/CacheDependentKey.swift
+++ b/apollo-ios/Sources/Apollo/Caching/CacheDependentKey.swift
@@ -1,0 +1,55 @@
+/// Identifies one `(cacheKey, fieldName)` pair that a watcher's
+/// query depends on, or that a cache merge surfaced as changed.
+///
+/// The dependency tracker (`GraphQLDependencyTracker`) emits a
+/// `CacheDependentKey` for every field a watcher's last read
+/// touched; the cache's merge path (`RecordSet.merge`) emits one
+/// for every field whose stored value changed. `GraphQLQueryWatcher`
+/// computes set intersection between the two: if any changed field
+/// matches one the query depended on, the watcher re-runs the query.
+///
+/// `cacheKey` is the storage-layer record key (matching `Record.key`);
+/// `fieldName` is the storage-layer field name (matching the
+/// `Record.fields` dictionary key, including any argument-derived
+/// suffix). For embedded sub-objects — those without a separate
+/// `@typePolicy` cache key — the writer synthesizes a record key
+/// from the response path (e.g. `"QUERY_ROOT.animal"`), and the
+/// dependency tracker records the corresponding pair as
+/// `(cacheKey: "QUERY_ROOT.animal", fieldName: "genus")`. Both
+/// the tracker and `RecordSet.merge` produce keys that agree at
+/// this record boundary, so set intersection is exact.
+///
+/// # See Also
+///
+/// - [ADR 0007 — Selection-set-aware cache reads](../Design/adr/0007-selection-aware-cache-reads.md)
+///   PR-009f: "Dirty `(cacheKey, fieldName)` entries become
+///   `FieldProjection`s via the direct `(columnShape, cardinality)`
+///   initializer." This type is the public, shape-agnostic surface;
+///   shape info is supplied by the consumer that converts it.
+/// - ``FieldProjection`` — the selection-set-aware sibling that
+///   adds `columnShape` / `cardinality`. The dependency tracker
+///   does not need the shape, so the dirty-set carries the slim
+///   `(cacheKey, fieldName)` form and shape is reconstituted at
+///   re-read time from the watcher's known projection set.
+public struct CacheDependentKey: Hashable, Sendable {
+
+  /// The cache key of the record carrying the field.
+  public let cacheKey: CacheKey
+
+  /// The field's name on the parent record. Matches the
+  /// storage-layer field name verbatim (`Record.fields` dictionary
+  /// key).
+  public let fieldName: String
+
+  public init(cacheKey: CacheKey, fieldName: String) {
+    self.cacheKey = cacheKey
+    self.fieldName = fieldName
+  }
+}
+
+extension CacheDependentKey: CustomStringConvertible {
+  /// Format matches the legacy `"\(cacheKey).\(fieldName)"` joined
+  /// string used before PR-009f. Useful for debugging and for tests
+  /// that previously compared joined-string sets.
+  public var description: String { "\(cacheKey).\(fieldName)" }
+}

--- a/apollo-ios/Sources/Apollo/Caching/InMemoryNormalizedCache.swift
+++ b/apollo-ios/Sources/Apollo/Caching/InMemoryNormalizedCache.swift
@@ -18,7 +18,7 @@ public class InMemoryNormalizedCache: NormalizedCache {
     records.removeRecord(for: key)
   }
   
-  public func merge(records newRecords: RecordSet) throws -> Set<CacheKey> {
+  public func merge(records newRecords: RecordSet) throws -> Set<CacheDependentKey> {
     return records.merge(records: newRecords)
   }
 

--- a/apollo-ios/Sources/Apollo/Caching/NormalizedCache.swift
+++ b/apollo-ios/Sources/Apollo/Caching/NormalizedCache.swift
@@ -11,8 +11,13 @@ public protocol NormalizedCache: AnyObject, ReadOnlyNormalizedCache {
   ///
   /// - Parameters:
   ///   - records: The set of records to merge.
-  /// - Returns: A set of keys corresponding to *fields* that have changed (i.e. QUERY_ROOT.Foo.myField). These are the same type of keys as are returned by RecordSet.merge(records:).
-  func merge(records: RecordSet) async throws -> Set<CacheKey>
+  /// - Returns: A set of ``CacheDependentKey``s identifying every
+  ///   `(cacheKey, fieldName)` pair whose stored value changed. These
+  ///   are the same dependency-tracking keys recorded by
+  ///   `GraphQLDependencyTracker` and consumed by
+  ///   ``ApolloStoreSubscriber/store(_:didChangeKeys:)`` /
+  ///   ``GraphQLQueryWatcher`` for dirty-set computation.
+  func merge(records: RecordSet) async throws -> Set<CacheDependentKey>
 
   /// Removes a record for the specified key. This method will only
   /// remove whole records, not individual fields.

--- a/apollo-ios/Sources/Apollo/Caching/RecordSet.swift
+++ b/apollo-ios/Sources/Apollo/Caching/RecordSet.swift
@@ -44,8 +44,8 @@ public struct RecordSet: Sendable, Hashable {
     return Set(storage.keys)
   }
 
-  @discardableResult public mutating func merge(records: RecordSet) -> Set<CacheKey> {
-    var changedKeys: Set<CacheKey> = Set()
+  @discardableResult public mutating func merge(records: RecordSet) -> Set<CacheDependentKey> {
+    var changedKeys: Set<CacheDependentKey> = []
 
     for (_, record) in records.storage {
       changedKeys.formUnion(merge(record: record))
@@ -54,28 +54,30 @@ public struct RecordSet: Sendable, Hashable {
     return changedKeys
   }
 
-  @discardableResult public mutating func merge(record: Record) -> Set<CacheKey> {
+  @discardableResult public mutating func merge(record: Record) -> Set<CacheDependentKey> {
     if let oldRecord = storage[record.key] {
-      var changedKeys: Set<CacheKey> = Set()
+      var changedKeys: Set<CacheDependentKey> = []
       var updatedRecord = oldRecord
 
       // Always take the new `CachedField` so the stored timestamp advances
       // to the latest write. Only notify watchers (via `changedKeys`) when
       // the observable value actually differs from what was stored.
-      for (key, newField) in record.fields {
-        updatedRecord.fields[key] = newField
-        if let oldField = oldRecord.fields[key],
+      for (fieldName, newField) in record.fields {
+        updatedRecord.fields[fieldName] = newField
+        if let oldField = oldRecord.fields[fieldName],
            AnyHashable(oldField.value) == AnyHashable(newField.value) {
           continue
         }
-        changedKeys.insert([record.key, key].joined(separator: "."))
+        changedKeys.insert(CacheDependentKey(cacheKey: record.key, fieldName: fieldName))
       }
 
       storage[record.key] = updatedRecord
       return changedKeys
     } else {
       storage[record.key] = record
-      return Set(record.fields.keys.map { [record.key, $0].joined(separator: ".") })
+      return Set(
+        record.fields.keys.map { CacheDependentKey(cacheKey: record.key, fieldName: $0) }
+      )
     }
   }
 }

--- a/apollo-ios/Sources/Apollo/Execution/ResultAccumulators/GraphQLDependencyTracker.swift
+++ b/apollo-ios/Sources/Apollo/Execution/ResultAccumulators/GraphQLDependencyTracker.swift
@@ -4,40 +4,65 @@ final class GraphQLDependencyTracker: GraphQLResultAccumulator {
 
   let requiresCacheKeyComputation: Bool = true
 
-  private var dependentKeys: Set<CacheKey> = Set()
+  private var dependentKeys: Set<CacheDependentKey> = []
 
   func accept(scalar: JSONValue, info: FieldExecutionInfo) {
-    dependentKeys.insert(info.cachePath.joined)
+    insert(info)
   }
 
   func accept(customScalar: JSONValue, info: FieldExecutionInfo) {
-    dependentKeys.insert(info.cachePath.joined)
+    insert(info)
   }
 
   func acceptNullValue(info: FieldExecutionInfo) {
-    dependentKeys.insert(info.cachePath.joined)
+    insert(info)
   }
 
   func acceptMissingValue(info: FieldExecutionInfo) throws -> () {
-    dependentKeys.insert(info.cachePath.joined)
+    insert(info)
   }
 
   func accept(list: [Void], info: FieldExecutionInfo) {
-    dependentKeys.insert(info.cachePath.joined)
+    insert(info)
   }
 
   func accept(childObject: Void, info: FieldExecutionInfo) {
   }
 
   func accept(fieldEntry: Void, info: FieldExecutionInfo) -> Void? {
-    dependentKeys.insert(info.cachePath.joined)
+    insert(info)
     return ()
   }
 
   func accept(fieldEntries: [Void], info: ObjectExecutionInfo) {
   }
 
-  func finish(rootValue: Void, info: ObjectExecutionInfo) -> Set<CacheKey> {
+  func finish(rootValue: Void, info: ObjectExecutionInfo) -> Set<CacheDependentKey> {
     return dependentKeys
+  }
+
+  /// Records a dependency on the field described by `info`. The
+  /// containing record's cache key is `info.parentInfo.cachePath` —
+  /// the executor sets this to the writer's record key on entry to
+  /// every record boundary (see `GraphQLExecutor.computeChildExecutionData`),
+  /// so the resulting `(cacheKey, fieldName)` pair matches the
+  /// changed-key set produced by `RecordSet.merge` by construction.
+  /// `fieldName` is the field's normalized name on that record (the
+  /// same name the writer wrote, including any argument-derived
+  /// suffix), which is the last segment of `info.cachePath`.
+  private func insert(_ info: FieldExecutionInfo) {
+    let recordKey = info.parentInfo.cachePath.joined
+    let fieldName: String
+    if let normalizedName = try? info.normalizedFieldName() {
+      fieldName = normalizedName
+    } else {
+      // Should not happen — `normalizedFieldName` only throws when the
+      // field's cache key cannot be computed from its arguments, which
+      // is the same precondition any caller of `info.cachePath` would
+      // have already satisfied. Falling back to `responseKeyForField`
+      // preserves intersection semantics for fields without arguments.
+      fieldName = info.responseKeyForField
+    }
+    dependentKeys.insert(CacheDependentKey(cacheKey: recordKey, fieldName: fieldName))
   }
 }

--- a/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -30,7 +30,7 @@ public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber {
   public private(set) var cancelled: Bool = false
 
   private var lastFetch: FetchContext?
-  private var dependentKeys: Set<CacheKey>? = nil
+  private var dependentKeys: Set<CacheDependentKey>? = nil
 
   private let resultHandler: ResultHandler
   private let contextIdentifier = UUID()
@@ -214,7 +214,7 @@ public actor GraphQLQueryWatcher<Query: GraphQLQuery>: ApolloStoreSubscriber {
 
   public nonisolated func store(
     _ store: ApolloStore,
-    didChangeKeys changedKeys: Set<CacheKey>
+    didChangeKeys changedKeys: Set<CacheDependentKey>
   ) {
     if let incomingIdentifier = QueryWatcherContext.identifier,
       incomingIdentifier == self.contextIdentifier

--- a/apollo-ios/Sources/Apollo/GraphQLResponse.swift
+++ b/apollo-ios/Sources/Apollo/GraphQLResponse.swift
@@ -21,17 +21,20 @@ public struct GraphQLResponse<Operation: GraphQLOperation>: Sendable {
   /// Source of data
   public let source: Source
 
-  /// The cache keys for the fields that were included in this response. Custom ``ApolloStoreSubscriber``s can use these
-  /// keys to understand when changes to the cache would affect the result of a specific response.
+  /// The ``CacheDependentKey``s identifying each `(cacheKey, fieldName)`
+  /// pair the response's data depends on. Custom ``ApolloStoreSubscriber``s
+  /// can intersect this set with the changed-key set delivered to
+  /// ``ApolloStoreSubscriber/store(_:didChangeKeys:)`` to detect whether
+  /// a cache change affects the response.
   @_spi(Execution)
-  public let dependentKeys: Set<CacheKey>?
+  public let dependentKeys: Set<CacheDependentKey>?
 
   public init(
     data: Operation.Data?,
     extensions: JSONObject?,
     errors: [GraphQLError]?,
     source: Source,
-    dependentKeys: Set<CacheKey>?
+    dependentKeys: Set<CacheDependentKey>?
   ) {
     self.data = data
     self.extensions = extensions

--- a/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalGraphQLResult.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalGraphQLResult.swift
@@ -19,7 +19,7 @@ struct IncrementalGraphQLResult: Sendable {
   /// A dictionary which services can use however they see fit to provide additional information to clients.
   let extensions: JSONObject?
 
-  let dependentKeys: Set<CacheKey>?
+  let dependentKeys: Set<CacheDependentKey>?
 
   init(
     label: String,
@@ -27,7 +27,7 @@ struct IncrementalGraphQLResult: Sendable {
     data: (any SelectionSet)?,
     extensions: JSONObject?,
     errors: [GraphQLError]?,
-    dependentKeys: Set<CacheKey>?
+    dependentKeys: Set<CacheDependentKey>?
   ) {
     self.label = label
     self.path = path

--- a/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
@@ -104,7 +104,7 @@ extension JSONResponseParser {
     }
 
     fileprivate func makeResult(
-      executor: ((any Deferrable.Type) async throws -> (data: DataDict?, dependentKeys: Set<CacheKey>?))
+      executor: ((any Deferrable.Type) async throws -> (data: DataDict?, dependentKeys: Set<CacheDependentKey>?))
     ) async throws -> IncrementalGraphQLResult {
       guard let path = base.responseBody["path"] as? [JSONValue] else {
         throw IncrementalResponseError.missingPath

--- a/apollo-ios/Sources/Apollo/ResponseParsing/SingleResponseExecutionHandler.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/SingleResponseExecutionHandler.swift
@@ -75,7 +75,7 @@ extension JSONResponseParser {
 
     private func makeResult(
       data: Operation.Data?,
-      dependentKeys: Set<CacheKey>?
+      dependentKeys: Set<CacheDependentKey>?
     ) -> GraphQLResponse<Operation> {      
       return GraphQLResponse<Operation>(
         data: data,

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -35,33 +35,12 @@ public final class SQLiteNormalizedCache {
     try self.database.createSchemaMetadataTableIfNeeded()
   }
   
-  private func recordCacheKey(forFieldCacheKey fieldCacheKey: CacheKey) -> CacheKey {
-    let components = fieldCacheKey.splitIntoCacheKeyComponents()
-    var updatedComponents = [String]()
-    if components.first?.contains("_ROOT") == true {
-      for component in components {
-        if updatedComponents.last?.last?.isNumber ?? false && component.first?.isNumber ?? false {
-          updatedComponents[updatedComponents.count - 1].append(".\(component)")
-        } else {
-          updatedComponents.append(component)
-        }
-      }
-    } else {
-      updatedComponents = components
-    }
-
-    if updatedComponents.count > 1 {
-      updatedComponents.removeLast()
-    }
-    return updatedComponents.joined(separator: ".")
-  }
-
-  private func mergeRecords(records: RecordSet) throws -> Set<CacheKey> {
+  private func mergeRecords(records: RecordSet) throws -> Set<CacheDependentKey> {
     var recordSet = RecordSet(records: try self.selectRecords(for: records.keys))
     let changedFieldKeys = recordSet.merge(records: records)
-    let changedRecordKeys = changedFieldKeys.map { self.recordCacheKey(forFieldCacheKey: $0) }
+    let changedRecordKeys = Set(changedFieldKeys.map(\.cacheKey))
 
-    let serializedRecords = try Set(changedRecordKeys)
+    let serializedRecords = try changedRecordKeys
       .compactMap { recordKey -> (CacheKey, String)? in
         if let recordFields = recordSet[recordKey]?.fields {
           let recordData = try SQLiteSerialization.serialize(fields: recordFields)
@@ -75,7 +54,7 @@ public final class SQLiteNormalizedCache {
       }
 
     try self.database.addOrUpdate(records: serializedRecords)
-    return Set(changedFieldKeys)
+    return changedFieldKeys
   }
   
   fileprivate func selectRecords(for keys: Set<CacheKey>) throws -> [Record] {
@@ -104,7 +83,7 @@ extension SQLiteNormalizedCache: NormalizedCache {
                                 })
   }
   
-  public func merge(records: RecordSet) throws -> Set<CacheKey> {
+  public func merge(records: RecordSet) throws -> Set<CacheDependentKey> {
     return try mergeRecords(records: records)
   }
   


### PR DESCRIPTION
Per ADR 0007 PR-009f. The watcher dependency-tracking surface moves from
joined `"\(record).\(field)"` strings to a structured value type so the
public contract carries `(cacheKey, fieldName)` semantics by construction
instead of by string convention.

## Why this matters

The 2.x cache and the 3.0 rewrite both compute "dirty fields" by intersecting
two sets: the fields a watcher's last read depended on, and the fields
whose stored value changed on a publish. Today both sides emit
`Set<CacheKey>` where each `CacheKey` is `"\(record).\(field)"`. That
encoding is fragile — the tracker and the merger have to keep building
exactly-the-same string by exactly-the-same rule, and any consumer that
wants to act on individual `(record, field)` pairs has to parse them
back out. ADR 0007 calls this out as PR-009f's scope: surface the
structure that's already implicit.

This PR introduces `CacheDependentKey { cacheKey, fieldName }` as that
structured surface. Future work (per the ADR) can convert a
`CacheDependentKey` to a `FieldProjection` for projection-driven re-reads
via the direct `(columnShape, cardinality)` initializer.

## Changes

**New type**
- `CacheDependentKey` (Hashable, Sendable, `CustomStringConvertible`) —
  `description` matches the legacy joined form `"\(cacheKey).\(fieldName)"`,
  preserving readability for tests and debug output.

**Tracker — `GraphQLDependencyTracker`**
- Switched from `Set<CacheKey>` to `Set<CacheDependentKey>`.
- Derives the pair from `info.parentInfo.cachePath` (the writer's record key
  for the containing object) plus `info.normalizedFieldName()`. This is the
  key correctness move — splitting `info.cachePath.joined` at the first `.`
  was tempting but wrong for embedded sub-objects whose synthesized record
  key contains dots. Using `parentInfo.cachePath` directly means the
  tracker's `cacheKey` is exactly the writer's `Record.key`, so set
  intersection is exact regardless of nesting.

**Writer — `RecordSet.merge`**
- `merge(records:)` and `merge(record:)` now return `Set<CacheDependentKey>`.

**Cache protocol + impls**
- `NormalizedCache.merge(records:)` returns `Set<CacheDependentKey>`.
- `InMemoryNormalizedCache.merge` and `SQLiteNormalizedCache.merge` adopt
  the new return type. SQLite's `recordCacheKey(forFieldCacheKey:)` helper
  is retired — the structured key carries the record cacheKey directly.

**Public consumers**
- `ApolloStoreSubscriber.store(_:didChangeKeys:)` parameter type.
- `GraphQLQueryWatcher.dependentKeys` storage + `store(_:didChangeKeys:)` callback.
- `GraphQLResponse.dependentKeys` (`@_spi(Execution)`).
- `IncrementalGraphQLResult.dependentKeys`.
- `SingleResponseExecutionHandler.makeResult(data:dependentKeys:)` and
  `IncrementalResponseExecutionHandler.makeResult(executor:)`'s tuple type.

## Tests

**New focused tests (+12)**
- `CacheDependentKeyTests` (7) — equality / inequality on cacheKey, fieldName;
  hashable; description format; embedded-record-path round-trip.
- `RecordSetMergeTests` (5) — new record / unchanged / single-field changed /
  multiple records / embedded sub-object record key. The last case is the
  one that verifies the writer-side dependency-key shape matches the
  tracker's reader-side for embedded objects.

**Existing tests updated**
- `WatchQueryTests` — five dependent-key assertions routed through
  `Set(deps.map(\.description))` so the existing literal joined-string
  expectations continue to read cleanly.
- `GraphQLResultTests.test__merging__givenIncrementalDependentKeys_shouldMergeDependentKeys`
  builds with the new type.
- `JSONResponseParser_IncrementalResponseParsingTests.test__parsing__givenIncrementalItem__dependentKeysShouldIncludeIncrementalPath`
  asserts `CacheDependentKey(cacheKey: "QUERY_ROOT.animal", fieldName: "genus")`
  — the structured shape now expresses the embedded-record boundary the
  legacy joined form hid.
- `StoreSubscriptionTests.SimpleSubscriber` and its expected change set.
- Test-only `NormalizedCache` mocks (`NoCache`, `MockBatchedNormalizedCache`,
  `ApolloClientOperationTests.MockCache`, `FailingWriteCache`).

**Result:** 1175 tests, 1164 passed, 0 failed, 11 not run (same not-run set
as the prior PR — the `+12` are the new focused tests).

## Sequence

Stacked on top of cache-rewrite/phase-1a-review-followups (PR #1021). Next
in the ADR 0007 sequence is **PR-009g** — `feat(sqlite): field-aware
`selectFields` with column projection`. PR-009g-bis (cross-phase
`FieldExecutionInfo` sharing) is still profile-gated.