### PR TITLE
docs: add missing await keyword in pagination tutorial snippet

### DIFF
--- a/docs/source/tutorial/tutorial-paginate-results.mdx
+++ b/docs/source/tutorial/tutorial-paginate-results.mdx
@@ -100,7 +100,7 @@ Next, go to `LaunchListView` and update our task to call the newly implemented `
 
 ```swift title="LaunchListView.swift"
 .task {
-    viewModel.loadMoreLaunchesIfTheyExist() // highlight-line
+    await viewModel.loadMoreLaunchesIfTheyExist() // highlight-line
 }
 ```
 


### PR DESCRIPTION
In the "Paginate results" section of the iOS tutorial, the code snippet demonstrating how to call `viewModel.loadMoreLaunchesIfTheyExist()` inside the `.task` modifier is missing the required `await` keyword.

Since `loadMoreLaunchesIfTheyExist()` is an asynchronous method, omitting `await` results in a compiler error for readers. This PR corrects the code snippet to include `await`, ensuring it compiles successfully and matches the implementation in the final project repository.