### PR TITLE
ci: fix subtree push segfaults and restore fast splits (ubuntu runners + vendored git-subtree v2.53)

### DIFF
--- a/.github/actions/subtree-split-push/action.yml
+++ b/.github/actions/subtree-split-push/action.yml
@@ -30,9 +30,8 @@ runs:
       PR_TITLE: ${{ inputs.pr-title }}
     run: |
       echo "git: $(git --version)"
-      # git-subtree is a bash script that can recurse thousands of frames deep
-      # when a subtree's rejoin anchor is stale (its walk grows with repo
-      # history). Remove the stack ceiling so deep walks cost time, never a
+      # git-subtree is a bash script that can recurse thousands of frames
+      # deep. Remove the stack ceiling so deep walks cost time, never a
       # segfault. See claude/ci-subtree-troubleshooting.md (July 2026 incident).
       ulimit -s unlimited 2>/dev/null || ulimit -s "$(ulimit -Hs)" || true
       # Fetch upstream for diagnostic visibility in logs. We do NOT pull —
@@ -42,5 +41,30 @@ runs:
       # See claude/ci-subtree-troubleshooting.md for the "stale upstream" incident
       # that motivated removing the pull.
       git fetch ${{ inputs.remote }} ${{ inputs.target-branch }}
-      splitResult=$(git subtree -P ${{ inputs.subtree }} split --squash --rejoin -m "split: ${{ inputs.subtree }} - PR #${{ inputs.pr-number }} - $PR_TITLE")
+      # Split with the vendored git-subtree from git v2.53.0 rather than the
+      # runner's `git subtree`: git >= 2.54 removed the multi-subtree walk
+      # optimization, making each split crawl the entire repo history (slow,
+      # growing forever). See scripts/vendor/README.md for provenance and the
+      # full rationale. The script needs GIT_EXEC_PATH to source git-sh-setup.
+      export GIT_EXEC_PATH="$(git --exec-path)"
+      export PATH="$GIT_EXEC_PATH:$PATH"
+      # When the subtree has no new changes, the script prints "Subtree is
+      # already at commit <sha>" to stderr and exits 0 with EMPTY stdout —
+      # that empty split_sha is the action's existing "nothing to push"
+      # contract, honored by the workflow's push step.
+      splitResult=$(bash "$GITHUB_WORKSPACE/scripts/vendor/git-subtree-2.53.0.sh" split --prefix=${{ inputs.subtree }} --squash --rejoin -m "split: ${{ inputs.subtree }} - PR #${{ inputs.pr-number }} - $PR_TITLE")
+      if [ -n "$splitResult" ]; then
+        # Safety net for the v2.53 optimization's known edge cases: the split
+        # commit's tree must exactly equal the subtree directory's tree in
+        # HEAD. A miscomputed split fails here, loudly, before any push.
+        splitTree=$(git rev-parse "$splitResult^{tree}")
+        subtreeTree=$(git rev-parse "HEAD:${{ inputs.subtree }}")
+        if [ "$splitTree" != "$subtreeTree" ]; then
+          echo "::error::Split verification failed for ${{ inputs.subtree }}: split commit tree $splitTree != HEAD:${{ inputs.subtree }} tree $subtreeTree. Not pushing."
+          exit 1
+        fi
+        echo "Split verified: tree $splitTree matches HEAD:${{ inputs.subtree }}"
+      else
+        echo "No new changes for ${{ inputs.subtree }}; nothing to push."
+      fi
       echo "split_sha=$splitResult" >> $GITHUB_OUTPUT

--- a/.github/actions/subtree-split-push/action.yml
+++ b/.github/actions/subtree-split-push/action.yml
@@ -30,6 +30,11 @@ runs:
       PR_TITLE: ${{ inputs.pr-title }}
     run: |
       echo "git: $(git --version)"
+      # git-subtree is a bash script that can recurse thousands of frames deep
+      # when a subtree's rejoin anchor is stale (its walk grows with repo
+      # history). Remove the stack ceiling so deep walks cost time, never a
+      # segfault. See claude/ci-subtree-troubleshooting.md (July 2026 incident).
+      ulimit -s unlimited 2>/dev/null || ulimit -s "$(ulimit -Hs)" || true
       # Fetch upstream for diagnostic visibility in logs. We do NOT pull —
       # the dev repo is the only writer to upstream subtree repos, so a pull
       # would only ever do work in degenerate cases (and historically caused

--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -17,7 +17,10 @@ on:
 jobs:
   split-subtrees:
     if: ${{ github.event.pull_request.merged }}
-    runs-on: macos-latest
+    # This job only needs git + ssh — do NOT use macos-latest. The macos-26
+    # image (July 2026 rollover) segfaults in `git subtree split` (Homebrew
+    # git-subtree bash script, exit 139). See claude/ci-subtree-troubleshooting.md.
+    runs-on: ubuntu-latest
     name: Split and Push Subtrees
     outputs:
       releaseVersion: ${{ steps.getVersion.outputs.RELEASE_VERSION }}
@@ -93,7 +96,7 @@ jobs:
   publish-release:
     if: success('split-subtrees') && startsWith(github.ref, 'refs/heads/release/')
     needs: split-subtrees
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     name: Publish Release
     steps:
       - name: Checkout Repo

--- a/claude/ci-subtree-troubleshooting.md
+++ b/claude/ci-subtree-troubleshooting.md
@@ -22,7 +22,10 @@ The action used to run `git subtree pull --squash` before `split`. That step exi
 
 ## Historical incident: macos-26 runner segfault in `git subtree split` (July 2026)
 
