### PR TITLE
refactor(cache): slim FieldProjection to (cacheKey, fieldName) (PR-009g-ii)

### DIFF
--- a/Tests/ApolloTests/Cache/FieldProjectionTests.swift
+++ b/Tests/ApolloTests/Cache/FieldProjectionTests.swift
@@ -7,365 +7,49 @@ import XCTest
 
 final class FieldProjectionTests: XCTestCase {
 
-  // MARK: - Construction via outputType initializer
+  // MARK: - Construction
 
-  func test__init_outputType__classifiesColumnShapeAndCardinality() {
+  func test__init__storesArgumentsVerbatim() {
     let projection = FieldProjection(
       cacheKey: "User:42",
-      fieldName: "name",
-      outputType: .nonNull(.scalar(String.self))
+      fieldName: "name"
     )
     expect(projection.cacheKey) == "User:42"
     expect(projection.fieldName) == "name"
-    expect(projection.columnShape) == .string
-    expect(projection.cardinality) == .scalar
-  }
-
-  func test__init_outputType__nonNullWrappingDoesNotAffectClassification() {
-    // `String?` and `String!` both project the same column with the
-    // same cardinality; only the wrapper differs. After classification,
-    // the projections must be indistinguishable.
-    let optional = FieldProjection(
-      cacheKey: "User:1",
-      fieldName: "nickname",
-      outputType: .scalar(String.self)
-    )
-    let nonNull = FieldProjection(
-      cacheKey: "User:1",
-      fieldName: "nickname",
-      outputType: .nonNull(.scalar(String.self))
-    )
-    expect(optional) == nonNull
-  }
-
-  // MARK: - Construction via direct initializer
-
-  func test__init_columnShapeAndCardinality__storesArgumentsVerbatim() {
-    let projection = FieldProjection(
-      cacheKey: "User:1",
-      fieldName: "tags",
-      columnShape: .string,
-      cardinality: .list
-    )
-    expect(projection.cacheKey) == "User:1"
-    expect(projection.fieldName) == "tags"
-    expect(projection.columnShape) == .string
-    expect(projection.cardinality) == .list
-  }
-
-  func test__init_columnShapeAndCardinality__matchesEquivalentOutputTypeInit() {
-    // Building a projection via the direct initializer with the same
-    // (columnShape, cardinality) as the outputType-derived classification
-    // produces equal projections — the two paths are interchangeable.
-    let direct = FieldProjection(
-      cacheKey: "User:1",
-      fieldName: "tags",
-      columnShape: .string,
-      cardinality: .list
-    )
-    let derived = FieldProjection(
-      cacheKey: "User:1",
-      fieldName: "tags",
-      outputType: .nonNull(.list(.nonNull(.scalar(String.self))))
-    )
-    expect(direct) == derived
   }
 
   // MARK: - Equatable
 
-  func test__equality__givenSameStorageShape__returnsTrue() {
-    let a = FieldProjection(cacheKey: "User:1", fieldName: "age", outputType: .nonNull(.scalar(Int.self)))
-    let b = FieldProjection(cacheKey: "User:1", fieldName: "age", outputType: .nonNull(.scalar(Int.self)))
+  func test__equality__givenSamePair__returnsTrue() {
+    let a = FieldProjection(cacheKey: "User:1", fieldName: "age")
+    let b = FieldProjection(cacheKey: "User:1", fieldName: "age")
     expect(a) == b
   }
 
   func test__equality__givenDifferentCacheKey__returnsFalse() {
-    let a = FieldProjection(cacheKey: "User:1", fieldName: "age", outputType: .scalar(Int.self))
-    let b = FieldProjection(cacheKey: "User:2", fieldName: "age", outputType: .scalar(Int.self))
+    let a = FieldProjection(cacheKey: "User:1", fieldName: "age")
+    let b = FieldProjection(cacheKey: "User:2", fieldName: "age")
     expect(a) != b
   }
 
   func test__equality__givenDifferentFieldName__returnsFalse() {
-    let a = FieldProjection(cacheKey: "User:1", fieldName: "age", outputType: .scalar(Int.self))
-    let b = FieldProjection(cacheKey: "User:1", fieldName: "height", outputType: .scalar(Int.self))
+    let a = FieldProjection(cacheKey: "User:1", fieldName: "age")
+    let b = FieldProjection(cacheKey: "User:1", fieldName: "height")
     expect(a) != b
-  }
-
-  func test__equality__givenDifferentColumnShape__returnsFalse() {
-    let a = FieldProjection(cacheKey: "User:1", fieldName: "value", outputType: .scalar(String.self))
-    let b = FieldProjection(cacheKey: "User:1", fieldName: "value", outputType: .scalar(Int.self))
-    expect(a) != b
-  }
-
-  func test__equality__givenDifferentCardinality__returnsFalse() {
-    // Same (cacheKey, fieldName, columnShape) but scalar vs list.
-    let scalar = FieldProjection(
-      cacheKey: "User:1", fieldName: "value",
-      columnShape: .string, cardinality: .scalar
-    )
-    let list = FieldProjection(
-      cacheKey: "User:1", fieldName: "value",
-      columnShape: .string, cardinality: .list
-    )
-    expect(scalar) != list
   }
 
   // MARK: - Hashable
 
   func test__hashable__equalProjectionsProduceEqualHashes() {
-    let a = FieldProjection(cacheKey: "User:1", fieldName: "age", outputType: .scalar(Int.self))
-    let b = FieldProjection(cacheKey: "User:1", fieldName: "age", outputType: .scalar(Int.self))
+    let a = FieldProjection(cacheKey: "User:1", fieldName: "age")
+    let b = FieldProjection(cacheKey: "User:1", fieldName: "age")
     expect(a.hashValue) == b.hashValue
   }
 
   func test__hashable__usableInSet__deduplicatesEqualValues() {
-    let a = FieldProjection(cacheKey: "User:1", fieldName: "age", outputType: .scalar(Int.self))
-    let b = FieldProjection(cacheKey: "User:1", fieldName: "age", outputType: .scalar(Int.self))
+    let a = FieldProjection(cacheKey: "User:1", fieldName: "age")
+    let b = FieldProjection(cacheKey: "User:1", fieldName: "age")
     let set: Set<FieldProjection> = [a, b]
     expect(set.count) == 1
   }
-
-  // MARK: - ColumnShape — built-in primitive scalars
-
-  func test__columnShape__givenStringScalar__returnsString() {
-    expect(FieldProjection.columnShape(of: .scalar(String.self))) == .string
-  }
-
-  func test__columnShape__givenIntScalar__returnsInt() {
-    expect(FieldProjection.columnShape(of: .scalar(Int.self))) == .int
-  }
-
-  func test__columnShape__givenInt32Scalar__returnsInt() {
-    expect(FieldProjection.columnShape(of: .scalar(Int32.self))) == .int
-  }
-
-  func test__columnShape__givenBoolScalar__returnsBool() {
-    expect(FieldProjection.columnShape(of: .scalar(Bool.self))) == .bool
-  }
-
-  func test__columnShape__givenFloatScalar__returnsFloat() {
-    expect(FieldProjection.columnShape(of: .scalar(Float.self))) == .float
-  }
-
-  func test__columnShape__givenDoubleScalar__returnsFloat() {
-    expect(FieldProjection.columnShape(of: .scalar(Double.self))) == .float
-  }
-
-  // MARK: - ColumnShape — wrapper transparency
-
-  func test__columnShape__givenNonNullWrappedScalar__peelsToInnerType() {
-    expect(FieldProjection.columnShape(of: .nonNull(.scalar(Int.self)))) == .int
-  }
-
-  func test__columnShape__givenListWrappedScalar__peelsToInnerType() {
-    expect(FieldProjection.columnShape(of: .list(.scalar(String.self)))) == .string
-  }
-
-  func test__columnShape__givenDeeplyWrappedScalar__peelsThroughEveryLayer() {
-    let outputType: Selection.Field.OutputType =
-      .nonNull(.list(.nonNull(.scalar(Bool.self))))
-    expect(FieldProjection.columnShape(of: outputType)) == .bool
-  }
-
-  func test__columnShape__givenNestedListOfInts__returnsChildKeyForOuterField() {
-    // `[[Int]]` — the outer list's rows hold `child_key_value`
-    // pointers at synthetic sub-records (per ADR 0006 §3.2). The
-    // inner-list element column (`.int`) is read via a follow-up
-    // projection against the synthetic sub-record, not by the
-    // outer field's projection.
-    let outputType: Selection.Field.OutputType =
-      .nonNull(.list(.nonNull(.list(.nonNull(.scalar(Int.self))))))
-    expect(FieldProjection.columnShape(of: outputType)) == .childKey
-  }
-
-  func test__columnShape__givenTripleNestedList__returnsChildKey() {
-    // `[[[String]]]` — same rule, regardless of nesting depth and
-    // inner type.
-    let outputType: Selection.Field.OutputType =
-      .nonNull(.list(.nonNull(.list(.nonNull(.list(.nonNull(.scalar(String.self))))))))
-    expect(FieldProjection.columnShape(of: outputType)) == .childKey
-  }
-
-  func test__columnShape__givenAsymmetricNestedList_nullableOuterNonNullInner__returnsChildKey() {
-    // `[[Int!]]` — GraphQL allows the outer list to be nullable while
-    // the inner list (and its elements) remain non-null. Codegen
-    // typically emits the fully-non-null wrapping, but the underlying
-    // type system permits this asymmetric shape. The nested-list rule
-    // (depth ≥ 2 → `.childKey`) must hold regardless of which wrapper
-    // layers are `.nonNull`-wrapped.
-    let outputType: Selection.Field.OutputType =
-      .list(.nonNull(.list(.nonNull(.scalar(Int.self)))))
-    expect(FieldProjection.columnShape(of: outputType)) == .childKey
-    expect(FieldProjection.cardinality(of: outputType)) == .list
-  }
-
-  func test__columnShape__givenAsymmetricNestedList_nonNullOuterNullableInner__returnsChildKey() {
-    // `[[Int]!]` — outer list non-null, inner list nullable. Mirror
-    // of the above case, asserting the rule is direction-agnostic.
-    let outputType: Selection.Field.OutputType =
-      .nonNull(.list(.list(.scalar(Int.self))))
-    expect(FieldProjection.columnShape(of: outputType)) == .childKey
-    expect(FieldProjection.cardinality(of: outputType)) == .list
-  }
-
-  func test__columnShape__givenSingleListOfScalars__doesNotApplyNestingRule() {
-    // `[Int]` — one `.list` wrapper. Inner-typed column applies.
-    let outputType: Selection.Field.OutputType =
-      .nonNull(.list(.nonNull(.scalar(Int.self))))
-    expect(FieldProjection.columnShape(of: outputType)) == .int
-  }
-
-  // MARK: - ColumnShape — object types map to childKey
-
-  func test__columnShape__givenObject__returnsChildKey() {
-    let outputType: Selection.Field.OutputType = .object(MockSelectionSet.self)
-    expect(FieldProjection.columnShape(of: outputType)) == .childKey
-  }
-
-  func test__columnShape__givenListOfObjects__returnsChildKey() {
-    let outputType: Selection.Field.OutputType =
-      .nonNull(.list(.nonNull(.object(MockSelectionSet.self))))
-    expect(FieldProjection.columnShape(of: outputType)) == .childKey
-  }
-
-  // MARK: - ColumnShape — custom scalars
-
-  func test__columnShape__givenCustomScalar__routesToCustomScalar() {
-    // Per the doc on `ColumnShape`, all `.customScalar(_)` cases
-    // route to `.customScalar` in this PR; precise-per-scalar
-    // mapping (for the codegen-default wrapper whose `_jsonValue`
-    // is a primitive like `String`) is deferred to a follow-up PR
-    // per ADR 0007 Principle 7.
-    expect(
-      FieldProjection.columnShape(of: .customScalar(StructCustomScalar.self))
-    ) == .customScalar
-  }
-
-  func test__columnShape__givenListOfCustomScalars__routesToCustomScalar() {
-    let outputType: Selection.Field.OutputType =
-      .nonNull(.list(.nonNull(.customScalar(StructCustomScalar.self))))
-    expect(FieldProjection.columnShape(of: outputType)) == .customScalar
-  }
-
-  // MARK: - Cardinality
-
-  func test__cardinality__givenScalar__returnsScalar() {
-    expect(FieldProjection.cardinality(of: .scalar(Int.self))) == .scalar
-  }
-
-  func test__cardinality__givenObject__returnsScalar() {
-    expect(FieldProjection.cardinality(of: .object(MockSelectionSet.self))) == .scalar
-  }
-
-  func test__cardinality__givenCustomScalar__returnsScalar() {
-    expect(FieldProjection.cardinality(of: .customScalar(StructCustomScalar.self))) == .scalar
-  }
-
-  func test__cardinality__givenNonNullScalar__returnsScalar() {
-    expect(FieldProjection.cardinality(of: .nonNull(.scalar(String.self)))) == .scalar
-  }
-
-  func test__cardinality__givenList__returnsList() {
-    expect(FieldProjection.cardinality(of: .list(.scalar(String.self)))) == .list
-  }
-
-  func test__cardinality__givenNonNullList__returnsList() {
-    expect(
-      FieldProjection.cardinality(of: .nonNull(.list(.scalar(Int.self))))
-    ) == .list
-  }
-
-  func test__cardinality__givenListOfNonNullScalars__returnsList() {
-    expect(
-      FieldProjection.cardinality(of: .list(.nonNull(.scalar(Int.self))))
-    ) == .list
-  }
-
-  func test__cardinality__givenNestedList__returnsList() {
-    // `[[Int]]` — outer list is what the initial projection reads.
-    // Inner-list materialization is the caller's responsibility per
-    // ADR 0006 §3.2.
-    let outputType: Selection.Field.OutputType =
-      .nonNull(.list(.nonNull(.list(.nonNull(.scalar(Int.self))))))
-    expect(FieldProjection.cardinality(of: outputType)) == .list
-  }
-
-  // MARK: - End-to-end shape inferences for common GraphQL field types
-
-  func test__shape__givenNonNullString__producesScalarStringColumn() {
-    let projection = FieldProjection(
-      cacheKey: "User:1",
-      fieldName: "name",
-      outputType: .nonNull(.scalar(String.self))
-    )
-    expect(projection.columnShape) == .string
-    expect(projection.cardinality) == .scalar
-  }
-
-  func test__shape__givenListOfNonNullStrings__producesListStringColumn() {
-    let projection = FieldProjection(
-      cacheKey: "User:1",
-      fieldName: "tags",
-      outputType: .nonNull(.list(.nonNull(.scalar(String.self))))
-    )
-    expect(projection.columnShape) == .string
-    expect(projection.cardinality) == .list
-  }
-
-  func test__shape__givenNonNullObject__producesScalarChildKeyColumn() {
-    let projection = FieldProjection(
-      cacheKey: "Query.viewer",
-      fieldName: "user",
-      outputType: .nonNull(.object(MockSelectionSet.self))
-    )
-    expect(projection.columnShape) == .childKey
-    expect(projection.cardinality) == .scalar
-  }
-
-  func test__shape__givenListOfObjects__producesListChildKeyColumn() {
-    let projection = FieldProjection(
-      cacheKey: "User:1",
-      fieldName: "friends",
-      outputType: .nonNull(.list(.nonNull(.object(MockSelectionSet.self))))
-    )
-    expect(projection.columnShape) == .childKey
-    expect(projection.cardinality) == .list
-  }
-
-  func test__shape__givenNestedListOfInts__producesListChildKeyColumn() {
-    // The outer list's rows hold `child_key_value` pointers at
-    // synthetic sub-records per ADR 0006 §3.2; the inner list
-    // lives under the sentinel field name on those sub-records
-    // and gets its own follow-up projection. The OUTER
-    // projection's column is `.childKey`, not the inner element's
-    // column — which is why this field is shape-equivalent to a
-    // list of objects at the projection layer.
-    let projection = FieldProjection(
-      cacheKey: "Matrix:1",
-      fieldName: "rows",
-      outputType: .nonNull(.list(.nonNull(.list(.nonNull(.scalar(Int.self))))))
-    )
-    expect(projection.columnShape) == .childKey
-    expect(projection.cardinality) == .list
-  }
-}
-
-// MARK: - Custom-scalar test fixture
-
-/// A user-defined custom scalar matching the shape codegen emits
-/// for custom scalars in a generated schema. The exact
-/// `_jsonValue` shape doesn't affect the projection — the
-/// projection only inspects the type identity passed via
-/// `.customScalar(_)`.
-private struct StructCustomScalar: CustomScalarType, Sendable, Hashable {
-  let payload: [String: String]
-
-  init(_jsonValue value: JSONValue) throws {
-    guard let dict = value as? [String: String] else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: Self.self)
-    }
-    self.payload = dict
-  }
-
-  var _jsonValue: JSONValue { payload }
 }

