### PR TITLE
Fix apollo-ios-cli initialization command in documentation

### DIFF
--- a/docs/source/tutorial/tutorial-add-graphql-schema.mdx
+++ b/docs/source/tutorial/tutorial-add-graphql-schema.mdx
@@ -31,7 +31,7 @@ In the **Reference** tab, you can now see a list of all of the things available 
 Next we need to setup our [codegen configuration](https://www.apollographql.com/docs/ios/code-generation/codegen-configuration) file. To do this run the following command in Terminal from project directory:
 
 ```bash
-./apollo-ios-cli init --schema-namespace RocketReserverAPI --module-type swiftPackage
+./apollo-ios-cli init --schema-namespace RocketReserverAPI --module-type swiftPackageManager
 ```
 
 This generates a basic `apollo-codegen-config.json` file for our project.


### PR DESCRIPTION
The current documentation specifies --module-type swiftPackage, which causes an error during apollo-ios-cli initialization because the correct value is swiftPackageManager. I have updated the command to reflect the correct parameter value required by the CLI.