### PR TITLE
Chore: Xcode 27b1 workaround

### DIFF
--- a/Tests/ApolloCodegenTests/TestHelpers/TemplateTestRegexMatchers.swift
+++ b/Tests/ApolloCodegenTests/TestHelpers/TemplateTestRegexMatchers.swift
@@ -63,7 +63,9 @@ enum RegexMatcher {
           startOfLine
           /(?:public)? var [`\w]+?: [^\n]+?(?:\?)?\ /
         }
-        let getter = /{ __data\["\w+?"\] }\n?/
+        // Use \x22 for quotes to avoid Swift Regex quoted-literal parsing inside composed regexes.
+        let getter = /[{] __data\[\x22\w+?\x22\] [}]\n?/
+        let setter = /set [{] __data\[\x22\w+?\x22\] = newValue [}]\n/
 
         let regex = {
           if mutable {
@@ -74,7 +76,7 @@ enum RegexMatcher {
                   /\n/; startOfLine
                   "get "; getter
                   startOfLine
-                  /set { __data\["\w+?"\] = newValue }\n/
+                  setter
                   startOfLine; "}"
                 }
               }
@@ -173,4 +175,3 @@ enum RegexMatcher {
     }
   }
 }
-

--- a/Tests/ApolloInternalTestHelpers/AsyncResultObserver.swift
+++ b/Tests/ApolloInternalTestHelpers/AsyncResultObserver.swift
@@ -52,7 +52,16 @@ public final actor AsyncResultObserver<Success: Sendable, Failure: Swift.Error> 
     block(self)
   }
 
-  public nonisolated func handler(_ result: Result<Success, Failure>) {
+  /// A `@Sendable` closure for receiving results, for passing to APIs that take a result handler.
+  ///
+  /// This is a closure-returning property rather than a method because the Swift 6.4 compiler no
+  /// longer treats partial applications of nonisolated actor methods as `@Sendable`, so a method
+  /// reference (`observer.handler`) cannot be passed where a `@Sendable` handler is expected.
+  public nonisolated var handler: @Sendable (Result<Success, Failure>) -> Void {
+    { result in self.receive(result) }
+  }
+
+  private nonisolated func receive(_ result: Result<Success, Failure>) {
     Task {
       await isolatedDo { isolatedSelf in
 

--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -313,12 +313,12 @@ private extension Mocks.Hero.FriendsQuery {
     let query = MockQuery<Mocks.Hero.FriendsQuery>()
     query.__variables = ["id": "2001", "flirst": 2, "after": GraphQLNullable<String>.none]
     return await server.expect(query) { _ in
-      let pageInfo: [AnyHashable: AnyHashable] = [
+      let pageInfo: JSONObject = [
         "__typename": "PageInfo",
         "endCursor": "Y3Vyc29yMg==",
         "hasNextPage": true,
       ]
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Luke Skywalker",
@@ -330,22 +330,22 @@ private extension Mocks.Hero.FriendsQuery {
           "id": "1002",
         ],
       ]
-      let friendsConnection = [
+      let friendsConnection: JSONObject = [
         "__typename": "FriendsConnection",
         "totalCount": 3,
-        "friends": friends,
-        "pageInfo": pageInfo,
+        "friends": friends as JSONValue,
+        "pageInfo": pageInfo as JSONValue,
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friendsConnection": friendsConnection,
+        "friendsConnection": friendsConnection as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [

--- a/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
+++ b/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
@@ -7,12 +7,12 @@ extension Mocks.Hero.FriendsQuery {
     let query = MockQuery<Mocks.Hero.FriendsQuery>()
     query.__variables = ["id": "2001", "first": 2, "after": GraphQLNullable<String>.null]
     return await server.expect(query) { _ in
-      let pageInfo: [AnyHashable: AnyHashable] = [
+      let pageInfo: JSONObject = [
         "__typename": "PageInfo",
         "endCursor": "Y3Vyc29yMg==",
         "hasNextPage": true,
       ]
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Luke Skywalker",
@@ -24,22 +24,22 @@ extension Mocks.Hero.FriendsQuery {
           "id": "1002",
         ],
       ]
-      let friendsConnection: [String: AnyHashable] = [
+      let friendsConnection: JSONObject = [
         "__typename": "FriendsConnection",
         "totalCount": 3,
-        "friends": friends,
-        "pageInfo": pageInfo,
+        "friends": friends as JSONValue,
+        "pageInfo": pageInfo as JSONValue,
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friendsConnection": friendsConnection,
+        "friendsConnection": friendsConnection as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [
@@ -52,34 +52,34 @@ extension Mocks.Hero.FriendsQuery {
     let query = MockQuery<Mocks.Hero.FriendsQuery>()
     query.__variables = ["id": "2001", "first": 2, "after": "Y3Vyc29yMg=="]
     return await server.expect(query) { _ in
-      let pageInfo: [AnyHashable: AnyHashable] = [
+      let pageInfo: JSONObject = [
         "__typename": "PageInfo",
         "endCursor": "Y3Vyc29yMw==",
         "hasNextPage": false,
       ]
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Leia Organa",
           "id": "1003",
         ],
       ]
-      let friendsConnection: [String: AnyHashable] = [
+      let friendsConnection: JSONObject = [
         "__typename": "FriendsConnection",
         "totalCount": 3,
-        "friends": friends,
-        "pageInfo": pageInfo,
+        "friends": friends as JSONValue,
+        "pageInfo": pageInfo as JSONValue,
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friendsConnection": friendsConnection,
+        "friendsConnection": friendsConnection as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [
@@ -92,12 +92,12 @@ extension Mocks.Hero.FriendsQuery {
     let query = MockQuery<Mocks.Hero.FriendsQuery>()
     query.__variables = ["id": "2001", "first": 2, "after": GraphQLNullable<String>.null]
     return await server.expect(query) { _ in
-      let pageInfo: [AnyHashable: AnyHashable] = [
+      let pageInfo: JSONObject = [
         "__typename": "PageInfo",
         "endCursor": "Y3Vyc29yMg==",
         "hasNextPage": true,
       ]
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Luke Skywalker",
@@ -109,22 +109,22 @@ extension Mocks.Hero.FriendsQuery {
           "id": "1002",
         ],
       ]
-      let friendsConnection: [String: AnyHashable] = [
+      let friendsConnection: JSONObject = [
         "__typename": "FriendsConnection",
         "totalCount": 3,
-        "friends": friends,
-        "pageInfo": pageInfo,
+        "friends": friends as JSONValue,
+        "pageInfo": pageInfo as JSONValue,
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friendsConnection": friendsConnection,
+        "friendsConnection": friendsConnection as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [
@@ -181,34 +181,34 @@ extension Mocks.Hero.ReverseFriendsQuery {
     let query = MockQuery<Mocks.Hero.ReverseFriendsQuery>()
     query.__variables = ["id": "2001", "first": 2, "before": "Y3Vyc29yMg=="]
     return await server.expect(query) { _ in
-      let pageInfo: [AnyHashable: AnyHashable] = [
+      let pageInfo: JSONObject = [
         "__typename": "PageInfo",
         "startCursor": "Y3Vyc29yZg==",
         "hasPreviousPage": false,
       ]
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Luke Skywalker",
           "id": "1000",
         ],
       ]
-      let friendsConnection: [String: AnyHashable] = [
+      let friendsConnection: JSONObject = [
         "__typename": "FriendsConnection",
         "totalCount": 3,
-        "friends": friends,
-        "pageInfo": pageInfo,
+        "friends": friends as JSONValue,
+        "pageInfo": pageInfo as JSONValue,
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friendsConnection": friendsConnection,
+        "friendsConnection": friendsConnection as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [
@@ -220,12 +220,12 @@ extension Mocks.Hero.ReverseFriendsQuery {
     let query = MockQuery<Mocks.Hero.ReverseFriendsQuery>()
     query.__variables = ["id": "2001", "first": 2, "before": "Y3Vyc29yMw=="]
     return await server.expect(query) { _ in
-      let pageInfo: [AnyHashable: AnyHashable] = [
+      let pageInfo: JSONObject = [
         "__typename": "PageInfo",
         "startCursor": "Y3Vyc29yMg==",
         "hasPreviousPage": true,
       ]
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Han Solo",
@@ -237,22 +237,22 @@ extension Mocks.Hero.ReverseFriendsQuery {
           "id": "1003",
         ],
       ]
-      let friendsConnection: [String: AnyHashable] = [
+      let friendsConnection: JSONObject = [
         "__typename": "FriendsConnection",
         "totalCount": 3,
-        "friends": friends,
-        "pageInfo": pageInfo,
+        "friends": friends as JSONValue,
+        "pageInfo": pageInfo as JSONValue,
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friendsConnection": friendsConnection,
+        "friendsConnection": friendsConnection as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [
@@ -267,36 +267,36 @@ extension Mocks.Hero.BidirectionalFriendsQuery {
     let query = MockQuery<Mocks.Hero.BidirectionalFriendsQuery>()
     query.__variables = ["id": "2001", "first": 1, "before": GraphQLNullable<String>.null, "after": "Y3Vyc29yMw=="]
     return await server.expect(query) { _ in
-      let pageInfo: [AnyHashable: AnyHashable] = [
+      let pageInfo: JSONObject = [
         "__typename": "PageInfo",
         "startCursor": "Y3Vyc29yMw==",
         "hasPreviousPage": true,
         "endCursor": "Y3Vyc29yMg==",
         "hasNextPage": true,
       ]
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Leia Organa",
           "id": "1003",
         ],
       ]
-      let friendsConnection = [
+      let friendsConnection: JSONObject = [
         "__typename": "FriendsConnection",
         "totalCount": 3,
-        "friends": friends,
-        "pageInfo": pageInfo,
+        "friends": friends as JSONValue,
+        "pageInfo": pageInfo as JSONValue,
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friendsConnection": friendsConnection,
+        "friendsConnection": friendsConnection as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [
@@ -309,36 +309,36 @@ extension Mocks.Hero.BidirectionalFriendsQuery {
     let query = MockQuery<Mocks.Hero.BidirectionalFriendsQuery>()
     query.__variables = ["id": "2001", "first": 1, "after": "Y3Vyc29yMg==", "before": GraphQLNullable<String>.null]
     return await server.expect(query) { _ in
-      let pageInfo: [AnyHashable: AnyHashable] = [
+      let pageInfo: JSONObject = [
         "__typename": "PageInfo",
         "startCursor": "Y3Vyc29yMg==",
         "hasPreviousPage": true,
         "endCursor": "Y3Vyc29yMa==",
         "hasNextPage": false,
       ]
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Han Solo",
           "id": "1002",
         ],
       ]
-      let friendsConnection: [String: AnyHashable] = [
+      let friendsConnection: JSONObject = [
         "__typename": "FriendsConnection",
         "totalCount": 3,
-        "friends": friends,
-        "pageInfo": pageInfo,
+        "friends": friends as JSONValue,
+        "pageInfo": pageInfo as JSONValue,
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friendsConnection": friendsConnection,
+        "friendsConnection": friendsConnection as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [
@@ -351,36 +351,36 @@ extension Mocks.Hero.BidirectionalFriendsQuery {
     let query = MockQuery<Mocks.Hero.BidirectionalFriendsQuery>()
     query.__variables = ["id": "2001", "first": 1, "before": "Y3Vyc29yMw==", "after": GraphQLNullable<String>.null]
     return await server.expect(query) { _ in
-      let pageInfo: [AnyHashable: AnyHashable] = [
+      let pageInfo: JSONObject = [
         "__typename": "PageInfo",
         "startCursor": "Y3Vyc29yMq==",
         "hasPreviousPage": false,
         "endCursor": "Y3Vyc29yMw==",
         "hasNextPage": true,
       ]
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Luke Skywalker",
           "id": "1000",
         ],
       ]
-      let friendsConnection: [String: AnyHashable] = [
+      let friendsConnection: JSONObject = [
         "__typename": "FriendsConnection",
         "totalCount": 3,
-        "friends": friends,
-        "pageInfo": pageInfo,
+        "friends": friends as JSONValue,
+        "pageInfo": pageInfo as JSONValue,
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friendsConnection": friendsConnection,
+        "friendsConnection": friendsConnection as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [
@@ -395,7 +395,7 @@ extension Mocks.Hero.OffsetFriendsQuery {
     let query = MockQuery<Mocks.Hero.OffsetFriendsQuery>()
     query.__variables = ["id": "2001", "offset": 0, "limit": 2]
     return await server.expect(query) { _ in
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Luke Skywalker",
@@ -408,15 +408,15 @@ extension Mocks.Hero.OffsetFriendsQuery {
         ],
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friends": friends,
+        "friends": friends as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [
@@ -429,7 +429,7 @@ extension Mocks.Hero.OffsetFriendsQuery {
     let query = MockQuery<Mocks.Hero.OffsetFriendsQuery>()
     query.__variables = ["id": "2001", "offset": 2, "limit": 2]
     return await server.expect(query) { _ in
-      let friends: [[String: AnyHashable]] = [
+      let friends: [JSONObject] = [
         [
           "__typename": "Human",
           "name": "Leia Organa",
@@ -437,15 +437,15 @@ extension Mocks.Hero.OffsetFriendsQuery {
         ],
       ]
 
-      let hero = [
+      let hero: JSONObject = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
-        "friends": friends,
+        "friends": friends as JSONValue,
       ]
 
-      let data = [
-        "hero": hero
+      let data: JSONObject = [
+        "hero": hero as JSONValue
       ]
 
       return [

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -143,7 +143,7 @@ class JSONTests: XCTestCase {
       }
     }
 
-    let jsonObj: [String: AnyHashable] = [
+    let jsonObj: JSONObject = [
       "hero": [
         "name": "Luke Skywalker",
         "__typename": "Human"

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+AnimalKingdomAPI.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+AnimalKingdomAPI.swift
@@ -20,7 +20,7 @@ extension Target {
         .folderReference(path: "Sources/\(target.name)/animalkingdom-graphql")
       ]),
       dependencies: [
-        .package(product: "ApolloAPI")
+        .target(name: ApolloTarget.apolloWrapper.name)
       ],
       settings: .forTarget(target)
     )

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloCodegenInternalTestHelpers.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloCodegenInternalTestHelpers.swift
@@ -22,7 +22,6 @@ extension Target {
       dependencies: [
         .target(name: ApolloTarget.apolloCodegenLibWrapper.name),
         .target(name: ApolloTarget.apolloInternalTestHelpers.name),
-        .package(product: "OrderedCollections")        
       ],
       settings: .forTarget(target)
     )

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloCodegenTests.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloCodegenTests.swift
@@ -22,7 +22,6 @@ extension Target {
         .target(name: ApolloTarget.apolloCodegenInternalTestHelpers.name),
         .target(name: ApolloTarget.apolloCodegenLibWrapper.name),
         .target(name: ApolloTarget.apolloInternalTestHelpers.name),
-        .package(product: "OrderedCollections"),
         .package(product: "Nimble"),
       ],
       settings: .forTarget(target)

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloInternalTestHelpers.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloInternalTestHelpers.swift
@@ -20,9 +20,6 @@ extension Target {
       ]),
       dependencies: [
         .target(name: ApolloTarget.apolloWrapper.name),
-        .package(product: "ApolloAPI"),
-        .package(product: "ApolloSQLite"),
-        .package(product: "ApolloWebSocket"),
       ],
       settings: .forTarget(target)
     )

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloPaginationTests.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloPaginationTests.swift
@@ -16,10 +16,7 @@ extension Target {
             ],
             dependencies: [
                 .target(name: ApolloTarget.apolloInternalTestHelpers.name),
-                .package(product: "Apollo"),
-                .package(product: "ApolloAPI"),
-                .package(product: "ApolloTestSupport"),
-                .package(product: "ApolloPagination"),
+                .target(name: ApolloTarget.apolloWrapper.name),
                 .package(product: "Nimble")
             ],
             settings: .forTarget(target)

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloPerformanceTests.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloPerformanceTests.swift
@@ -22,7 +22,7 @@ extension Target {
         .target(name: ApolloTarget.apolloInternalTestHelpers.name),
         .target(name: ApolloTarget.animalKingdomAPI.name),
         .target(name: ApolloTarget.gitHubAPI.name),
-        .package(product: "Apollo"),
+        .target(name: ApolloTarget.apolloWrapper.name),
         .package(product: "Nimble"),
       ],
       settings: .forTarget(target)

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloTests.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloTests.swift
@@ -19,10 +19,7 @@ extension Target {
         .target(name: ApolloTarget.apolloInternalTestHelpers.name),
         .target(name: ApolloTarget.starWarsAPI.name),
         .target(name: ApolloTarget.uploadAPI.name),
-        .package(product: "Apollo"),
-        .package(product: "ApolloSQLite"),
-        .package(product: "ApolloWebSocket"),
-        .package(product: "ApolloTestSupport"),
+        .target(name: ApolloTarget.apolloWrapper.name),
         .package(product: "Nimble"),
       ],
       settings: .forTarget(target)

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloWrapper.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+ApolloWrapper.swift
@@ -12,8 +12,19 @@ extension Target {
       bundleId: "com.apollographql.\(target.name.lowercased())",
       deploymentTargets: target.deploymentTargets,
       infoPlist: .file(path: "Tests/\(target.name)/Info.plist"),
+      // This wrapper must be the ONLY target in the workspace that links the apollo package
+      // products. SPM library products are static, so every target that links one embeds its own
+      // copy of the module — including duplicate copies of each type's runtime metadata. Dynamic
+      // casts (e.g. `as? DataDict`) compare nominal type descriptors by pointer, so a value
+      // created in one image fails to cast in another. All other targets must depend on this
+      // framework (directly or transitively) so exactly one copy of each module exists at runtime.
       dependencies: [
-        .package(product: "Apollo")
+        .package(product: "Apollo"),
+        .package(product: "ApolloAPI"),
+        .package(product: "ApolloSQLite"),
+        .package(product: "ApolloWebSocket"),
+        .package(product: "ApolloTestSupport"),
+        .package(product: "ApolloPagination"),
       ],
       settings: .forTarget(target)
     )

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+CodegenCLITests.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+CodegenCLITests.swift
@@ -20,7 +20,7 @@ extension Target {
       ],
       dependencies: [
         .target(name: ApolloTarget.apolloInternalTestHelpers.name),
-        .package(product: "Apollo"),
+        .target(name: ApolloTarget.apolloWrapper.name),
         .package(product: "CodegenCLI"),
         .package(product: "Nimble"),
       ],

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+GitHubAPI.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+GitHubAPI.swift
@@ -16,7 +16,7 @@ extension Target {
                 "Sources/\(target.name)/\(target.name)/Sources/**"
             ],
             dependencies: [
-                .package(product: "ApolloAPI")
+                .target(name: ApolloTarget.apolloWrapper.name)
             ],
             settings: .forTarget(target)
         )

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+StarWarsAPI.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+StarWarsAPI.swift
@@ -19,7 +19,7 @@ extension Target {
         .folderReference(path: "Sources/\(target.name)/starwars-graphql")
       ]),
       dependencies: [
-        .package(product: "ApolloAPI")
+        .target(name: ApolloTarget.apolloWrapper.name)
       ],
       settings: .forTarget(target)
     )

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+SubscriptionAPI.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+SubscriptionAPI.swift
@@ -19,7 +19,7 @@ extension Target {
         .folderReference(path: "Sources/\(target.name)/graphql")
       ]),
       dependencies: [
-        .package(product: "ApolloAPI")
+        .target(name: ApolloTarget.apolloWrapper.name)
       ],
       settings: .forTarget(target)
     )

--- a/Tuist/ProjectDescriptionHelpers/Targets/Target+UploadAPI.swift
+++ b/Tuist/ProjectDescriptionHelpers/Targets/Target+UploadAPI.swift
@@ -16,7 +16,7 @@ extension Target {
         "Sources/\(target.name)/\(target.name)/Sources/**"
       ],
       dependencies: [
-        .package(product: "ApolloAPI")
+        .target(name: ApolloTarget.apolloWrapper.name)
       ],
       settings: .forTarget(target)
     )

--- a/apollo-ios/Sources/Apollo/SelectionSet+DictionaryIntializer.swift
+++ b/apollo-ios/Sources/Apollo/SelectionSet+DictionaryIntializer.swift
@@ -36,8 +36,10 @@ extension RootSelectionSet {
       } else  {
         if let dictValue = value as? [String: Any] {
           result[key] = try convertToAnyHashableValueDict(dict: dictValue) as JSONValue
-        } else if let hashableValue = value as? AnyHashable {
-          result[key] = hashableValue as JSONValue
+        } else if case let jsonValue as JSONValue = value {
+          // A type cast pattern is used here because `AnyHashable`'s `Sendable` conformance is
+          // explicitly unavailable, making `as?`/`as` casts to `JSONValue` ill-formed.
+          result[key] = jsonValue
         } else {
           throw RootSelectionSetInitializeError.hasNonHashableValue
         }
@@ -56,8 +58,10 @@ extension RootSelectionSet {
         result.append(try convertToAnyHashableArray(array: array) as JSONValue)
       } else if let dict = value as? [String: Any] {
         result.append(try convertToAnyHashableValueDict(dict: dict) as JSONValue)
-      } else if let hashable = value as? AnyHashable {
-        result.append(hashable as JSONValue)
+      } else if case let jsonValue as JSONValue = value {
+        // A type cast pattern is used here because `AnyHashable`'s `Sendable` conformance is
+        // explicitly unavailable, making `as?`/`as` casts to `JSONValue` ill-formed.
+        result.append(jsonValue)
       } else {
         throw RootSelectionSetInitializeError.hasNonHashableValue
       }

--- a/apollo-ios/Sources/ApolloTestSupport/TestMock.swift
+++ b/apollo-ios/Sources/ApolloTestSupport/TestMock.swift
@@ -102,7 +102,15 @@ public class Mock<O: MockObject>: AnyMock, Hashable {
       if let mockArray = $0 as? Array<Any> {
         return mockArray._unsafelyConvertToSelectionSetData() as JSONValue
       }
-      return $0 as JSONValue
+      // `AnyHashable`'s `Sendable` conformance is explicitly unavailable, so it cannot be cast
+      // to `JSONValue` directly. Numeric values are converted through `NSNumber` to preserve the
+      // type-promiscuous casting (e.g. `Int32` to `Int`) that `AnyHashable` storage previously
+      // provided. The base of an `AnyHashable` is always `Hashable`, so the forced cast in the
+      // fallback will never fail.
+      if let number = $0.base as? NSNumber {
+        return number as JSONValue
+      }
+      return $0.base as! JSONValue
     }
   }
 

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketConnection.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketConnection.swift
@@ -60,7 +60,7 @@ final class WebSocketConnection: Sendable {
   }
 
   func send(_ message: URLSessionWebSocketTask.Message) {
-    Task {
+    _ = Task {
       try await webSocketTask.send(message)
     }
   }


### PR DESCRIPTION
I'm not 100% happy with the changes here but they unblock testing for me.

Some of the challenges I ran into once I got the source + tests to compile was the issue where Xcode 27 in the test bundles would complain that two copies of types came from different sources -- `tuist generate` has warnings around this.

Posting as draft so that other people can potentially use it and perhaps the maintainers can take some of the changes as inspiration for proper fixes.