### PR TITLE
feat(sqlite): field-aware selectFields with column projection (PR-009g)

### DIFF
--- a/Tests/ApolloTests/SQLiteSelectFieldsTests.swift
+++ b/Tests/ApolloTests/SQLiteSelectFieldsTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable @_spi(Execution) import Apollo
+@testable @_spi(Execution) import ApolloSQLite
+import ApolloInternalTestHelpers
+
+/// Covers the projection-aware `selectFields(_:)` read on
+/// `ApolloSQLiteDatabase`. Companion to `SQLiteRowPerElementCRUDTests`
+/// — uses `insertOrUpdate(records:)` to seed the database and
+/// verifies `selectFields` returns the expected partial records under
+/// PR-009f's `loadFields` contract: a cache key appears in the result
+/// if and only if the *record* exists, regardless of whether the
+/// projected fields are present on it.
+final class SQLiteSelectFieldsTests: XCTestCase {
+
+  // MARK: - Helpers
+
+  private func makeDatabase() throws -> ApolloSQLiteDatabase {
+    let db = try ApolloSQLiteDatabase(fileURL: SQLiteTestCacheProvider.temporarySQLiteFileURL())
+    try db.createSchemaMetadataTableIfNeeded()
+    try db.createNewRecordsTableIfNeeded()
+    return db
+  }
+
+  private func record(
+    _ key: CacheKey,
+    fields: [CacheKey: any Hashable & Sendable],
+    writtenAt: Int64 = 100
+  ) -> Record {
+    Record(
+      key: key,
+      fields: fields.mapValues { CachedField(value: $0, writtenAt: writtenAt) }
+    )
+  }
+
+  private func projection(
+    _ cacheKey: CacheKey,
+    _ fieldName: String,
+    columnShape: FieldProjection.ColumnShape = .string,
+    cardinality: FieldProjection.Cardinality = .scalar
+  ) -> FieldProjection {
+    FieldProjection(
+      cacheKey: cacheKey,
+      fieldName: fieldName,
+      columnShape: columnShape,
+      cardinality: cardinality
+    )
+  }
+
+  // MARK: - Empty input
+
+  func test__selectFields__givenEmptyProjections__returnsEmptyDictionary() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["name": "Anthony"])])
+
+    let result = try db.selectFields([])
+    XCTAssertTrue(result.isEmpty)
+  }
+
+  // MARK: - Single record, single field
+
+  func test__selectFields__givenSingleField__returnsThatField() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: [
+      "name": "Anthony",
+      "age": 42,
+    ])])
+
+    let result = try db.selectFields([projection("User:1", "name")])
+
+    XCTAssertEqual(result.count, 1)
+    let record = try XCTUnwrap(result["User:1"])
+    XCTAssertEqual(record.fields.count, 1)
+    XCTAssertEqual(record.fields["name"]?.value as? String, "Anthony")
+    XCTAssertNil(record.fields["age"])
+  }
+
+  func test__selectFields__givenMultipleFieldsOnOneRecord__returnsAllRequested() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: [
+      "name": "Anthony",
+      "age": 42,
+      "city": "Brooklyn",
+    ])])
+
+    let result = try db.selectFields([
+      projection("User:1", "name"),
+      projection("User:1", "age", columnShape: .int),
+    ])
+
+    let record = try XCTUnwrap(result["User:1"])
+    XCTAssertEqual(record.fields.count, 2)
+    XCTAssertEqual(record.fields["name"]?.value as? String, "Anthony")
+    XCTAssertEqual(record.fields["age"]?.value as? Int, 42)
+    XCTAssertNil(record.fields["city"])
+  }
+
+  // MARK: - Multi-record projection
+
+  func test__selectFields__givenProjectionsAcrossRecords__returnsEachRecordPartial() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [
+      record("User:1", fields: ["name": "Anthony", "age": 42]),
+      record("User:2", fields: ["name": "Sarah", "age": 36]),
+    ])
+
+    let result = try db.selectFields([
+      projection("User:1", "name"),
+      projection("User:2", "age", columnShape: .int),
+    ])
+
+    XCTAssertEqual(result.count, 2)
+    XCTAssertEqual(result["User:1"]?.fields["name"]?.value as? String, "Anthony")
+    XCTAssertNil(result["User:1"]?.fields["age"])
+    XCTAssertEqual(result["User:2"]?.fields["age"]?.value as? Int, 36)
+    XCTAssertNil(result["User:2"]?.fields["name"])
+  }
+
+  // MARK: - Existence contract
+
+  func test__selectFields__givenRecordAbsentFromDB__omitsKeyFromResult() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["name": "Anthony"])])
+
+    let result = try db.selectFields([
+      projection("User:1", "name"),
+      projection("User:2", "name"),
+    ])
+
+    XCTAssertEqual(result.count, 1)
+    XCTAssertNotNil(result["User:1"])
+    XCTAssertNil(result["User:2"])
+  }
+
+  func test__selectFields__givenRecordPresentButFieldMissing__returnsEmptyFieldsForRecord() throws {
+    // Per `ReadOnlyNormalizedCache/loadFields(_:)`: a record that
+    // exists but holds none of the requested fields surfaces as
+    // present-with-empty-fields, not absent. This is what lets the
+    // executor distinguish a per-field `missingValue` from a
+    // record-level miss.
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["name": "Anthony"])])
+
+    let result = try db.selectFields([projection("User:1", "homePlanet")])
+
+    XCTAssertEqual(result.count, 1)
+    let record = try XCTUnwrap(result["User:1"])
+    XCTAssertTrue(record.fields.isEmpty)
+  }
+
+  // MARK: - Dedupe
+
+  func test__selectFields__givenDuplicateProjections__readsRowOnce() throws {
+    // Two `FieldProjection`s that differ only in declared shape but
+    // share `(cacheKey, fieldName)` should coalesce at the SQL bind
+    // layer. The test asserts the read still succeeds and returns the
+    // single stored value — the shape conflict is a programmer error
+    // documented in `loadFields(_:)`'s precondition.
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record("User:1", fields: ["name": "Anthony"])])
+
+    let result = try db.selectFields([
+      projection("User:1", "name", columnShape: .string, cardinality: .scalar),
+      projection("User:1", "name", columnShape: .int, cardinality: .scalar),
+    ])
+
+    XCTAssertEqual(result["User:1"]?.fields["name"]?.value as? String, "Anthony")
+  }
+
+  // MARK: - List field
+
+  func test__selectFields__givenListField__returnsAssembledList() throws {
+    let db = try makeDatabase()
+    let colors: [Record.Value] = ["red", "green", "blue"]
+    try db.insertOrUpdate(records: [Record(
+      key: "User:1",
+      fields: ["colors": CachedField(value: colors as Record.Value, writtenAt: 100)]
+    )])
+
+    let result = try db.selectFields([
+      projection("User:1", "colors", columnShape: .string, cardinality: .list),
+    ])
+
+    let assembled = result["User:1"]?.fields["colors"]?.value as? [Any]
+    XCTAssertEqual(assembled?.count, 3)
+    XCTAssertEqual(assembled?[0] as? String, "red")
+    XCTAssertEqual(assembled?[2] as? String, "blue")
+  }
+
+  // MARK: - Nested list synthetic resolution
+
+  func test__selectFields__givenNestedListField__resolvesSyntheticSubRecord() throws {
+    // A nested list (`[[Int]]`) is stored as a parent row with a
+    // `child_key_value` pointing at a synthetic sub-record. The SELECT
+    // returns only the parent row; `selectFields` must follow the
+    // child reference to materialize the inner list.
+    let db = try makeDatabase()
+    let outer: [Record.Value] = [
+      [1, 2] as Record.Value,
+      [3, 4] as Record.Value,
+    ]
+    try db.insertOrUpdate(records: [Record(
+      key: "Grid:1",
+      fields: ["rows": CachedField(value: outer as Record.Value, writtenAt: 100)]
+    )])
+
+    let result = try db.selectFields([
+      projection("Grid:1", "rows", columnShape: .childKey, cardinality: .list),
+    ])
+
+    let outerLoaded = result["Grid:1"]?.fields["rows"]?.value as? [Any]
+    XCTAssertEqual(outerLoaded?.count, 2)
+    let row0 = outerLoaded?[0] as? [Any]
+    let row1 = outerLoaded?[1] as? [Any]
+    XCTAssertEqual(row0?[0] as? Int, 1)
+    XCTAssertEqual(row0?[1] as? Int, 2)
+    XCTAssertEqual(row1?[0] as? Int, 3)
+    XCTAssertEqual(row1?[1] as? Int, 4)
+  }
+
+  // MARK: - WrittenAt preserved
+
+  func test__selectFields__givenWriteWithTimestamp__preservesWrittenAt() throws {
+    let db = try makeDatabase()
+    try db.insertOrUpdate(records: [record(
+      "User:1",
+      fields: ["name": "Anthony"],
+      writtenAt: 1_700_000_000
+    )])
+
+    let result = try db.selectFields([projection("User:1", "name")])
+
+    XCTAssertEqual(result["User:1"]?.fields["name"]?.writtenAt, 1_700_000_000)
+  }
+}

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -409,13 +409,140 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     }
   }
 