--- a/Tests/ApolloTests/Cache/LoadFieldsTests.swift
+++ b/Tests/ApolloTests/Cache/LoadFieldsTests.swift
@@ -32,8 +32,7 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     let (cache, _) = await cacheType.makeNormalizedCache()
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "User:1", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar)
+      FieldProjection(cacheKey: "User:1", fieldName: "name")
     ])
     expect(result.isEmpty) == true
   }
@@ -45,10 +44,8 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "User:2", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar),
-      FieldProjection(cacheKey: "User:3", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:2", fieldName: "name"),
+      FieldProjection(cacheKey: "User:3", fieldName: "name"),
     ])
     expect(result.isEmpty) == true
   }
@@ -66,8 +63,7 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "User:1", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar)
+      FieldProjection(cacheKey: "User:1", fieldName: "name")
     ])
 
     expect(result.count) == 1
@@ -87,10 +83,8 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "User:1", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar),
-      FieldProjection(cacheKey: "User:1", fieldName: "age",
-                      columnShape: .int, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:1", fieldName: "name"),
+      FieldProjection(cacheKey: "User:1", fieldName: "age"),
     ])
 
     expect(result.count) == 1
@@ -116,10 +110,8 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "User:1", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar),
-      FieldProjection(cacheKey: "User:2", fieldName: "email",
-                      columnShape: .string, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:1", fieldName: "name"),
+      FieldProjection(cacheKey: "User:2", fieldName: "email"),
     ])
 
     expect(result.count) == 2
