### PR TITLE
Fix(doc): Add missing 'await' keywords in bookOrCancel() method

### DIFF
--- a/docs/source/tutorial/tutorial-define-additional-mutations.mdx
+++ b/docs/source/tutorial/tutorial-define-additional-mutations.mdx
@@ -200,7 +200,7 @@ guard let launch = launch else {
     return
 }
         
-launch.isBooked ? cancelTrip(with: launch.id) : bookTrip(with: launch.id)
+launch.isBooked ? await cancelTrip(with: launch.id) : await bookTrip(with: launch.id)
 ```
 
 Now build and run the application, if you go to the detail view for any launch and click "Book trip" you should get a message that the trip was successfully booked, but you'll notice that the UI doesn't update, even if you go out of the detail view and back into it again.


### PR DESCRIPTION
Update trip booking logic to use aThis PR fixes a Swift Concurrency compilation error in the `bookOrCancel()` method inside the tutorial code. 

Since both `cancelTrip(with:)` and `bookTrip(with:)` are declared as `async` functions, they must be awaited when called. When using a ternary conditional operator, the `await` keyword needs to be explicitly placed before each asynchronous function call.wait for async calls.