+  /// Per-ADR 0007 projection-aware read. Two SQL statements inside
+  /// one `performSync`: an existence probe so the caller can tell
+  /// "record absent" from "record present, field missing", then a
+  /// row-filter `SELECT` that fetches only the requested
+  /// `(cacheKey, fieldName)` pairs. Synthetic sub-record references
+  /// in the returned rows are resolved transparently via
+  /// `resolveSyntheticIfNeeded`, so nested-list fields materialize
+  /// in their assembled form.
+  @_spi(Execution)
+  public func selectFields(_ projections: [FieldProjection]) throws -> [CacheKey: Record] {
+    guard !projections.isEmpty else { return [:] }
+
+    // Dedupe `(cacheKey, fieldName)` early — `FieldProjection`'s
+    // `Hashable` conformance hashes by the full tuple including shape
+    // info, so two projections that differ only in `columnShape` /
+    // `cardinality` won't collapse via `Set<FieldProjection>`. The
+    // SQL doesn't read shape info, only the storage pair, so we
+    // dedupe on that.
+    let uniqueProjections = Set(projections.map {
+      ProjectionKey(cacheKey: $0.cacheKey, fieldName: $0.fieldName)
+    })
+    let requestedKeys = Set(uniqueProjections.map(\.cacheKey))
+
+    return try performSync {
+      let existingKeys = try selectExistingKeys(requestedKeys)
+
+      // No matching records exist — short-circuit before the
+      // projection query so we don't issue a `WHERE (...) IN ()`
+      // (SQLite rejects an empty IN-list anyway, and the result
+      // would be empty regardless).
+      guard !existingKeys.isEmpty else { return [:] }
+
+      let projectedRows = try selectProjectedRows(Array(uniqueProjections))
+      let assembled = try assembleRecords(from: projectedRows)
+      let assembledByKey = Dictionary(uniqueKeysWithValues: assembled.map { ($0.key, $0) })
+
+      var result: [CacheKey: Record] = [:]
+      result.reserveCapacity(existingKeys.count)
+      for key in existingKeys {
+        // Honor `loadFields`'s contract: a record that exists but
+        // has none of the requested fields surfaces with empty
+        // `fields`. The caller's executor needs this to distinguish
+        // a per-field `missingValue` error (record present, field
+        // missing) from a record-level lookup miss.
+        result[key] = assembledByKey[key] ?? Record(key: key, fields: [:])
+      }
+      return result
+    }
+  }
+
+  /// Runs the existence-probe SQL: `SELECT DISTINCT cache_key …
+  /// WHERE cache_key IN (?, ?, …)`. The result tells the caller
+  /// which of the requested cache keys correspond to records that
+  /// actually exist in the database.
+  private func selectExistingKeys(_ keys: Set<CacheKey>) throws -> Set<CacheKey> {
+    guard !keys.isEmpty else { return [] }
+    let placeholders = Array(repeating: "?", count: keys.count).joined(separator: ", ")
+    let sql = """
+    SELECT DISTINCT \(SQLiteSchema.Records.cacheKey)
+    FROM \(SQLiteSchema.recordsTableName)
+    WHERE \(SQLiteSchema.Records.cacheKey) IN (\(placeholders))
+    """
+    let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare existence-probe select")
+    defer { sqlite3_finalize(stmt) }
+
+    var bindIdx: Int32 = 1
+    for key in keys {
+      sqlite3_bind_text(stmt, bindIdx, key, -1, SQLITE_TRANSIENT)
+      bindIdx += 1
+    }
+
+    var result: Set<CacheKey> = []
+    var step = sqlite3_step(stmt)
+    while step == SQLITE_ROW {
+      if let ptr = sqlite3_column_text(stmt, 0) {
+        result.insert(String(cString: ptr))
+      }
+      step = sqlite3_step(stmt)
+    }
+    if step != SQLITE_DONE {
+      throw SQLiteError.step(
+        message: "Existence-probe step failed: \(sqliteErrorMessage())",
+        resultCode: step
+      )
+    }
+    return result
+  }
+
+  /// Runs the projection SQL: `SELECT … WHERE (cache_key, field_name)
+  /// IN (VALUES (?, ?), (?, ?), …)`. Returns the raw rows; assembly
+  /// happens in the caller via the shared `assembleRecords` helper.
+  private func selectProjectedRows<C: Collection>(_ projections: C) throws -> [DecodedRow]
+  where C.Element == ProjectionKey {
+    guard !projections.isEmpty else { return [] }
+
+    let valuesClause = Array(repeating: "(?, ?)", count: projections.count).joined(separator: ", ")
+    let sql = """
+    SELECT
+      \(SQLiteSchema.Records.cacheKey),
+      \(SQLiteSchema.Records.fieldName),
+      \(SQLiteSchema.Records.position),
+      \(SQLiteSchema.Records.intValue),
+      \(SQLiteSchema.Records.stringValue),
+      \(SQLiteSchema.Records.floatValue),
+      \(SQLiteSchema.Records.boolValue),
+      \(SQLiteSchema.Records.childKeyValue),
+      \(SQLiteSchema.Records.customScalarValue),
+      \(SQLiteSchema.Records.writtenAt)
+    FROM \(SQLiteSchema.recordsTableName)
+    WHERE (\(SQLiteSchema.Records.cacheKey), \(SQLiteSchema.Records.fieldName))
+      IN (VALUES \(valuesClause))
+    ORDER BY \(SQLiteSchema.Records.cacheKey),
+             \(SQLiteSchema.Records.fieldName),
+             \(SQLiteSchema.Records.position)
+    """
+    let stmt = try prepareStatement(sql, errorMessage: "Failed to prepare projection select")
+    defer { sqlite3_finalize(stmt) }
+
+    var bindIdx: Int32 = 1
+    for projection in projections {
+      sqlite3_bind_text(stmt, bindIdx, projection.cacheKey, -1, SQLITE_TRANSIENT)
+      sqlite3_bind_text(stmt, bindIdx + 1, projection.fieldName, -1, SQLITE_TRANSIENT)
+      bindIdx += 2
+    }
+
+    return try readDecodedRows(stmt: stmt)
+  }
+
   /// Test-only read path: loads every row for the given cache keys,
   /// reassembles them into `Record` instances, and follows synthetic
   /// sub-record `child_key_value` pointers to materialize nested lists.
   /// **Not part of the `SQLiteDatabase` public protocol** — production