@@ -141,10 +133,8 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "User:1", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar),
-      FieldProjection(cacheKey: "User:99", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:1", fieldName: "name"),
+      FieldProjection(cacheKey: "User:99", fieldName: "name"),
     ])
 
     expect(result.count) == 1
@@ -166,8 +156,7 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "User:1", fieldName: "nonExistentField",
-                      columnShape: .string, cardinality: .scalar)
+      FieldProjection(cacheKey: "User:1", fieldName: "nonExistentField")
     ])
 
     expect(result.count) == 1
@@ -182,10 +171,8 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "User:1", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar),
-      FieldProjection(cacheKey: "User:1", fieldName: "missing",
-                      columnShape: .string, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:1", fieldName: "name"),
+      FieldProjection(cacheKey: "User:1", fieldName: "missing"),
     ])
 
     let record = try XCTUnwrap(result["User:1"])
@@ -204,8 +191,7 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let projection = FieldProjection(
-      cacheKey: "User:1", fieldName: "name",
-      columnShape: .string, cardinality: .scalar
+      cacheKey: "User:1", fieldName: "name"
     )
 
     let result = try await cache.loadFields([projection, projection, projection])
@@ -227,8 +213,7 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "User:1", fieldName: "tags",
-                      columnShape: .string, cardinality: .list)
+      FieldProjection(cacheKey: "User:1", fieldName: "tags")
     ])
 
     let record = try XCTUnwrap(result["User:1"])