-**How it happened:** GitHub rolled the `macos-latest` label over from `macos-15-arm64` to `macos-26-arm64`. On the macos-26 image, `git subtree split` (a bash script from Homebrew git, same git 2.55.0 as the working image) segfaulted mid-split with exit code 139:
+**How it happened:** Two independent changes intersected.
+
+1. **git 2.54.0 removed the multi-subtree walk optimization.** Upstream commit [`1f70684b51`](https://github.com/git/git/commit/1f70684b51) (Feb 2026) deliberately removed `should_ignore_subtree_split_commit` — the logic that skipped *other* subtrees' split/squash commits during a split — because it could incorrectly exclude commits and alter split hashes (an API contract violation). The consequence for multi-subtree repos like this one: each split now crawls essentially the **entire repo history** as "extra" commits, every run, and that crawl grows with every merged PR. Measured on a July 2026 run (git 2.55, ~5,500 commits on main): apollo-ios walked ~300 commits, codegen ~3,500, pagination ~3,900. On git ≤2.53 (including Apple/Xcode git 2.50) the same pagination split walks ~130 commits with zero extras. This crawl is deep bash recursion in the `git-subtree` script — one stack frame chain per uncached ancestry run.
+2. **GitHub rolled `macos-latest` over to `macos-26-arm64`** (June 2026). Same Bash 3.2.57 and git 2.55.0 as macos-15, but the recompiled system bash and/or default stack rlimit on the new image tolerates less recursion depth. The ~1,900-frame-deep crawl that (barely) fit on macos-15 segfaulted on macos-26:
 
 ```
 /opt/homebrew/opt/git/libexec/git-core/git-subtree: line 925: 12196 Done    eval "$grl"
@@ -35,7 +38,11 @@ During the label rollover, runs landed on either image at random, so failures lo
 
 **Impact:** None to repair. `Push Subtrees` is gated on `if: success()`, so failed runs pushed nothing and no rejoin metadata reached `main`. The missed subtree commits were carried upstream automatically by the next successful run (splits walk full history).
 
-**Fix:** Moved the workflow's jobs to `runs-on: ubuntu-latest`. The job only needs git and ssh — nothing macOS-specific — and Linux runners avoid both the macOS image churn and Homebrew git drift. Do not move these jobs back to macOS runners.
+**Fix:** Moved the workflow's jobs to `runs-on: ubuntu-latest` (nothing in them is macOS-specific) and added `ulimit -s unlimited` before the split in the `subtree-split-push` action, which Linux permits — deep crawls now cost minutes, never a segfault. Do not move these jobs back to macOS runners.
+
+**Residual issue:** the O(full-history) crawl per split is upstream git's intended behavior as of 2.54 — split wall-clock time grows with repo history forever. If runs get too slow, the candidate escape hatch is [`splitsh-lite`](https://github.com/splitsh/lite) (a C/libgit2 splitter that claims hash-compatibility with `git subtree split`, used by Symfony's monorepo, walks full history in seconds and supports a persistent cache). Verify hash-compatibility against the existing upstream heads before switching — a mismatched split SHA would push non-fast-forward.
+
+**⚠️ Local vs CI git divergence:** Apple/Xcode git (2.50.x as of this writing) still contains the removed optimization — the one upstream deleted *because it can compute incorrect split hashes*. Prefer git ≥2.54 (e.g. `brew install git`) when performing any local recovery split intended to be pushed upstream; CI's hashes are the canonical ones.
 
 ## Historical incident: stale-upstream pull conflict (May 2026)
 

--- a/claude/ci-subtree-troubleshooting.md
+++ b/claude/ci-subtree-troubleshooting.md
@@ -38,11 +38,15 @@ During the label rollover, runs landed on either image at random, so failures lo
 
 **Impact:** None to repair. `Push Subtrees` is gated on `if: success()`, so failed runs pushed nothing and no rejoin metadata reached `main`. The missed subtree commits were carried upstream automatically by the next successful run (splits walk full history).
 
-**Fix:** Moved the workflow's jobs to `runs-on: ubuntu-latest` (nothing in them is macOS-specific) and added `ulimit -s unlimited` before the split in the `subtree-split-push` action, which Linux permits — deep crawls now cost minutes, never a segfault. Do not move these jobs back to macOS runners.
+**Fix (PR #1047):** Three layers.
 
-**Residual issue:** the O(full-history) crawl per split is upstream git's intended behavior as of 2.54 — split wall-clock time grows with repo history forever. If runs get too slow, the candidate escape hatch is [`splitsh-lite`](https://github.com/splitsh/lite) (a C/libgit2 splitter that claims hash-compatibility with `git subtree split`, used by Symfony's monorepo, walks full history in seconds and supports a persistent cache). Verify hash-compatibility against the existing upstream heads before switching — a mismatched split SHA would push non-fast-forward.
+1. Moved the workflow's jobs to `runs-on: ubuntu-latest` (nothing in them is macOS-specific). Do not move these jobs back to macOS runners.
+2. Added `ulimit -s unlimited` before the split (Linux permits it) — a deep walk can now cost time, never a segfault.
+3. Vendored `git-subtree.sh` from git v2.53.0 at `scripts/vendor/git-subtree-2.53.0.sh` — the last version with the multi-subtree optimization — and pointed the `subtree-split-push` action at it. Splits are back to ~12s each with a walk that stays flat as history grows. Verified before adoption: it reproduces the exact upstream head SHAs for all three subtrees. The action asserts after every split that the split commit's tree equals `HEAD:<subtree>`, so the optimization's known edge cases (which require merge topologies this repo doesn't produce) would fail loudly before any push. See `scripts/vendor/README.md` for full provenance and rationale.
 
-**⚠️ Local vs CI git divergence:** Apple/Xcode git (2.50.x as of this writing) still contains the removed optimization — the one upstream deleted *because it can compute incorrect split hashes*. Prefer git ≥2.54 (e.g. `brew install git`) when performing any local recovery split intended to be pushed upstream; CI's hashes are the canonical ones.
+**Rejected alternative:** [`splitsh-lite`](https://github.com/splitsh/lite) — unmaintained (archived git2go binding pinned to libgit2 1.5) and empirically NOT hash-compatible with this repo's squash-based history (produced a different apollo-ios split SHA). Do not revisit it.
+
+**⚠️ Local vs CI git divergence:** different git versions implement `subtree split` differently (the optimization was present ≤2.53, removed in 2.54). Both algorithms have so far agreed on this repo's history, but for any local recovery split intended to be pushed upstream, use the vendored script (`scripts/vendor/git-subtree-2.53.0.sh`, with `GIT_EXEC_PATH="$(git --exec-path)"` exported and on `PATH`) — that is exactly what CI runs, so its hashes are the canonical ones.
 
 ## Historical incident: stale-upstream pull conflict (May 2026)
 

--- a/claude/ci-subtree-troubleshooting.md
+++ b/claude/ci-subtree-troubleshooting.md
@@ -20,6 +20,23 @@ If any step fails, the runner exits without ever pushing the broken rejoin metad
 
 The action used to run `git subtree pull --squash` before `split`. That step existed to defensively bring upstream commits into dev — but in our setup, upstream never has commits dev doesn't, so the pull was always either a no-op or a problem. The May 2026 incident (below) showed it was a self-perpetuating failure source. Removed in PR #990 (or whatever).
 
+## Historical incident: macos-26 runner segfault in `git subtree split` (July 2026)
+
+**How it happened:** GitHub rolled the `macos-latest` label over from `macos-15-arm64` to `macos-26-arm64`. On the macos-26 image, `git subtree split` (a bash script from Homebrew git, same git 2.55.0 as the working image) segfaulted mid-split with exit code 139:
+
+```
+/opt/homebrew/opt/git/libexec/git-core/git-subtree: line 925: 12196 Done    eval "$grl"
+     12197 Segmentation fault: 11  | while read rev parents; do
+    process_split_commit "$rev" "$parents";
+done
+```
+
+During the label rollover, runs landed on either image at random, so failures looked flaky — two PRs failed while one in between succeeded (it happened to get a macos-15 runner).
+
+**Impact:** None to repair. `Push Subtrees` is gated on `if: success()`, so failed runs pushed nothing and no rejoin metadata reached `main`. The missed subtree commits were carried upstream automatically by the next successful run (splits walk full history).
+
+**Fix:** Moved the workflow's jobs to `runs-on: ubuntu-latest`. The job only needs git and ssh — nothing macOS-specific — and Linux runners avoid both the macOS image churn and Homebrew git drift. Do not move these jobs back to macOS runners.
+
 ## Historical incident: stale-upstream pull conflict (May 2026)
 
 Fixed in PR #989; root cause prevention in PR #990 (approx — match by date).

--- a/scripts/push-forked-branch.sh
+++ b/scripts/push-forked-branch.sh
@@ -49,4 +49,15 @@ then
 fi
 
 git fetch $remote
-git subtree push -P $package $remote $branch
+
+# Split with the vendored git-subtree (v2.53.0) instead of the system
+# `git subtree` so local splits produce the same hashes as CI regardless of
+# the locally installed git version. See scripts/vendor/README.md.
+export GIT_EXEC_PATH="$(git --exec-path)"
+export PATH="$GIT_EXEC_PATH:$PATH"
+splitSha=$(bash "$SCRIPT_DIR/vendor/git-subtree-2.53.0.sh" split --prefix=$package) || exit $?
+if [ -z "$splitSha" ]; then
+  echo "Split produced no SHA for $package; refusing to push." >&2
+  exit 1
+fi
+git push $remote "$splitSha:refs/heads/$branch"

--- a/scripts/vendor/README.md
+++ b/scripts/vendor/README.md
@@ -1,0 +1,54 @@
+# Vendored tools
+
+## git-subtree-2.53.0.sh
+
+A pristine, unmodified copy of `contrib/subtree/git-subtree.sh` from git
+**v2.53.0** (GPLv2, © 2009 Avery Pennarun and git contributors).
+
+Verify provenance:
+
+```bash
+curl -s https://raw.githubusercontent.com/git/git/v2.53.0/contrib/subtree/git-subtree.sh | shasum -a 256
+# b7d22f2ab1f30174cb4d5b1b183b062f84f57a88b994ed36a29063d900f37e49
+```
+
+### Why it is vendored
+
+git 2.54.0 removed the `should_ignore_subtree_split_commit` optimization from
+`git subtree split` ([git/git@`1f70684b51`](https://github.com/git/git/commit/1f70684b51))
+because it can miscompute split hashes in exotic merge topologies. The cost of
+that removal for multi-subtree repos like this one: every split crawls the
+entire repo history via deep bash recursion — O(total history) per subtree per
+run, growing forever, and deep enough to segfault bash on some runners (see
+`claude/ci-subtree-troubleshooting.md`, July 2026 incident).
+
+v2.53.0 is the last release with the optimization, including its two rounds of
+fixes (`83f9dad7d6`, `28a7e27cff`). It is the algorithm that produced this
+repo's upstream subtree history for years. Verified July 2026: it reproduces
+the exact upstream head SHAs for all three subtrees in ~12s per split (vs.
+minutes and unbounded growth for git ≥2.54).
+
+### Safety net
+
+The miscompute risk that motivated upstream's removal only manifests in merge
+topologies this repo doesn't produce (main is linear squash merges), and the
+`subtree-split-push` action guards against it anyway: after every split it
+asserts the split commit's tree is identical to the subtree directory's tree
+in HEAD, and a bad split would additionally fail as a non-fast-forward push.
+Wrong output fails loudly before anything is published.
+
+### How it is used
+
+`.github/actions/subtree-split-push/action.yml` invokes this script directly
+(instead of `git subtree`). It requires `GIT_EXEC_PATH` to be set and on
+`PATH` so it can source `git-sh-setup`:
+
+```bash
+export GIT_EXEC_PATH="$(git --exec-path)"
+export PATH="$GIT_EXEC_PATH:$PATH"
+bash scripts/vendor/git-subtree-2.53.0.sh split --prefix=<subtree> --squash --rejoin -m "<msg>"
+```
+
+Do NOT "helpfully" update this file to a newer git version — losing the
+optimization is the whole point of pinning it. If it ever misbehaves, the
+fallback is stock `git subtree split` (slow but correct).

--- a/scripts/vendor/git-subtree-2.53.0.sh
+++ b/scripts/vendor/git-subtree-2.53.0.sh
@@ -1,0 +1,1150 @@
+#!/bin/sh
+#
+# git-subtree.sh: split/join git repositories in subdirectories of this one
+#
+# Copyright (C) 2009 Avery Pennarun <apenwarr@gmail.com>
+#
+
+if test -z "$GIT_EXEC_PATH" || ! test -f "$GIT_EXEC_PATH/git-sh-setup" || {
+	test "${PATH#"${GIT_EXEC_PATH}:"}" = "$PATH" &&
+	test ! "$GIT_EXEC_PATH" -ef "${PATH%%:*}" 2>/dev/null
+}
+then
+	basename=${0##*[/\\]}
+	echo >&2 'It looks like either your git installation or your'
+	echo >&2 'git-subtree installation is broken.'
+	echo >&2
+	echo >&2 "Tips:"
+	echo >&2 " - If \`git --exec-path\` does not print the correct path to"
+	echo >&2 "   your git install directory, then set the GIT_EXEC_PATH"
+	echo >&2 "   environment variable to the correct directory."
+	echo >&2 " - Make sure that your \`$basename\` file is either in your"
+	echo >&2 "   PATH or in your git exec path (\`$(git --exec-path)\`)."
+	echo >&2 " - You should run git-subtree as \`git ${basename#git-}\`,"
+	echo >&2 "   not as \`$basename\`." >&2
+	exit 126
+fi
+
+OPTS_SPEC="\
+git subtree add   --prefix=<prefix> [-S[=<key-id>]] <commit>
+git subtree add   --prefix=<prefix> [-S[=<key-id>]] <repository> <ref>
+git subtree merge --prefix=<prefix> [-S[=<key-id>]] <commit>
+git subtree split --prefix=<prefix> [-S[=<key-id>]] [<commit>]
+git subtree pull  --prefix=<prefix> [-S[=<key-id>]] <repository> <ref>
+git subtree push  --prefix=<prefix> [-S[=<key-id>]] <repository> <refspec>
+--
+h,help!       show the help
+q,quiet!      quiet
+d,debug!      show debug messages
+P,prefix=     the name of the subdir to split out
+ options for 'split' (also: 'push')
+annotate=     add a prefix to commit message of new commits
+b,branch!=    create a new branch from the split subtree
+ignore-joins  ignore prior --rejoin commits
+onto=         try connecting new tree to an existing one
+rejoin        merge the new branch back into HEAD
+ options for 'add' and 'merge' (also: 'pull', 'split --rejoin', and 'push --rejoin')
+squash        merge subtree changes as a single commit
+m,message!=   use the given message as the commit message for the merge commit
+S,gpg-sign?key-id   GPG-sign commits. The keyid argument is optional and defaults to the committer identity
+"
+
+indent=0
+
+# Usage: say [MSG...]
+say () {
+	if test -z "$arg_quiet"
+	then
+		printf '%s\n' "$*"
+	fi
+}
+
+# Usage: debug [MSG...]
+debug () {
+	if test -n "$arg_debug"
+	then
+		printf "%$(($indent * 2))s%s\n" '' "$*" >&2
+	fi
+}
+
+# Usage: progress [MSG...]
+progress () {
+	if test -z "$arg_quiet"
+	then
+		if test -z "$arg_debug"
+		then
+			# Debug mode is off.
+			#
+			# Print one progress line that we keep updating (use
+			# "\r" to return to the beginning of the line, rather
+			# than "\n" to start a new line).  This only really
+			# works when stderr is a terminal.
+			printf "%s\r" "$*" >&2
+		else
+			# Debug mode is on.  The `debug` function is regularly
+			# printing to stderr.
+			#
+			# Don't do the one-line-with-"\r" thing, because on a
+			# terminal the debug output would overwrite and hide the
+			# progress output.  Add a "progress:" prefix to make the
+			# progress output and the debug output easy to
+			# distinguish.  This ensures maximum readability whether
+			# stderr is a terminal or a file.
+			printf "progress: %s\n" "$*" >&2
+		fi
+	fi
+}
+
+# Usage: assert CMD...
+assert () {
+	if ! "$@"
+	then
+		die "fatal: assertion failed: $*"
+	fi
+}
+
+# Usage: die_incompatible_opt OPTION COMMAND
+die_incompatible_opt () {
+	assert test "$#" = 2
+	opt="$1"
+	arg_command="$2"
+	die "fatal: the '$opt' flag does not make sense with 'git subtree $arg_command'."
+}
+
+main () {
+	if test $# -eq 0
+	then
+		set -- -h
+	fi
+	set_args="$(echo "$OPTS_SPEC" | git rev-parse --parseopt --stuck-long -- "$@" || echo exit $?)"
+	eval "$set_args"
+	. git-sh-setup
+	require_work_tree
+
+	# First figure out the command and whether we use --rejoin, so
+	# that we can provide more helpful validation when we do the
+	# "real" flag parsing.
+	arg_split_rejoin=
+	allow_split=
+	allow_addmerge=
+	while test $# -gt 0
+	do
+		opt="$1"
+		shift
+		case "$opt" in
+			--rejoin)
+				arg_split_rejoin=1
+				;;
+			--no-rejoin)
+				arg_split_rejoin=
+				;;
+			--)
+				break
+				;;
+		esac
+	done
+	arg_command=$1
+	case "$arg_command" in
+	add|merge|pull)
+		allow_addmerge=1
+		;;
+	split|push)
+		allow_split=1
+		allow_addmerge=$arg_split_rejoin
+		;;
+	*)
+		die "fatal: unknown command '$arg_command'"
+		;;
+	esac
+	# Reset the arguments array for "real" flag parsing.
+	eval "$set_args"
+
+	# Begin "real" flag parsing.
+	arg_quiet=
+	arg_debug=
+	arg_prefix=
+	arg_split_branch=
+	arg_split_onto=
+	arg_split_ignore_joins=
+	arg_split_annotate=
+	arg_addmerge_squash=
+	arg_addmerge_message=
+    arg_gpg_sign=
+	while test $# -gt 0
+	do
+		opt="$1"
+		shift
+
+		case "$opt" in
+		--quiet)
+			arg_quiet=1
+			;;
+		--debug)
+			arg_debug=1
+			;;
+		--annotate=*)
+			test -n "$allow_split" || die_incompatible_opt "$opt" "$arg_command"
+			arg_split_annotate="${opt#*=}"
+			;;
+		--no-annotate)
+			test -n "$allow_split" || die_incompatible_opt "$opt" "$arg_command"
+			arg_split_annotate=
+			;;
+		--branch=*)
+			test -n "$allow_split" || die_incompatible_opt "$opt" "$arg_command"
+			arg_split_branch="${opt#*=}"
+			;;
+		--prefix=*)
+			arg_prefix="${opt#*=}"
+			;;
+		--message=*)
+			test -n "$allow_addmerge" || die_incompatible_opt "$opt" "$arg_command"
+			arg_addmerge_message="${opt#*=}"
+			;;
+		--no-prefix)
+			arg_prefix=
+			;;
+		--onto=*)
+			test -n "$allow_split" || die_incompatible_opt "$opt" "$arg_command"
+			arg_split_onto="${opt#*=}"
+			;;
+		--no-onto)
+			test -n "$allow_split" || die_incompatible_opt "$opt" "$arg_command"
+			arg_split_onto=
+			;;
+		--rejoin)
+			test -n "$allow_split" || die_incompatible_opt "$opt" "$arg_command"
+			;;
+		--no-rejoin)
+			test -n "$allow_split" || die_incompatible_opt "$opt" "$arg_command"
+			;;
+		--ignore-joins)
+			test -n "$allow_split" || die_incompatible_opt "$opt" "$arg_command"
+			arg_split_ignore_joins=1
+			;;
+		--no-ignore-joins)
+			test -n "$allow_split" || die_incompatible_opt "$opt" "$arg_command"
+			arg_split_ignore_joins=
+			;;
+		--squash)
+			test -n "$allow_addmerge" || die_incompatible_opt "$opt" "$arg_command"
+			arg_addmerge_squash=1
+			;;
+		--no-squash)
+			test -n "$allow_addmerge" || die_incompatible_opt "$opt" "$arg_command"
+			arg_addmerge_squash=
+			;;
+	--gpg-sign=* | --gpg-sign | --no-gpg-sign)
+	    arg_gpg_sign="$opt"
+	    ;;
+		--)
+			break
+			;;
+		*)
+			die "fatal: unexpected option: $opt"
+			;;
+		esac
+	done
+	shift
+
+	if test -z "$arg_prefix"
+	then
+		die "fatal: you must provide the --prefix option."
+	fi
+
+	case "$arg_command" in
+	add)
+		test -e "$arg_prefix" &&
+			die "fatal: prefix '$arg_prefix' already exists."
+		;;
+	*)
+		test -e "$arg_prefix" ||
+			die "fatal: '$arg_prefix' does not exist; use 'git subtree add'"
+		;;
+	esac
+
+	dir="$(dirname "$arg_prefix/.")"
+
+	debug "command: {$arg_command}"
+	debug "quiet: {$arg_quiet}"
+	debug "dir: {$dir}"
+	debug "opts: {$*}"
+    debug "gpg-sign: {$arg_gpg_sign}"
+	debug
+
+	"cmd_$arg_command" "$@"
+}
+
+# Usage: cache_setup
+cache_setup () {
+	assert test $# = 0
+	cachedir="$GIT_DIR/subtree-cache/$$"
+	rm -rf "$cachedir" ||
+		die "fatal: can't delete old cachedir: $cachedir"
+	mkdir -p "$cachedir" ||
+		die "fatal: can't create new cachedir: $cachedir"
+	mkdir -p "$cachedir/notree" ||
+		die "fatal: can't create new cachedir: $cachedir/notree"
+	debug "Using cachedir: $cachedir" >&2
+}
+
+# Usage: cache_get [REVS...]
+cache_get () {
+	for oldrev in "$@"
+	do
+		if test -r "$cachedir/$oldrev"
+		then
+			read newrev <"$cachedir/$oldrev"
+			echo $newrev
+		fi
+	done
+}
+
+# Usage: cache_miss [REVS...]
+cache_miss () {
+	for oldrev in "$@"
+	do
+		if ! test -r "$cachedir/$oldrev"
+		then
+			echo $oldrev
+		fi
+	done
+}
+
+# Usage: check_parents [REVS...]
+check_parents () {
+	missed=$(cache_miss "$@") || exit $?
+	local indent=$(($indent + 1))
+	for miss in $missed
+	do
+		if ! test -r "$cachedir/notree/$miss"
+		then
+			debug "incorrect order: $miss"
+			process_split_commit "$miss" ""
+		fi
+	done
+}
+
+# Usage: set_notree REV
+set_notree () {
+	assert test $# = 1
+	echo "1" > "$cachedir/notree/$1"
+}
+
+# Usage: cache_set OLDREV NEWREV
+cache_set () {
+	assert test $# = 2
+	oldrev="$1"
+	newrev="$2"
+	if test "$oldrev" != "latest_old" &&
+		test "$oldrev" != "latest_new" &&
+		test -e "$cachedir/$oldrev"
+	then
+		die "fatal: cache for $oldrev already exists!"
+	fi
+	echo "$newrev" >"$cachedir/$oldrev"
+}
+
+# Usage: rev_exists REV
+rev_exists () {
+	assert test $# = 1
+	if git rev-parse "$1" >/dev/null 2>&1
+	then
+		return 0
+	else
+		return 1
+	fi
+}
+
+# Usage: try_remove_previous REV
+#
+# If a commit doesn't have a parent, this might not work.  But we only want
+# to remove the parent from the rev-list, and since it doesn't exist, it won't
+# be there anyway, so do nothing in that case.
+try_remove_previous () {
+	assert test $# = 1
+	if rev_exists "$1^"
+	then
+		echo "^$1^"
+	fi
+}
+
+# Usage: process_subtree_split_trailer SPLIT_HASH MAIN_HASH [REPOSITORY]
+process_subtree_split_trailer () {
+	assert test $# -ge 2
+	assert test $# -le 3
+	b="$1"
+	sq="$2"
+	repository=""
+	if test "$#" = 3
+	then
+		repository="$3"
+	fi
+	fail_msg="fatal: could not rev-parse split hash $b from commit $sq"
+	if ! sub="$(git rev-parse --verify --quiet "$b^{commit}")"
+	then
+		# if 'repository' was given, try to fetch the 'git-subtree-split' hash
+		# before 'rev-parse'-ing it again, as it might be a tag that we do not have locally
+		if test -n "${repository}"
+		then
+			git fetch "$repository" "$b"
+			sub="$(git rev-parse --verify --quiet "$b^{commit}")" ||
+				die "$fail_msg"
+		else
+			hint1=$(printf "hint: hash might be a tag, try fetching it from the subtree repository:")
+			hint2=$(printf "hint:    git fetch <subtree-repository> $b")
+			fail_msg=$(printf "$fail_msg\n$hint1\n$hint2")
+			die "$fail_msg"
+		fi
+	fi
+}
+
+# Usage: find_latest_squash DIR [REPOSITORY]
+find_latest_squash () {
+	assert test $# -ge 1
+	assert test $# -le 2
+	dir="$1"
+	repository=""
+	if test "$#" = 2
+	then
+		repository="$2"
+	fi
+	debug "Looking for latest squash (dir=$dir, repository=$repository)..."
+	local indent=$(($indent + 1))
+
+	sq=
+	main=
+	sub=
+	git log --grep="^git-subtree-dir: $dir/*\$" \
+		--no-show-signature --pretty=format:'START %H%n%s%n%n%b%nEND%n' HEAD |
+	while read a b junk
+	do
+		debug "$a $b $junk"
+		debug "{{$sq/$main/$sub}}"
+		case "$a" in
+		START)
+			sq="$b"
+			;;
+		git-subtree-mainline:)
+			main="$b"
+			;;
+		git-subtree-split:)
+			process_subtree_split_trailer "$b" "$sq" "$repository"
+			;;
+		END)
+			if test -n "$sub"
+			then
+				if test -n "$main"
+				then
+					# a rejoin commit?
+					# Pretend its sub was a squash.
+					sq=$(git rev-parse --verify "$sq^2") ||
+						die
+				fi
+				debug "Squash found: $sq $sub"
+				echo "$sq" "$sub"
+				break
+			fi
+			sq=
+			main=
+			sub=
+			;;
+		esac
+	done || exit $?
+}
+
+# Usage: find_existing_splits DIR REV [REPOSITORY]
+find_existing_splits () {
+	assert test $# -ge 2
+	assert test $# -le 3
+	debug "Looking for prior splits..."
+	local indent=$(($indent + 1))
+
+	dir="$1"
+	rev="$2"
+	repository=""
+	if test "$#" = 3
+	then
+		repository="$3"
+	fi
+	main=
+	sub=
+	local grep_format="^git-subtree-dir: $dir/*\$"
+	if test -n "$arg_split_ignore_joins"
+	then
+		grep_format="^Add '$dir/' from commit '"
+	fi
+	git log --grep="$grep_format" \
+		--no-show-signature --pretty=format:'START %H%n%s%n%n%b%nEND%n' "$rev" |
+	while read a b junk
+	do
+		case "$a" in
+		START)
+			sq="$b"
+			;;
+		git-subtree-mainline:)
+			main="$b"
+			;;
+		git-subtree-split:)
+			process_subtree_split_trailer "$b" "$sq" "$repository"
+			;;
+		END)
+			debug "Main is: '$main'"
+			if test -z "$main" && test -n "$sub"
+			then
+				# squash commits refer to a subtree
+				debug "  Squash: $sq from $sub"
+				cache_set "$sq" "$sub"
+			fi
+			if test -n "$main" && test -n "$sub"
+			then
+				debug "  Prior: $main -> $sub"
+				cache_set $main $sub
+				cache_set $sub $sub
+				try_remove_previous "$main"
+				try_remove_previous "$sub"
+			fi
+			main=
+			sub=
+			;;
+		esac
+	done || exit $?
+}
+
+# Usage: copy_commit REV TREE FLAGS_STR
+copy_commit () {
+	assert test $# = 3
+	# We're going to set some environment vars here, so
+	# do it in a subshell to get rid of them safely later
+	debug copy_commit "{$1}" "{$2}" "{$3}"
+	git log -1 --no-show-signature --pretty=format:'%an%n%ae%n%aD%n%cn%n%ce%n%cD%n%B' "$1" |
+	(
+		read GIT_AUTHOR_NAME
+		read GIT_AUTHOR_EMAIL
+		read GIT_AUTHOR_DATE
+		read GIT_COMMITTER_NAME
+		read GIT_COMMITTER_EMAIL
+		read GIT_COMMITTER_DATE
+		export  GIT_AUTHOR_NAME \
+			GIT_AUTHOR_EMAIL \
+			GIT_AUTHOR_DATE \
+			GIT_COMMITTER_NAME \
+			GIT_COMMITTER_EMAIL \
+			GIT_COMMITTER_DATE
+		(
+			printf "%s" "$arg_split_annotate"
+			cat
+		) |
+		git commit-tree $arg_gpg_sign "$2" $3  # reads the rest of stdin
+	) || die "fatal: can't copy commit $1"
+}
+
+# Usage: add_msg DIR LATEST_OLD LATEST_NEW
+add_msg () {
+	assert test $# = 3
+	dir="$1"
+	latest_old="$2"
+	latest_new="$3"
+	if test -n "$arg_addmerge_message"
+	then
+		commit_message="$arg_addmerge_message"
+	else
+		commit_message="Add '$dir/' from commit '$latest_new'"
+	fi
+	if test -n "$arg_split_rejoin"
+	then
+		# If this is from a --rejoin, then rejoin_msg has
+		# already inserted the `git-subtree-xxx:` tags
+		echo "$commit_message"
+		return
+	fi
+	cat <<-EOF
+		$commit_message
+
+		git-subtree-dir: $dir
+		git-subtree-mainline: $latest_old
+		git-subtree-split: $latest_new
+	EOF
+}
+
+# Usage: add_squashed_msg REV DIR
+add_squashed_msg () {
+	assert test $# = 2
+	if test -n "$arg_addmerge_message"
+	then
+		echo "$arg_addmerge_message"
+	else
+		echo "Merge commit '$1' as '$2'"
+	fi
+}
+
+# Usage: rejoin_msg DIR LATEST_OLD LATEST_NEW
+rejoin_msg () {
+	assert test $# = 3
+	dir="$1"
+	latest_old="$2"
+	latest_new="$3"
+	if test -n "$arg_addmerge_message"
+	then
+		commit_message="$arg_addmerge_message"
+	else
+		commit_message="Split '$dir/' into commit '$latest_new'"
+	fi
+	cat <<-EOF
+		$commit_message
+
+		git-subtree-dir: $dir
+		git-subtree-mainline: $latest_old
+		git-subtree-split: $latest_new
+	EOF
+}
+
+# Usage: squash_msg DIR OLD_SUBTREE_COMMIT NEW_SUBTREE_COMMIT
+squash_msg () {
+	assert test $# = 3
+	dir="$1"
+	oldsub="$2"
+	newsub="$3"
+	newsub_short=$(git rev-parse --short "$newsub")
+
+	if test -n "$oldsub"
+	then
+		oldsub_short=$(git rev-parse --short "$oldsub")
+		echo "Squashed '$dir/' changes from $oldsub_short..$newsub_short"
+		echo
+		git log --no-show-signature --pretty=tformat:'%h %s' "$oldsub..$newsub"
+		git log --no-show-signature --pretty=tformat:'REVERT: %h %s' "$newsub..$oldsub"
+	else
+		echo "Squashed '$dir/' content from commit $newsub_short"
+	fi
+
+	echo
+	echo "git-subtree-dir: $dir"
+	echo "git-subtree-split: $newsub"
+}
+
+# Usage: toptree_for_commit COMMIT
+toptree_for_commit () {
+	assert test $# = 1
+	commit="$1"
+	git rev-parse --verify "$commit^{tree}" || exit $?
+}
+
+# Usage: subtree_for_commit COMMIT DIR
+subtree_for_commit () {
+	assert test $# = 2
+	commit="$1"
+	dir="$2"
+	git ls-tree "$commit" -- "$dir" |
+	while read mode type tree name
+	do
+		assert test "$name" = "$dir"
+
+		case "$type" in
+		commit)
+			continue;; # ignore submodules
+		tree)
+			echo $tree
+			break;;
+		*)
+			die "fatal: tree entry is of type ${type}, expected tree or commit";;
+		esac
+	done || exit $?
+}
+
+# Usage: tree_changed TREE [PARENTS...]
+tree_changed () {
+	assert test $# -gt 0
+	tree=$1
+	shift
+	if test $# -ne 1
+	then
+		return 0   # weird parents, consider it changed
+	else
+		ptree=$(toptree_for_commit $1) || exit $?
+		if test "$ptree" != "$tree"
+		then
+			return 0   # changed
+		else
+			return 1   # not changed
+		fi
+	fi
+}
+
+# Usage: new_squash_commit OLD_SQUASHED_COMMIT OLD_NONSQUASHED_COMMIT NEW_NONSQUASHED_COMMIT
+new_squash_commit () {
+	assert test $# = 3
+	old="$1"
+	oldsub="$2"
+	newsub="$3"
+	tree=$(toptree_for_commit $newsub) || exit $?
+	if test -n "$old"
+	then
+		squash_msg "$dir" "$oldsub" "$newsub" |
+		git commit-tree $arg_gpg_sign "$tree" -p "$old" || exit $?
+	else
+		squash_msg "$dir" "" "$newsub" |
+		git commit-tree $arg_gpg_sign "$tree" || exit $?
+	fi
+}
+
+# Usage: copy_or_skip REV TREE NEWPARENTS
+copy_or_skip () {
+	assert test $# = 3
+	rev="$1"
+	tree="$2"
+	newparents="$3"
+	assert test -n "$tree"
+
+	identical=
+	nonidentical=
+	p=
+	gotparents=
+	copycommit=
+	for parent in $newparents
+	do
+		ptree=$(toptree_for_commit $parent) || exit $?
+		test -z "$ptree" && continue
+		if test "$ptree" = "$tree"
+		then
+			# an identical parent could be used in place of this rev.
+			if test -n "$identical"
+			then
+				# if a previous identical parent was found, check whether
+				# one is already an ancestor of the other
+				mergebase=$(git merge-base $identical $parent)
+				if test "$identical" = "$mergebase"
+				then
+					# current identical commit is an ancestor of parent
+					identical="$parent"
+				elif test "$parent" != "$mergebase"
+				then
+					# no common history; commit must be copied
+					copycommit=1
+				fi
+			else
+				# first identical parent detected
+				identical="$parent"
+			fi
+		else
+			nonidentical="$parent"
+		fi
+
+		# sometimes both old parents map to the same newparent;
+		# eliminate duplicates
+		is_new=1
+		for gp in $gotparents
+		do
+			if test "$gp" = "$parent"
+			then
+				is_new=
+				break
+			fi
+		done
+		if test -n "$is_new"
+		then
+			gotparents="$gotparents $parent"
+			p="$p -p $parent"
+		fi
+	done
+
+	if test -n "$identical" && test -n "$nonidentical"
+	then
+		extras=$(git rev-list --count $identical..$nonidentical)
+		if test "$extras" -ne 0
+		then
+			# we need to preserve history along the other branch
+			copycommit=1
+		fi
+	fi
+	if test -n "$identical" && test -z "$copycommit"
+	then
+		echo $identical
+	else
+		copy_commit "$rev" "$tree" "$p" || exit $?
+	fi
+}
+
+# Usage: ensure_clean
+ensure_clean () {
+	assert test $# = 0
+	if ! git diff-index HEAD --exit-code --quiet 2>&1
+	then
+		die "fatal: working tree has modifications.  Cannot add."
+	fi
+	if ! git diff-index --cached HEAD --exit-code --quiet 2>&1
+	then
+		die "fatal: index has modifications.  Cannot add."
+	fi
+}
+
+# Usage: ensure_valid_ref_format REF
+ensure_valid_ref_format () {
+	assert test $# = 1
+	git check-ref-format "refs/heads/$1" ||
+		die "fatal: '$1' does not look like a ref"
+}
+
+# Usage: should_ignore_subtree_split_commit REV
+#
+# Check if REV is a commit from another subtree and should be
+# ignored from processing for splits
+should_ignore_subtree_split_commit () {
+	assert test $# = 1
+
+	git show \
+		--no-patch \
+		--no-show-signature \
+		--format='%(trailers:key=git-subtree-dir,key=git-subtree-mainline)' \
+		"$1" |
+	(
+	have_mainline=
+	subtree_dir=
+
+	while read -r trailer val
+	do
+		case "$trailer" in
+		git-subtree-dir:)
+			subtree_dir="${val%/}" ;;
+		git-subtree-mainline:)
+			have_mainline=y ;;
+		esac
+	done
+
+	if test -n "${subtree_dir}" &&
+		test -z "${have_mainline}" &&
+		test "${subtree_dir}" != "$arg_prefix"
+	then
+		return 0
+	fi
+	return 1
+	)
+}
+
+# Usage: process_split_commit REV PARENTS
+process_split_commit () {
+	assert test $# = 2
+	local rev="$1"
+	local parents="$2"
+
+	if test $indent -eq 0
+	then
+		revcount=$(($revcount + 1))
+	else
+		# processing commit without normal parent information;
+		# fetch from repo
+		parents=$(git rev-parse "$rev^@")
+		extracount=$(($extracount + 1))
+	fi
+
+	progress "$revcount/$revmax ($createcount) [$extracount]"
+
+	debug "Processing commit: $rev"
+	local indent=$(($indent + 1))
+	exists=$(cache_get "$rev") || exit $?
+	if test -n "$exists"
+	then
+		debug "prior: $exists"
+		return
+	fi
+	createcount=$(($createcount + 1))
+	debug "parents: $parents"
+	check_parents $parents
+	newparents=$(cache_get $parents) || exit $?
+	debug "newparents: $newparents"
+
+	tree=$(subtree_for_commit "$rev" "$dir") || exit $?
+	debug "tree is: $tree"
+
+	# ugly.  is there no better way to tell if this is a subtree
+	# vs. a mainline commit?  Does it matter?
+	if test -z "$tree"
+	then
+		set_notree "$rev"
+		if test -n "$newparents"
+		then
+			cache_set "$rev" "$rev"
+		fi
+		return
+	fi
+
+	newrev=$(copy_or_skip "$rev" "$tree" "$newparents") || exit $?
+	debug "newrev is: $newrev"
+	cache_set "$rev" "$newrev"
+	cache_set latest_new "$newrev"
+	cache_set latest_old "$rev"
+}
+
+# Usage: cmd_add REV
+#    Or: cmd_add REPOSITORY REF
+cmd_add () {
+
+	ensure_clean
+
+	if test $# -eq 1
+	then
+		git rev-parse -q --verify "$1^{commit}" >/dev/null ||
+			die "fatal: '$1' does not refer to a commit"
+
+		cmd_add_commit "$@"
+
+	elif test $# -eq 2
+	then
+		# Technically we could accept a refspec here but we're
+		# just going to turn around and add FETCH_HEAD under the
+		# specified directory.  Allowing a refspec might be
+		# misleading because we won't do anything with any other
+		# branches fetched via the refspec.
+		ensure_valid_ref_format "$2"
+
+		cmd_add_repository "$@"
+	else
+		say >&2 "fatal: parameters were '$*'"
+		die "Provide either a commit or a repository and commit."
+	fi
+}
+
+# Usage: cmd_add_repository REPOSITORY REFSPEC
+cmd_add_repository () {
+	assert test $# = 2
+	echo "git fetch" "$@"
+	repository=$1
+	refspec=$2
+	git fetch "$@" || exit $?
+	cmd_add_commit FETCH_HEAD
+}
+
+# Usage: cmd_add_commit REV
+cmd_add_commit () {
+	# The rev has already been validated by cmd_add(), we just
+	# need to normalize it.
+	assert test $# = 1
+	rev=$(git rev-parse --verify "$1^{commit}") || exit $?
+
+	debug "Adding $dir as '$rev'..."
+	if test -z "$arg_split_rejoin"
+	then
+		# Only bother doing this if this is a genuine 'add',
+		# not a synthetic 'add' from '--rejoin'.
+		git read-tree --prefix="$dir" $rev || exit $?
+	fi
+	git checkout -- "$dir" || exit $?
+	tree=$(git write-tree) || exit $?
+
+	headrev=$(git rev-parse --verify HEAD) || exit $?
+	if test -n "$headrev" && test "$headrev" != "$rev"
+	then
+		headp="-p $headrev"
+	else
+		headp=
+	fi
+
+	if test -n "$arg_addmerge_squash"
+	then
+		rev=$(new_squash_commit "" "" "$rev") || exit $?
+		commit=$(add_squashed_msg "$rev" "$dir" |
+			git commit-tree $arg_gpg_sign "$tree" $headp -p "$rev") || exit $?
+	else
+		revp=$(peel_committish "$rev") || exit $?
+		commit=$(add_msg "$dir" $headrev "$rev" |
+			git commit-tree $arg_gpg_sign "$tree" $headp -p "$revp") || exit $?
+	fi
+	git reset "$commit" || exit $?
+
+	say >&2 "Added dir '$dir'"
+}
+
+# Usage: cmd_split [REV] [REPOSITORY]
+cmd_split () {
+	if test $# -eq 0
+	then
+		rev=$(git rev-parse HEAD)
+	elif test $# -eq 1 || test $# -eq 2
+	then
+		rev=$(git rev-parse -q --verify "$1^{commit}") ||
+			die "fatal: '$1' does not refer to a commit"
+	else
+		die "fatal: you must provide exactly one revision, and optionally a repository.  Got: '$*'"
+	fi
+	repository=""
+	if test "$#" = 2
+	then
+		repository="$2"
+	fi
+
+	if test -n "$arg_split_rejoin"
+	then
+		ensure_clean
+	fi
+
+	debug "Splitting $dir..."
+	cache_setup || exit $?
+
+	if test -n "$arg_split_onto"
+	then
+		debug "Reading history for --onto=$arg_split_onto..."
+		git rev-list $arg_split_onto |
+		while read rev
+		do
+			# the 'onto' history is already just the subdir, so
+			# any parent we find there can be used verbatim
+			debug "cache: $rev"
+			cache_set "$rev" "$rev"
+		done || exit $?
+	fi
+
+	unrevs="$(find_existing_splits "$dir" "$rev" "$repository")" || exit $?
+
+	# We can't restrict rev-list to only $dir here, because some of our
+	# parents have the $dir contents the root, and those won't match.
+	# (and rev-list --follow doesn't seem to solve this)
+	grl='git rev-list --topo-order --reverse --parents $rev $unrevs'
+	revmax=$(eval "$grl" | wc -l)
+	revcount=0
+	createcount=0
+	extracount=0
+	eval "$grl" |
+	while read rev parents
+	do
+		if should_ignore_subtree_split_commit "$rev"
+		then
+			continue
+		fi
+		parsedparents=''
+		for parent in $parents
+		do
+			if ! should_ignore_subtree_split_commit "$parent"
+			then
+				parsedparents="$parsedparents$parent "
+			fi
+		done
+		process_split_commit "$rev" "$parsedparents"
+	done || exit $?
+
+	latest_new=$(cache_get latest_new) || exit $?
+	if test -z "$latest_new"
+	then
+		die "fatal: no new revisions were found"
+	fi
+
+	if test -n "$arg_split_rejoin"
+	then
+		debug "Merging split branch into HEAD..."
+		latest_old=$(cache_get latest_old) || exit $?
+		arg_addmerge_message="$(rejoin_msg "$dir" "$latest_old" "$latest_new")" || exit $?
+		if test -z "$(find_latest_squash "$dir")"
+		then
+			cmd_add "$latest_new" >&2 || exit $?
+		else
+			cmd_merge "$latest_new" >&2 || exit $?
+		fi
+	fi
+	if test -n "$arg_split_branch"
+	then
+		if rev_exists "refs/heads/$arg_split_branch"
+		then
+			if ! git merge-base --is-ancestor "$arg_split_branch" "$latest_new"
+			then
+				die "fatal: branch '$arg_split_branch' is not an ancestor of commit '$latest_new'."
+			fi
+			action='Updated'
+		else
+			action='Created'
+		fi
+		git update-ref -m 'subtree split' \
+			"refs/heads/$arg_split_branch" "$latest_new" || exit $?
+		say >&2 "$action branch '$arg_split_branch'"
+	fi
+	echo "$latest_new"
+	exit 0
+}
+
+# Usage: cmd_merge REV [REPOSITORY]
+cmd_merge () {
+	if test $# -lt 1 || test $# -gt 2
+	then
+		die "fatal: you must provide exactly one revision, and optionally a repository. Got: '$*'"
+	fi
+
+	rev=$(git rev-parse -q --verify "$1^{commit}") ||
+		die "fatal: '$1' does not refer to a commit"
+	repository=""
+	if test "$#" = 2
+	then
+		repository="$2"
+	fi
+	ensure_clean
+
+	if test -n "$arg_addmerge_squash"
+	then
+		first_split="$(find_latest_squash "$dir" "$repository")" || exit $?
+		if test -z "$first_split"
+		then
+			die "fatal: can't squash-merge: '$dir' was never added."
+		fi
+		set $first_split
+		old=$1
+		sub=$2
+		if test "$sub" = "$rev"
+		then
+			say >&2 "Subtree is already at commit $rev."
+			exit 0
+		fi
+		new=$(new_squash_commit "$old" "$sub" "$rev") || exit $?
+		debug "New squash commit: $new"
+		rev="$new"
+	fi
+
+	if test -n "$arg_addmerge_message"
+	then
+		git merge --no-ff -Xsubtree="$arg_prefix" \
+			--message="$arg_addmerge_message" $arg_gpg_sign "$rev"
+	else
+		git merge --no-ff -Xsubtree="$arg_prefix" $arg_gpg_sign $rev
+	fi
+}
+
+# Usage: cmd_pull REPOSITORY REMOTEREF
+cmd_pull () {
+	if test $# -ne 2
+	then
+		die "fatal: you must provide <repository> <ref>"
+	fi
+	repository="$1"
+	ref="$2"
+	ensure_clean
+	ensure_valid_ref_format "$ref"
+	git fetch "$repository" "$ref" || exit $?
+	cmd_merge FETCH_HEAD "$repository"
+}
+
+# Usage: cmd_push REPOSITORY [+][LOCALREV:]REMOTEREF
+cmd_push () {
+	if test $# -ne 2
+	then
+		die "fatal: you must provide <repository> <refspec>"
+	fi
+	if test -e "$dir"
+	then
+		repository=$1
+		refspec=${2#+}
+		remoteref=${refspec#*:}
+		if test "$remoteref" = "$refspec"
+		then
+			localrevname_presplit=HEAD
+		else
+			localrevname_presplit=${refspec%%:*}
+		fi
+		ensure_valid_ref_format "$remoteref"
+		localrev_presplit=$(git rev-parse -q --verify "$localrevname_presplit^{commit}") ||
+			die "fatal: '$localrevname_presplit' does not refer to a commit"
+
+		echo "git push using: " "$repository" "$refspec"
+		localrev=$(cmd_split "$localrev_presplit" "$repository") || die
+		git push "$repository" "$localrev":"refs/heads/$remoteref"
+	else
+		die "fatal: '$dir' must already exist. Try 'git subtree add'."
+	fi
+}
+
+main "$@"


### PR DESCRIPTION
## What

Fixes the failing PR Subtree Push jobs and makes the split step immune to repo-history growth. Three layers:

1. **`macos-latest` → `ubuntu-latest`** for both jobs — nothing in them is macOS-specific (git + ssh + gh only).
2. **`ulimit -s unlimited`** before the split — a deep git-subtree bash walk can cost time, never a segfault.
3. **Vendored `git-subtree.sh` from git v2.53.0** (`scripts/vendor/`, pristine copy, provenance + sha256 in the README) — restores ~12s splits with a walk that stays flat as history grows.

## Why

Two independent changes intersected:

- **git 2.54.0 removed the multi-subtree walk optimization** ([git/git@1f70684b51](https://github.com/git/git/commit/1f70684b515bc78bcbfe4546e29c13c1baf9c96b)) because it can miscompute splits in exotic merge topologies. Since then every split crawls essentially the entire repo history (measured: ~3,900 commits for pagination, every run) via deep bash recursion.
- **`macos-latest` rolled over to `macos-26-arm64`**, which tolerates less bash recursion depth than macos-15. Same git 2.55, same bash 3.2.57 — the deep crawl that barely fit on macos-15 segfaults (exit 139) on macos-26. Runs landed on either image at random during rollover, hence the flaky-looking failures on #1039 / #1015 with a pass in between.

v2.53.0 is the last release with the optimization (including both rounds of upstream fixes to it) and is the algorithm that produced our upstream subtree history for years.

## Verification (local, against `origin/main` with upstream objects fetched, exactly as CI runs)

- `apollo-ios` split → `28d16a0e46…` — **byte-identical to the upstream head**
- `apollo-ios-pagination` split → `7ac89fa109…` — **byte-identical to the upstream head**
- `apollo-ios-codegen` split → exactly the pending #1015 commit (author preserved), parent = current upstream head (clean fast-forward), tree identical to `main:apollo-ios-codegen`
- ~12s per split (vs. minutes and unbounded growth on git ≥2.54)
- Unchanged subtrees: empty stdout + exit 0, matching the action's existing "empty split-sha = skip push" contract (simulated the full action sequence including `--squash --rejoin`)

## Safety nets

- The action now **asserts the split commit's tree equals `HEAD:<subtree>`** before outputting the SHA — the vendored optimization's theoretical miscompute (requires merge topologies our linear squash-merge main doesn't produce) would fail loudly before any push. Worth having regardless of splitter.
- `push-forked-branch.sh` now uses the vendored script too (local recoveries produce CI-identical hashes) and refuses to push an empty split SHA — previously that would have expanded to `git push remote :refs/heads/branch`, i.e. remote branch deletion.
- Incident + rationale documented in `claude/ci-subtree-troubleshooting.md` and `scripts/vendor/README.md`.

## Recovery

Nothing partial reached upstream from the failed runs. #1039's apollo-ios change already went upstream via #1046's run. **Merging this PR triggers the subtree push on the fixed workflow and carries #1015's pending codegen change upstream automatically** — that first run is also the live end-to-end test of the vendored path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)