### PR TITLE
Fix Swift 6.4 (Xcode 27) build: AnyHashable→JSONValue cast

### DIFF
--- a/Tests/ApolloTests/SelectionSet_JSONInitializerTests.swift
+++ b/Tests/ApolloTests/SelectionSet_JSONInitializerTests.swift
@@ -249,4 +249,54 @@ class SelectionSet_JSONInitializerTests: XCTestCase {
     expect(data.asHuman?.friend.asHuman).toNot(beNil())
     expect(data.asHuman?.friend.asHuman?.heroName).to(equal("Han Solo"))
   }
+
+  // MARK: - `[String: Any]` overload
+
+  /// Confirms the `init(data: [String: Any])` overload compiles and works under Swift 6.4, which
+  /// marks the conformance of `AnyHashable` to `Sendable` unavailable. Passing an untyped
+  /// `[String: Any]` (rather than a `JSONObject`) selects the `@_disfavoredOverload` that converts
+  /// values via `convertToAnyHashableValueDict` / `convertToAnyHashableArray`, exercising both the
+  /// scalar-dictionary and scalar-array branches that cast `AnyHashable` to `JSONValue`.
+  func test__initFromAnyDictionary__withScalarAndScalarListValues_buildsSelectionSet() async throws {
+    // given
+    struct Types {
+      static let Human = Object(typename: "Human", implementedInterfaces: [])
+    }
+
+    MockSchemaMetadata.stub_objectTypeForTypeName({
+      switch $0 {
+      case "Human": return Types.Human
+      default: XCTFail(); return nil
+      }
+    })
+
+    class Hero: MockSelectionSet, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: any ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("__typename", String.self),
+        .field("name", String.self),
+        .field("appearsIn", [String].self),
+      ]}
+
+      var name: String { __data["name"] }
+      var appearsIn: [String] { __data["appearsIn"] }
+    }
+
+    // An untyped `[String: Any]` selects `init(data: [String: Any])`, not the typed `JSONObject`
+    // overload.
+    let anyDictionary: [String: Any] = [
+      "__typename": "Human",
+      "name": "Luke Skywalker",
+      "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
+    ]
+
+    // when
+    let data = try await Hero(data: anyDictionary)
+
+    // then
+    expect(data.name).to(equal("Luke Skywalker"))
+    expect(data.appearsIn).to(equal(["NEWHOPE", "EMPIRE", "JEDI"]))
+  }
 }

--- a/apollo-ios/Sources/Apollo/SelectionSet+DictionaryIntializer.swift
+++ b/apollo-ios/Sources/Apollo/SelectionSet+DictionaryIntializer.swift
@@ -37,7 +37,10 @@ extension RootSelectionSet {
         if let dictValue = value as? [String: Any] {
           result[key] = try convertToAnyHashableValueDict(dict: dictValue) as JSONValue
         } else if let hashableValue = value as? AnyHashable {
-          result[key] = hashableValue as JSONValue
+          // `AnyHashable: Sendable` is unavailable as of Swift 6.4, so a static `as JSONValue`
+          // (any Sendable & Hashable) coercion no longer compiles. Force-cast instead, matching
+          // the existing `as! JSONValue` usage in JSONSerializationFormat.
+          result[key] = hashableValue as! JSONValue
         } else {
           throw RootSelectionSetInitializeError.hasNonHashableValue
         }
@@ -57,7 +60,8 @@ extension RootSelectionSet {
       } else if let dict = value as? [String: Any] {
         result.append(try convertToAnyHashableValueDict(dict: dict) as JSONValue)
       } else if let hashable = value as? AnyHashable {
-        result.append(hashable as JSONValue)
+        // See note above: `AnyHashable: Sendable` is unavailable as of Swift 6.4.
+        result.append(hashable as! JSONValue)
       } else {
         throw RootSelectionSetInitializeError.hasNonHashableValue
       }


### PR DESCRIPTION
## Problem

Building Apollo with **Swift 6.4 (Xcode 27)** fails to compile:

```
SelectionSet+DictionaryIntializer.swift:40:25: error: conformance of 'AnyHashable' to 'Sendable' is unavailable
SelectionSet+DictionaryIntializer.swift:60:23: error: conformance of 'AnyHashable' to 'Sendable' is unavailable
Swift.AnyHashable:2:11: note: conformance of 'AnyHashable' to 'Sendable' has been explicitly marked unavailable here
```

Swift 6.4 marks `AnyHashable`'s `Sendable` conformance **explicitly unavailable**. In the `init(data: [String: Any])` overload, `convertToAnyHashableValueDict` / `convertToAnyHashableArray` cast `AnyHashable` to `JSONValue` (`any Sendable & Hashable`) with a static `as`, which now requires that unavailable conformance. Because it's a type-check error (not a strict-concurrency diagnostic), it can't be silenced with a build setting, and the `Apollo` target builds in Swift 6 language mode. It does not reproduce on Swift 6.3 / Xcode 26.5.

## Fix

Switch the two `AnyHashable → JSONValue` coercions from `as` to a forced cast `as!`, matching the existing `as! JSONValue` usage in `JSONSerializationFormat.swift`. A forced cast compiles because the `Sendable` marker isn't checked at runtime, and JSON scalar values are always `Sendable`, so it's safe.

```diff
- result[key] = hashableValue as JSONValue
+ result[key] = hashableValue as! JSONValue
...
- result.append(hashable as JSONValue)
+ result.append(hashable as! JSONValue)
```

## Test

Adds `test__initFromAnyDictionary__withScalarAndScalarListValues_buildsSelectionSet` to `SelectionSet_JSONInitializerTests`. The existing tests pass a typed `JSONObject`, which resolves to the typed `init` overload — so the `@_disfavoredOverload` `init(data: [String: Any])` (and these two casts) had no coverage. The new test passes an untyped `[String: Any]` with a scalar field and a scalar list, exercising both the dictionary and array scalar branches.

## Verification

I verified the source fix compiles and a real consumer app builds with **Xcode 27 (Swift 6.4)** and still builds on **Xcode 26.5 (Swift 6.3.2)**. I wasn't able to run the full `apollo-ios-dev` test suite locally (no Tuist setup on hand), so I kept the test minimal and modeled on the existing tests — happy to adjust to your conventions.