@@ -245,8 +230,7 @@ class LoadFieldsTests: XCTestCase, CacheDependentTesting {
     ])
 
     let result = try await cache.loadFields([
-      FieldProjection(cacheKey: "Query.viewer", fieldName: "user",
-                      columnShape: .childKey, cardinality: .scalar)
+      FieldProjection(cacheKey: "Query.viewer", fieldName: "user")
     ])
 
     let record = try XCTUnwrap(result["Query.viewer"])

--- a/Tests/ApolloTests/Execution/FieldProjectionCollectorTests.swift
+++ b/Tests/ApolloTests/Execution/FieldProjectionCollectorTests.swift
@@ -23,14 +23,12 @@ final class FieldProjectionCollectorTests: XCTestCase {
     )
 
     expect(projections) == Set([
-      FieldProjection(cacheKey: "User:1", fieldName: "name",
-                      columnShape: .string, cardinality: .scalar),
-      FieldProjection(cacheKey: "User:1", fieldName: "age",
-                      columnShape: .int, cardinality: .scalar),
+      FieldProjection(cacheKey: "User:1", fieldName: "name"),
+      FieldProjection(cacheKey: "User:1", fieldName: "age"),
     ])
   }
 
-  func test__collect__givenListField__emitsListCardinalityProjection() throws {
+  func test__collect__givenListField__emitsProjectionForListField() throws {
     let selections: [Selection] = [
       .field("tags", [String].self),
     ]
@@ -43,12 +41,11 @@ final class FieldProjectionCollectorTests: XCTestCase {
     )
 
     expect(projections) == Set([
-      FieldProjection(cacheKey: "User:1", fieldName: "tags",
-                      columnShape: .string, cardinality: .list)
+      FieldProjection(cacheKey: "User:1", fieldName: "tags")
     ])
   }
 
-  func test__collect__givenObjectField__emitsChildKeyColumnShape() throws {
+  func test__collect__givenObjectField__emitsProjectionForObjectField() throws {
     class FriendSelectionSet: MockSelectionSet, @unchecked Sendable {
       override class var __selections: [Selection] { [
         .field("name", String.self)
@@ -67,8 +64,7 @@ final class FieldProjectionCollectorTests: XCTestCase {
     )
 
     expect(projections) == Set([
-      FieldProjection(cacheKey: "User:1", fieldName: "bestFriend",
-                      columnShape: .childKey, cardinality: .scalar)
+      FieldProjection(cacheKey: "User:1", fieldName: "bestFriend")
     ])
   }
 

--- a/Tests/ApolloTests/ProjectionLoaderTests.swift
+++ b/Tests/ApolloTests/ProjectionLoaderTests.swift
@@ -18,16 +18,11 @@ final class ProjectionLoaderTests: XCTestCase {
 
   // MARK: - Helpers
 
-  /// `FieldProjection.init(cacheKey:fieldName:columnShape:cardinality:)`
-  /// shorthand — these tests don't care about column shape / cardinality
-  /// (they verify the loader's batching contract, not the cache backend's
-  /// column projection). `.string` / `.scalar` are arbitrary placeholders.
+  /// `FieldProjection.init(cacheKey:fieldName:)` shorthand.
   private func projection(_ cacheKey: CacheKey, _ fieldName: String) -> FieldProjection {
     FieldProjection(
       cacheKey: cacheKey,
-      fieldName: fieldName,
-      columnShape: .string,
-      cardinality: .scalar
+      fieldName: fieldName
     )
   }
 

--- a/Tests/ApolloTests/SQLiteSelectFieldsTests.swift
+++ b/Tests/ApolloTests/SQLiteSelectFieldsTests.swift
@@ -34,15 +34,11 @@ final class SQLiteSelectFieldsTests: XCTestCase {
 
   private func projection(
     _ cacheKey: CacheKey,
-    _ fieldName: String,
-    columnShape: FieldProjection.ColumnShape = .string,
-    cardinality: FieldProjection.Cardinality = .scalar
+    _ fieldName: String
   ) -> FieldProjection {
     FieldProjection(
       cacheKey: cacheKey,
-      fieldName: fieldName,
-      columnShape: columnShape,
-      cardinality: cardinality
+      fieldName: fieldName
     )
   }
 
@@ -84,7 +80,7 @@ final class SQLiteSelectFieldsTests: XCTestCase {
 
     let result = try db.selectFields([
       projection("User:1", "name"),
-      projection("User:1", "age", columnShape: .int),
+      projection("User:1", "age"),
     ])
 
     let record = try XCTUnwrap(result["User:1"])
@@ -105,7 +101,7 @@ final class SQLiteSelectFieldsTests: XCTestCase {
 
     let result = try db.selectFields([
       projection("User:1", "name"),
-      projection("User:2", "age", columnShape: .int),
+      projection("User:2", "age"),
     ])
 
     XCTAssertEqual(result.count, 2)
@@ -159,8 +155,8 @@ final class SQLiteSelectFieldsTests: XCTestCase {
     try db.insertOrUpdate(records: [record("User:1", fields: ["name": "Anthony"])])
 
     let result = try db.selectFields([
-      projection("User:1", "name", columnShape: .string, cardinality: .scalar),
-      projection("User:1", "name", columnShape: .int, cardinality: .scalar),
+      projection("User:1", "name"),
+      projection("User:1", "name"),
     ])
 
     XCTAssertEqual(result["User:1"]?.fields["name"]?.value as? String, "Anthony")
@@ -177,7 +173,7 @@ final class SQLiteSelectFieldsTests: XCTestCase {
     )])
 
     let result = try db.selectFields([
-      projection("User:1", "colors", columnShape: .string, cardinality: .list),
+      projection("User:1", "colors"),
     ])
 
     let assembled = result["User:1"]?.fields["colors"]?.value as? [Any]
@@ -204,7 +200,7 @@ final class SQLiteSelectFieldsTests: XCTestCase {
     )])
 
     let result = try db.selectFields([
-      projection("Grid:1", "rows", columnShape: .childKey, cardinality: .list),
+      projection("Grid:1", "rows"),
     ])
 
     let outerLoaded = result["Grid:1"]?.fields["rows"]?.value as? [Any]

--- a/apollo-ios/Sources/Apollo/Caching/ApolloStore.swift
+++ b/apollo-ios/Sources/Apollo/Caching/ApolloStore.swift
@@ -296,8 +296,10 @@ public final class ApolloStore: Sendable {
     /// `__typename` is not yet loaded at projection time. The
     /// executor's later selection-set traversal uses the loaded
     /// `__typename` to pick the matching type case; the unmatched
-    /// type-case fields are an over-fetch that PR-009g will narrow
-    /// once SQL-level projection lands on the SQLite backend.
+    /// type-case fields are an over-fetch accepted per ADR 0007.
+    /// Narrowing it at the SQL layer (a `__typename`-aware filter) is
+    /// a deferred optimization gated on the Phase 1A performance
+    /// results.
     final func loadObject(
       forKey key: CacheKey,
       selections: [Selection],

--- a/apollo-ios/Sources/Apollo/Caching/CacheDependentKey.swift
+++ b/apollo-ios/Sources/Apollo/Caching/CacheDependentKey.swift
@@ -22,15 +22,10 @@
 /// # See Also
 ///
 /// - [ADR 0007 — Selection-set-aware cache reads](../Design/adr/0007-selection-aware-cache-reads.md)
-///   PR-009f: "Dirty `(cacheKey, fieldName)` entries become
-///   `FieldProjection`s via the direct `(columnShape, cardinality)`
-///   initializer." This type is the public, shape-agnostic surface;
-///   shape info is supplied by the consumer that converts it.
-/// - ``FieldProjection`` — the selection-set-aware sibling that
-///   adds `columnShape` / `cardinality`. The dependency tracker
-///   does not need the shape, so the dirty-set carries the slim
-///   `(cacheKey, fieldName)` form and shape is reconstituted at
-///   re-read time from the watcher's known projection set.
+/// - ``FieldProjection`` — the read-request sibling. Both types
+///   carry the same `(cacheKey, fieldName)` pair; this one names a
+///   field a result *depends on* (watcher dirty-set matching), while
+///   `FieldProjection` names a field a read *requests*.
 public struct CacheDependentKey: Hashable, Sendable {
 
   /// The cache key of the record carrying the field.

--- a/apollo-ios/Sources/Apollo/Caching/FieldProjection.swift
+++ b/apollo-ios/Sources/Apollo/Caching/FieldProjection.swift
@@ -1,24 +1,24 @@
 import ApolloAPI
 
 /// A request to read one field's value(s) from one record in the
-/// normalized cache, carrying enough type information for any
-/// `NormalizedCache` implementation to fulfill the request without
-/// re-deriving it from a `Selection.Field`.
+/// normalized cache.
 ///
 /// `FieldProjection` is the value-type expression of ADR 0007's
-/// selection-set-aware cache reads. The executor builds projections
-/// upfront by traversing the selection set; the cache fulfills the
-/// projections in one batched read. For the SQLite-backed cache
-/// (per ADR 0006's row-per-element schema), `columnShape` tells the
-/// read which of the six typed value columns to project and
-/// `cardinality` tells it whether to expect one row at the default
-/// `position` value (`-1`) or N rows at `position = 0..N-1`. For
-/// the in-memory cache, the same information identifies the entry
-/// to return.
+/// selection-set-aware cache reads: the executor builds projections
+/// upfront by traversing the operation's selection sets, and the
+/// cache fulfills them in one batched read, returning only the
+/// requested `(cacheKey, fieldName)` pairs instead of whole records.
 ///
-/// This PR introduces the type only; no consumers exist yet. The
-/// `NormalizedCache` protocol change to accept `[FieldProjection]`
-/// is the next PR in sub-phase 1A.5 (PR-009c per ADR 0007).
+/// The projection deliberately carries no type or shape metadata.
+/// Storage backends return the whole stored value for the pair — the
+/// row-per-element SQLite schema (ADR 0006) infers scalar-vs-list
+/// shape from the stored rows' `position` values at read time, and
+/// the in-memory cache returns the stored entry as-is. If the stored
+/// shape disagrees with the shape the generated models declare (a
+/// non-backwards-compatible schema change shipped without clearing
+/// the cache), the mismatch surfaces to the caller as a
+/// `JSONDecodingError.wrongType` execution error — the same behavior
+/// as Apollo iOS 2.x — rather than being masked by the read layer.
 ///
 /// # See Also
 ///
@@ -36,248 +36,8 @@ public struct FieldProjection: Hashable, Sendable {
   /// carries the storage field name, not the response key).
   public let fieldName: String
 
-  /// The SQLite typed-column slot the field's value(s) occupy on
-  /// each stored row. See `ColumnShape` for the mapping rules.
-  public let columnShape: ColumnShape
-
-  /// `.scalar` if the field is stored as a single row at the default
-  /// `position` value (`-1`); `.list` if the field is stored as N
-  /// rows at `position = 0..N-1`. See `Cardinality` for details.
-  public let cardinality: Cardinality
-
-  /// Primary initializer used by the executor. Classifies a
-  /// `Selection.Field.OutputType` into the projection's `columnShape`
-  /// and `cardinality` at construction time. The OutputType itself
-  /// is not retained — once classified, the projection's
-  /// `(cacheKey, fieldName, columnShape, cardinality)` is everything
-  /// any planned consumer needs (see ADR 0007 §implementation
-  /// sequence). The executor keeps its own `Selection.Field` tree
-  /// alongside the projections it issues for decoding return values
-  /// into Swift types and for driving follow-up projections; the
-  /// cache layer detects synthetic-vs-real `child_key_value` pointers
-  /// at read time via the `.$[N]` suffix pattern established in
-  /// PR #1007.
-  public init(
-    cacheKey: CacheKey,
-    fieldName: String,
-    outputType: Selection.Field.OutputType
-  ) {
-    self.init(
-      cacheKey: cacheKey,
-      fieldName: fieldName,
-      columnShape: Self.columnShape(of: outputType),
-      cardinality: Self.cardinality(of: outputType)
-    )
-  }
-
-  /// Direct initializer for callers that build projections from
-  /// non-`Selection.Field` sources — most importantly the
-  /// dependency tracker (PR-009f), whose watcher dirty-set entries
-  /// arrive as `(cacheKey, fieldName)` pairs without a wrapping
-  /// `Selection.Field` in scope, and tests that exercise
-  /// projection-driven behavior without a full selection set.
-  ///
-  /// Production code paths that have a `Selection.Field.OutputType`
-  /// in hand should prefer the `outputType:` initializer so column-
-  /// shape and cardinality classification stay in one place.
-  public init(
-    cacheKey: CacheKey,
-    fieldName: String,
-    columnShape: ColumnShape,
-    cardinality: Cardinality
-  ) {
+  public init(cacheKey: CacheKey, fieldName: String) {
     self.cacheKey = cacheKey
     self.fieldName = fieldName
-    self.columnShape = columnShape
-    self.cardinality = cardinality
-  }
-
-  // MARK: - Output-type classification
-
-  /// The SQLite typed-column slot a field's value occupies. One of
-  /// the six value columns introduced by the row-per-element schema
-  /// (ADR 0006); the other five columns are `NULL` on every row.
-  ///
-  /// The mapping from a `Selection.Field.OutputType` is determined
-  /// by the type's *named* type — its innermost form, after peeling
-  /// off `.nonNull` and `.list` wrappers:
-  ///
-  /// | Named type            | ColumnShape     | Storage column        |
-  /// |---|---|---|
-  /// | `String`              | `.string`       | `string_value`        |
-  /// | `Int`, `Int32`        | `.int`          | `int_value`           |
-  /// | `Bool`                | `.bool`         | `bool_value`          |
-  /// | `Float`, `Double`     | `.float`        | `float_value`         |
-  /// | `.object(_)`          | `.childKey`     | `child_key_value`     |
-  /// | `.customScalar(_)`    | `.customScalar` | `custom_scalar_value` |
-  ///
-  /// ## Custom scalars and the precise-column TODO
-  ///
-  /// All `.customScalar(T)` cases currently route to
-  /// `.customScalar` regardless of `T`'s `_jsonValue` shape. The
-  /// codegen-default custom scalar (`struct ScalarName:
-  /// CustomScalarType { let value: String; var _jsonValue: ...
-  /// { value } }`) unwraps to a `String` at write time via the
-  /// normalizer's `accept(customScalar:)` path, and
-  /// `SQLiteFieldEncoding` then writes that `String` into
-  /// `string_value` — which means the read-side projection routing
-  /// custom scalars to `.customScalar` will miss the value. This
-  /// mismatch is harmless until PR-009g wires up SQL-level
-  /// projection; it is the explicit subject of ADR 0007 Principle 7
-  /// (custom scalars must declare their storage column) and is
-  /// resolved by a follow-up PR that adds a static declaration on
-  /// `CustomScalarType` (likely `_cacheStorageColumn`) and updates
-  /// the codegen to emit it.
-  ///
-  /// This PR fixes the type system but defers the custom-scalar
-  /// declaration mechanism to keep the scope narrow.
-  public enum ColumnShape: Hashable, Sendable {
-    case bool
-    case int
-    case float
-    case string
-    case childKey
-    case customScalar
-  }
-
-  /// Whether a field is stored as one row (scalar) or N rows (list).
-  /// In the row-per-element schema this maps to the `position`
-  /// predicate of the read:
-  ///
-  /// - `.scalar` — the field has one row at the default `position`
-  ///   value (`-1`). Read with `WHERE position = -1`.
-  /// - `.list` — the field has N rows at `position = 0..N-1`.
-  ///   Read with `WHERE position >= 0 ORDER BY position`.
-  ///
-  /// Nested-list output types (`[[T]]`) report `.list` because
-  /// only the outer list is read by the initial projection; the
-  /// inner list is materialized by issuing a follow-up
-  /// `FieldProjection` against the synthetic sub-record the outer
-  /// row's `child_key_value` points at (per ADR 0006 §3.2).
-  public enum Cardinality: Hashable, Sendable {
-    case scalar
-    case list
-  }
-
-  /// Classifies `outputType` into the SQLite column slot the field's
-  /// value(s) are stored in. See `ColumnShape` for the mapping
-  /// rules.
-  ///
-  /// Nested lists (`[[T]]`, two or more `.list` wrappers) report
-  /// `.childKey` regardless of the innermost named type, because
-  /// the outer-list rows hold `child_key_value` pointers to
-  /// synthetic sub-records that carry the inner list's elements
-  /// (per ADR 0006 §3.2). The inner list's column shape is
-  /// determined by a *follow-up* projection issued by the consumer
-  /// against the synthetic sub-record.
-  public static func columnShape(
-    of outputType: Selection.Field.OutputType
-  ) -> ColumnShape {
-    if listNestingDepth(of: outputType) >= 2 {
-      return .childKey
-    }
-    return columnShape(ofNamedType: peelToNamedType(outputType))
-  }
-
-  /// Returns `.scalar` if `outputType` has no `.list` wrapper at any
-  /// nesting level, `.list` otherwise. `.nonNull` wrappers are
-  /// transparent.
-  ///
-  /// Nested-list output types (`[[T]]`) return `.list` because only
-  /// the outer list drives the initial projection's row predicate —
-  /// the inner list is materialized via follow-up projections per
-  /// `Cardinality`'s doc comment.
-  public static func cardinality(
-    of outputType: Selection.Field.OutputType
-  ) -> Cardinality {
-    switch outputType {
-    case .list:
-      return .list
-    case .nonNull(let inner):
-      return cardinality(of: inner)
-    case .scalar, .customScalar, .object:
-      return .scalar
-    }
-  }
-
-  // MARK: - Output-type classification internals
-
-  /// Returns the inner classification of `outputType` after peeling
-  /// off every `.nonNull` and `.list` wrapper. The result is one of
-  /// `.scalar`, `.customScalar`, or `.object`. A `Selection.Field.
-  /// OutputType` constructed by codegen always bottoms out in one
-  /// of these three cases.
-  private static func peelToNamedType(
-    _ outputType: Selection.Field.OutputType
-  ) -> Selection.Field.OutputType {
-    switch outputType {
-    case .nonNull(let inner), .list(let inner):
-      return peelToNamedType(inner)
-    case .scalar, .customScalar, .object:
-      return outputType
-    }
-  }
-
-  /// Counts the number of `.list` wrappers in `outputType`'s
-  /// wrapper chain. `.nonNull` wrappers are transparent. Used to
-  /// distinguish a flat list (`[T]`, one `.list` wrapper) from a
-  /// nested list (`[[T]]`, two or more) for column-shape routing.
-  private static func listNestingDepth(
-    of outputType: Selection.Field.OutputType
-  ) -> Int {
-    switch outputType {
-    case .list(let inner):
-      return 1 + listNestingDepth(of: inner)
-    case .nonNull(let inner):
-      return listNestingDepth(of: inner)
-    case .scalar, .customScalar, .object:
-      return 0
-    }
-  }
-
-  /// Maps an already-peeled named type (the `.scalar`,
-  /// `.customScalar`, or `.object` case) to its column slot.
-  private static func columnShape(
-    ofNamedType namedType: Selection.Field.OutputType
-  ) -> ColumnShape {
-    switch namedType {
-    case .scalar(let scalarType):
-      return columnShape(forBuiltInScalarType: scalarType)
-    case .customScalar:
-      // All custom scalars route to `.customScalar` for now; the
-      // precise-per-scalar mapping is deferred to a follow-up PR
-      // that adds a static declaration on `CustomScalarType` per
-      // ADR 0007 Principle 7. See `ColumnShape`'s doc comment.
-      return .customScalar
-    case .object:
-      return .childKey
-    case .nonNull, .list:
-      // Unreachable: `peelToNamedType` is the only caller path
-      // and it strips every wrapper before passing the result here.
-      // If this case is ever entered, the invariant has broken — fail
-      // loudly rather than silently routing to `.customScalar`, which
-      // would produce wrong-column reads at runtime.
-      preconditionFailure(
-        "columnShape(ofNamedType:) reached a wrapper type (\(namedType)); peelToNamedType invariant violated"
-      )
-    }
-  }
-
-  /// Maps a built-in `ScalarType` metatype to its column slot. The
-  /// five GraphQL primitive scalars route to their typed columns;
-  /// any other type would be a codegen invariant violation (codegen
-  /// emits non-built-in scalar types through the `.customScalar` case,
-  /// not `.scalar`), so the fallthrough crashes rather than silently
-  /// routing to a wrong column.
-  private static func columnShape(
-    forBuiltInScalarType scalarType: any ScalarType.Type
-  ) -> ColumnShape {
-    if scalarType == String.self { return .string }
-    if scalarType == Int.self || scalarType == Int32.self { return .int }
-    if scalarType == Bool.self { return .bool }
-    if scalarType == Float.self || scalarType == Double.self { return .float }
-    preconditionFailure(
-      "columnShape(forBuiltInScalarType:) received an unrecognized ScalarType (\(scalarType)); custom scalars must route through `.customScalar`, not `.scalar`"
-    )
   }
 }

--- a/apollo-ios/Sources/Apollo/Caching/NormalizedCache.swift
+++ b/apollo-ios/Sources/Apollo/Caching/NormalizedCache.swift
@@ -65,37 +65,14 @@ public protocol ReadOnlyNormalizedCache: AnyObject {
   /// Loads the field values described by `projections`, returning each
   /// requested record's fields as a partial `Record` containing only the
   /// fields the caller asked for. Per ADR 0007 this is the projection-
-  /// aware replacement for ``loadRecords(forKeys:)``; the executor
-  /// (PR-009d) and `ApolloStore` (PR-009e) migrate to this method
-  /// during sub-phase 1A.5, and PR-009g lands SQL-level column
-  /// projection on the SQLite backend.
+  /// aware read path used by the executor and `ApolloStore`.
   ///
   /// - Parameters:
   ///   - projections: The set of fields to read. Each
   ///     ``FieldProjection`` identifies one `(cacheKey, fieldName)`
-  ///     pair plus its storage shape. Multiple projections may share
-  ///     a `cacheKey` to request different fields on the same record.
-  ///     Duplicate projections are tolerated; their results coalesce.
-  ///
-  ///     **Precondition:** the caller must not supply two projections
-  ///     with the same `(cacheKey, fieldName)` but a different
-  ///     `columnShape` or `cardinality`. The cache backend stores each
-  ///     field under a single column-shape (determined at write time
-  ///     by the field's GraphQL type) and cannot answer two
-  ///     incompatible projections for the same row. ``FieldProjection``'s
-  ///     `Hashable` conformance hashes by the full tuple, so the
-  ///     pending set in `ProjectionLoader` won't dedupe such conflicts
-  ///     — they will reach the backend as two separate projections
-  ///     that ask for inconsistent answers. The
-  ///     `FieldProjectionCollector` path derives `columnShape` /
-  ///     `cardinality` from `Selection.Field.OutputType`, which GraphQL
-  ///     validation guarantees is identical for every selection of the
-  ///     same `(cacheKey, fieldName)`, so this can only happen when
-  ///     callers hand-construct projections via the direct
-  ///     ``FieldProjection/init(cacheKey:fieldName:columnShape:cardinality:)``
-  ///     initializer. PR-009g's SQL projection path enforces the
-  ///     precondition implicitly by picking one storage column per
-  ///     field.
+  ///     pair. Multiple projections may share a `cacheKey` to request
+  ///     different fields on the same record. Duplicate projections
+  ///     are tolerated; their results coalesce.
   ///
   /// - Returns: A dictionary of cache keys to partial records. A cache
   ///   key appears in the result if and only if the *record* exists in
@@ -121,14 +98,14 @@ extension ReadOnlyNormalizedCache {
   /// fetch the full records for the projections' cache keys, then
   /// filters each record's `fields` to the requested field names.
   ///
-  /// This is the "fallback" path the ADR 0007 table references for the
-  /// SQLite backend during the 1A.5 transition: until PR-009g lands
-  /// SQL-level column projection, every backend that conforms to
-  /// ``ReadOnlyNormalizedCache`` automatically inherits a correct (if
-  /// unoptimized) `loadFields` implementation by reading whole records
-  /// and filtering in Swift. Custom cache implementors get the same
-  /// behavior without a forced API migration; they may override the
-  /// method with a projection-aware path when they're ready.
+  /// Every backend that conforms to ``ReadOnlyNormalizedCache``
+  /// automatically inherits a correct (if unoptimized) `loadFields`
+  /// implementation by reading whole records and filtering in Swift.
+  /// The SQLite backend relies on this default until PR-009h switches
+  /// it to the row-level `selectFields` read path. Custom cache
+  /// implementors get the same behavior without a forced API
+  /// migration; they may override the method with a projection-aware
+  /// path when they're ready.
   ///
   /// **Performance:** this default is `O(records.count * filteredFields.count)`
   /// with one new dict allocation per surfaced record (the `record.fields.filter`

--- a/apollo-ios/Sources/Apollo/Execution/FieldProjectionCollector.swift
+++ b/apollo-ios/Sources/Apollo/Execution/FieldProjectionCollector.swift
@@ -98,8 +98,10 @@ public enum FieldProjectionCollector {
     //    passes `includeAllInlineFragments: true`, which selects
     //    `.includeAll`. The resulting projection set over-fetches every
     //    type case's fields; the executor's later, type-aware traversal
-    //    surfaces only the matching type case to the response. PR-009g
-    //    will narrow this at the SQL layer.
+    //    surfaces only the matching type case to the response. The
+    //    over-fetch is an accepted cost per ADR 0007; narrowing it at
+    //    the SQL layer (a `__typename`-aware filter) is a deferred
+    //    optimization gated on the Phase 1A performance results.
     //
     //  - `deferredFragmentPolicy: .eager` because the cache path has no
     //    incremental delivery channel — `CacheDataExecutionSource` sets
@@ -156,8 +158,7 @@ public enum FieldProjectionCollector {
     case .parentRecordField(let name):
       projections.insert(FieldProjection(
         cacheKey: cacheKey,
-        fieldName: name,
-        outputType: field.type
+        fieldName: name
       ))
     case .policyReference, .policyReferenceList:
       // No parent-record projection: the field's value is a direct

--- a/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/ApolloSQLiteDatabase.swift
@@ -421,15 +421,8 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
   public func selectFields(_ projections: [FieldProjection]) throws -> [CacheKey: Record] {
     guard !projections.isEmpty else { return [:] }
 
-    // Dedupe `(cacheKey, fieldName)` early — `FieldProjection`'s
-    // `Hashable` conformance hashes by the full tuple including shape
-    // info, so two projections that differ only in `columnShape` /
-    // `cardinality` won't collapse via `Set<FieldProjection>`. The
-    // SQL doesn't read shape info, only the storage pair, so we
-    // dedupe on that.
-    let uniqueProjections = Set(projections.map {
-      ProjectionKey(cacheKey: $0.cacheKey, fieldName: $0.fieldName)
-    })
+    // Dedupe early so duplicate projections coalesce to one SQL bind.
+    let uniqueProjections = Set(projections)
     let requestedKeys = Set(uniqueProjections.map(\.cacheKey))
 
     return try performSync {
@@ -501,7 +494,7 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
   /// IN (VALUES (?, ?), (?, ?), …)`. Returns the raw rows; assembly
   /// happens in the caller via the shared `assembleRecords` helper.
   private func selectProjectedRows<C: Collection>(_ projections: C) throws -> [DecodedRow]
-  where C.Element == ProjectionKey {
+  where C.Element == FieldProjection {
     guard !projections.isEmpty else { return [] }
 
     let valuesClause = Array(repeating: "(?, ?)", count: projections.count).joined(separator: ", ")
@@ -948,14 +941,6 @@ public final class ApolloSQLiteDatabase: SQLiteDatabase {
     let writtenAt: Int64
   }
 
-  /// Storage-shape-agnostic key for deduping projections before
-  /// issuing the SQL. `FieldProjection`'s `Hashable` hashes the full
-  /// tuple (including `columnShape` and `cardinality`), but the row-
-  /// filter SQL only consults `cacheKey` and `fieldName`.
-  private struct ProjectionKey: Hashable {
-    let cacheKey: CacheKey
-    let fieldName: String
-  }
 }
 
 // MARK: - Extensions

--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -173,12 +173,10 @@ public protocol SQLiteDatabase {
   /// surface as top-level cache keys.
   ///
   /// Duplicate projections (same `cacheKey` and `fieldName`) are
-  /// tolerated and coalesce to a single SQL bind. Projections whose
-  /// `columnShape`/`cardinality` differ but share `(cacheKey, fieldName)`
-  /// is a programmer error per the
-  /// ``ReadOnlyNormalizedCache/loadFields(_:)`` precondition; this
-  /// implementation does not detect or report the conflict — it reads
-  /// whichever row exists and returns its actual stored shape.
+  /// tolerated and coalesce to a single SQL bind. The read returns
+  /// each field's actual stored shape; scalar-vs-list is inferred
+  /// from the stored rows' `position` values, not from the
+  /// projection.
   ///
   /// Requires the row-per-element records table (see
   /// `createNewRecordsTableIfNeeded()`).


### PR DESCRIPTION
## Goal
Remove the unconsumed `columnShape`/`cardinality` metadata from `FieldProjection`, making the slim `(cacheKey, fieldName)` pair the entire 3.0 projection contract.

## Design doc reference
- [0007-selection-aware-cache-reads.md](apollo-ios/Design/adr/0007-selection-aware-cache-reads.md): amended decision (amendment PR forthcoming) — row filtering is the shipped read design; column projection is dropped, position predicates are dropped, and the `__typename` SQL filter is deferred behind perf measurement.

## Position in execution plan
PR-009g-ii of the cache rewrite Phase 1 stack. See [cache-rewrite-phase1-execution.md](apollo-ios/Design/cache-rewrite-phase1-execution.md) §8.

## Stacks on
- `cache-rewrite/phase-1a-sqlite-projection` (PR-009g, #1023)

## Followups in this stack
- ADR 0007 amendment + perf-plan `selectFields` scenarios (docs PR against `cache-rewrite/phase-1-plan`)
- PR-009h: `SQLiteNormalizedCache` switches to field-aware path + drop-and-rebuild migration

## Files changed
- `apollo-ios/Sources/Apollo/Caching/`
  - `FieldProjection.swift` — slimmed to `(cacheKey, fieldName)`; `ColumnShape`, `Cardinality`, and all OutputType classification machinery removed
  - `NormalizedCache.swift` — conflicting-duplicate-projections precondition removed (no longer expressible); stale 1A.5 migration narration rewritten
  - `CacheDependentKey.swift`, `ApolloStore.swift` — stale shape/PR-009g references rewritten
- `apollo-ios/Sources/Apollo/Execution/`
  - `FieldProjectionCollector.swift` — constructs slim projections; over-fetch comment now cites the accepted-cost decision
- `apollo-ios/Sources/ApolloSQLite/`
  - `ApolloSQLiteDatabase.swift` — redundant `ProjectionKey` dedupe struct removed; `Set<FieldProjection>` used directly
  - `SQLiteDatabase.swift` — `selectFields` doc updated (stored shape inferred from `position` values)
- `Tests/ApolloTests/` — `FieldProjectionTests` rewritten for the slim surface; shape arguments removed from `LoadFieldsTests`, `SQLiteSelectFieldsTests`, `ProjectionLoaderTests`, `FieldProjectionCollectorTests`

## Tests added
- None new — this PR removes API. `FieldProjectionTests` retains construction, equality, and hashing coverage for the slim type; all existing projection/loader/read-path behavior tests pass unchanged, demonstrating the shape metadata had no behavioral consumers.

## Acceptance criteria
- [ ] No references to `columnShape`/`ColumnShape`/`cardinality`/`Cardinality` remain in `apollo-ios/Sources` or `Tests`
- [ ] `Set<FieldProjection>` dedupes on `(cacheKey, fieldName)` — the conflicting-duplicates hazard is structurally gone
- [ ] Shape-mismatch behavior (declared vs stored) remains a caller-visible `JSONDecodingError.wrongType`, matching 2.x

## Verification
- `tuist generate` succeeds: yes
- Build green: yes — ApolloTests scheme
- Tests pass: yes — FieldProjection/Collector/LoadFields/SQLiteSelectFields/ProjectionLoader/ReadWriteFromStore/LoadQueryFromStore/WatchQuery suites (131/131) on Apollo-UnitTestPlan
- `XcodeListNavigatorIssues severity:"error"` returns zero: yes
- New warnings introduced: none

## Notes for reviewer
Rationale for dropping (not deferring) column projection: SQLite is row-oriented and the records table is `WITHOUT ROWID` (clustered whole-row storage), so column narrowing saves no IO — NULL columns cost ~1 header byte each. Position predicates read identical rows on well-formed data; their only effect was converting a declared-vs-stored shape mismatch into a silent refetch, where the intended semantics (per discussion) is the 2.x-matching caller-visible error. If the profile-gated `__typename` SQL filter is later justified, it requires type-condition metadata that can be added to `FieldProjection` as an additive, non-breaking property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)