-  /// reads will use a projection-aware API introduced in a later PR
-  /// (per ADR 0007). This helper exists so the write/delete tests can
-  /// verify round-trip behavior in the interim.
+  /// reads use ``selectFields(_:)``. Retained as test infrastructure
+  /// for the row-per-element CRUD tests until PR-009h.
   internal func selectRecords(forKeys keys: Set<CacheKey>) throws -> [Record] {
     guard !keys.isEmpty else { return [] }
 
@@ -674,6 +801,16 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
       bindIdx += 1
     }
 
+    let rawRows = try readDecodedRows(stmt: stmt)
+    return try assembleRecords(from: rawRows)
+  }
+
+  /// Iterates a prepared `SELECT` whose column order matches the
+  /// row-per-element schema's `cache_key, field_name, position,
+  /// int_value, string_value, float_value, bool_value, child_key_value,
+  /// custom_scalar_value, written_at` projection and decodes each
+  /// row into a `DecodedRow`.
+  private func readDecodedRows(stmt: OpaquePointer?) throws -> [DecodedRow] {
     var rawRows: [DecodedRow] = []
     var step = sqlite3_step(stmt)
     while step == SQLITE_ROW {
@@ -711,8 +848,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     if step != SQLITE_DONE {
       throw SQLiteError.step(message: "Failed to step row-per-element select: \(sqliteErrorMessage())", resultCode: step)
     }
-
-    return try assembleRecords(from: rawRows)
+    return rawRows
   }
 
   /// Groups raw rows by cache_key, then by field_name, distinguishing
@@ -810,6 +946,15 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     let position: Int64
     let value: Record.Value
     let writtenAt: Int64
+  }
+
+  /// Storage-shape-agnostic key for deduping projections before
+  /// issuing the SQL. `FieldProjection`'s `Hashable` hashes the full
+  /// tuple (including `columnShape` and `cardinality`), but the row-
+  /// filter SQL only consults `cacheKey` and `fieldName`.
+  private struct ProjectionKey: Hashable {
+    let cacheKey: CacheKey
+    let fieldName: String
   }
 }
 

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Apollo
+@_spi(Execution) import Apollo
 
 public struct DatabaseRow {
   let cacheKey: CacheKey
@@ -150,6 +150,45 @@ public protocol SQLiteDatabase {
   /// `\`, `%`, and `_` in `pattern` are escaped so they match
   /// literally rather than acting as `LIKE` wildcards.
   func deleteRecords(matchingKey pattern: CacheKey) throws
+
+  /// Loads the row-per-element rows for the requested
+  /// `(cacheKey, fieldName)` pairs and assembles them into partial
+  /// `Record`s.
+  ///
+  /// Honors the same contract as ``ReadOnlyNormalizedCache/loadFields(_:)``:
+  /// a cache key appears in the result if and only if the *record*
+  /// exists in the database — independent of whether the specific
+  /// projected fields are present. A record that exists but holds
+  /// none of the requested fields is returned as a `Record` with empty
+  /// `fields`; a record absent from the database is omitted entirely.
+  /// The distinction is what lets the executor surface per-field
+  /// `missingValue` errors with response-path context (record present
+  /// but field missing) versus a record-level lookup miss (record
+  /// absent) at the caller.
+  ///
+  /// Nested-list fields are reassembled by following
+  /// `child_key_value` synthetic-sub-record references; the synthetic
+  /// rows are loaded transparently and their list contents materialize
+  /// into the returned `Record.fields`. Synthetic sub-records never
+  /// surface as top-level cache keys.
+  ///
+  /// Duplicate projections (same `cacheKey` and `fieldName`) are
+  /// tolerated and coalesce to a single SQL bind. Projections whose
+  /// `columnShape`/`cardinality` differ but share `(cacheKey, fieldName)`
+  /// is a programmer error per the
+  /// ``ReadOnlyNormalizedCache/loadFields(_:)`` precondition; this
+  /// implementation does not detect or report the conflict — it reads
+  /// whichever row exists and returns its actual stored shape.
+  ///
+  /// Requires the row-per-element records table (see
+  /// `createNewRecordsTableIfNeeded()`).
+  ///
+  /// - Parameter projections: The set of fields to read. May be empty,
+  ///   in which case the returned dictionary is empty.
+  /// - Returns: A dictionary of cache keys to partial records as
+  ///   described above.
+  @_spi(Execution)
+  func selectFields(_ projections: [FieldProjection]) throws -> [CacheKey: Record]
 
 }
 


### PR DESCRIPTION
Per ADR 0007 PR-009g. Adds a projection-aware read on the row-per-element schema: `ApolloSQLiteDatabase.selectFields(_:)` takes `[FieldProjection]` and returns `[CacheKey: Record]` honoring the `loadFields` contract — a cache key appears in the result if and only if the *record* exists, regardless of whether the projected fields are present on it.

## Implementation

Two SQL statements inside one `performSync`:
1. **Existence probe** — `SELECT DISTINCT cache_key FROM records WHERE cache_key IN (?, ?, …)`. Yields the set of cache keys that name a present record. This is what lets the caller distinguish *record absent* from *record present, field missing* on the return value.
2. **Row-filter projection** — `SELECT … WHERE (cache_key, field_name) IN (VALUES (?, ?), (?, ?), …)`. Yields only the requested `(cacheKey, fieldName)` rows, regardless of how many other fields the record stores. SQLite's `(col1, col2) IN (VALUES …)` syntax does the multi-column match in one statement.

Then assemble — for every existing cache key, build a `Record`. If the key has projected rows, the record's `fields` carries the matched fields (with their `writtenAt` timestamps); if not, the record is present with empty `fields`. Synthetic sub-records (`<parent>.<field>.$[N]`) are resolved transparently via the existing `resolveSyntheticIfNeeded` walk, so nested-list fields materialize in their assembled form.

Projections are deduped on `(cacheKey, fieldName)` before binding via a private `ProjectionKey` struct — `FieldProjection`'s `Hashable` hashes the full tuple including shape info, so `Set<FieldProjection>` wouldn't collapse two projections that differ only in `columnShape` / `cardinality`. The SQL doesn't read shape info, only the storage pair.

The existing `loadRecordBatch` was refactored to share the row-decoding loop via a new `readDecodedRows(stmt:)` helper that both `loadRecordBatch` and `selectProjectedRows` consume.

## Out of scope (deferred to ADR follow-ons)

- **Inline-fragment `__typename` CTE filter.** ADR PR-009g talks about a correlated subquery / CTE on `__typename` that filters inline-fragment-conditional fields by the record's runtime type. That requires extending `FieldProjection` with type-case info so the SQL knows which fields are conditional on which type case. Deferred to a separate PR — the over-fetch the collector's `includeAllInlineFragments: true` currently produces is still bounded at the wire by the executor's later, type-aware traversal; this PR doesn't change that boundary.
- **Wiring into `SQLiteNormalizedCache.loadFields(_:)`.** The cache's read+write paths are still on the legacy JSON-blob schema (`addOrUpdate(records:)` / `selectRawRows(forKeys:)`). Wiring `selectFields` in would create a read/write schema mismatch — every read would find no rows because writes still go through the legacy path. The full switchover, including drop-and-rebuild migration of pre-3.0 caches, is PR-009h.
- **Removal of `selectRecords(forKeys:)`.** Kept as test infrastructure until PR-009h. The doc-comment notes it's no longer the production read.

## Tests

New `SQLiteSelectFieldsTests` (+10):
- Empty projections → empty dictionary.
- Single field on a record → only that field present in the returned record.
- Multiple fields on one record → all requested present, others absent.
- Projections spanning multiple records → each surfaces with its own partial.
- Record absent from DB → key omitted from result (record-level miss).
- Record present but field missing → key present with empty `fields` (per-field miss).
- Duplicate projections sharing `(cacheKey, fieldName)` → coalesce to one bind, single row.
- List field → assembled list with all elements in order.
- Nested list (`[[Int]]`) → synthetic sub-record resolved, inner list materialized.
- `writtenAt` preserved through the read.

**Result:** 1185 tests, 1174 passed, 0 failed, 11 not run.

## Sequence

Stacked on top of cache-rewrite/phase-1a-dependency-key (PR #1022, PR-009f). Next in the ADR 0007 sequence is **PR-009h** — `refactor(sqlite): SQLiteNormalizedCache switches to field-aware path + drop-and-rebuild migration`, which wires this `selectFields` into the cache, switches writes to `insertOrUpdate(records:)`, and ships the schema migration.