### PR TITLE
fix(docs): correct method call in LaunchListView .task snippet (Section 6)

### DIFF
--- a/docs/source/tutorial/tutorial-connect-queries-to-ui.mdx
+++ b/docs/source/tutorial/tutorial-connect-queries-to-ui.mdx
@@ -73,7 +73,7 @@ The last step is to call the `loadMoreLaunches` method we updated earlier to act
 
 ```swift title="LaunchListView.swift"
 .task {
-    await viewModel.loadMoreLaunchesIfTheyExist() // highlight-line
+    await viewModel.loadMoreLaunches() // highlight-line
 }
 ```
 


### PR DESCRIPTION
The code snippet for the `.task` modifier in `LaunchListView` mistakenly called `loadMoreLaunchesIfTheyExist()` instead of `loadMoreLaunches()`. Because the former is empty at this point in the tutorial, the UI would not load any data. This PR aligns the code snippet with the preceding text instructions.