### PR TITLE
Resolve deferred response paths against the initial cache records

### DIFF
--- a/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests_IncrementalItems.swift
+++ b/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests_IncrementalItems.swift
@@ -544,9 +544,6 @@ final class JSONResponseParsingInterceptorTests_IncrementalItems: XCTestCase {
 
   typealias AnimalQuery = MockDeferredAnimalQuery
 
-  /// Like ``MockDeferredAnimalQuery`` but selects `id` on `animal` so it normalizes by an id-based
-  /// cache key when `cacheKeyInfo` is configured. Used to verify deferred paths resolve to the real
-  /// record key rather than the naive `QUERY_ROOT.<path>` join.
   struct AnimalWithIDQuery: GraphQLQuery, @unchecked Sendable {
     static var operationName: String { "AnimalWithIDQuery" }
 

--- a/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests_IncrementalItems.swift
+++ b/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests_IncrementalItems.swift
@@ -540,6 +540,325 @@ final class JSONResponseParsingInterceptorTests_IncrementalItems: XCTestCase {
     )
   }
 
+  func test__intercept__givenAliasedPathComponent_incrementalRecordsResolveToRealRecord()
+    async throws
+  {
+    // given
+    // The container is reached via an aliased field (`pet: animal`), so the incremental path is
+    // ["pet"] but the record stores the field under its name `animal`. The resolver must map the
+    // response key back to the field's cache key.
+    await MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
+
+    let operation = AliasedAnimalQuery()
+    let streamMocker = AsyncStreamMocker<Data>()
+
+    let urlResponse = HTTPURLResponse.deferResponseMock()
+
+    // when
+    var actualResultsIterator = try await subject.parse(
+      response: HTTPResponse(
+        response: urlResponse,
+        chunks: streamMocker.getStream()
+      ),
+      for: JSONRequest.mock(operation: operation, fetchBehavior: .NetworkOnly),
+      includeCacheRecords: true
+    )
+    .getStream()
+    .makeAsyncIterator()
+
+    streamMocker.emit(
+      """
+      {
+        "data": {
+          "pet": {
+            "__typename": "Animal",
+            "id": "1",
+            "species": "Canis Familiaris"
+          }
+        },
+        "hasNext": true
+      }
+      """.data(using: .utf8)!
+    )
+
+    // then
+    let result1 = try await actualResultsIterator.next()
+    expect(result1?.cacheRecords).to(
+      equal(
+        RecordSet(records: [
+          Record(key: "QUERY_ROOT", ["animal": CacheReference("Animal:1")]),
+          Record(key: "Animal:1", ["__typename": "Animal", "id": "1", "species": "Canis Familiaris"]),
+        ])
+      )
+    )
+
+    streamMocker.emit(
+      """
+      {
+        "incremental": [
+          {
+            "label": "deferredGenus",
+            "data": { "genus": "Canis" },
+            "path": ["pet"]
+          }
+        ],
+        "hasNext": false
+      }
+      """.data(using: .utf8)!
+    )
+
+    // then
+    let result2 = try await actualResultsIterator.next()
+    expect(result2?.cacheRecords).to(
+      equal(
+        RecordSet(records: [
+          Record(key: "QUERY_ROOT", ["animal": CacheReference("Animal:1")]),
+          Record(
+            key: "Animal:1",
+            ["__typename": "Animal", "id": "1", "genus": "Canis", "species": "Canis Familiaris"]
+          ),
+        ])
+      )
+    )
+  }
+
+  func test__intercept__givenArgumentBearingPathComponent_incrementalRecordsResolveToRealRecord()
+    async throws
+  {
+    // given
+    // The container is reached via a field with arguments (`animal(kind: "dog")`), so the record
+    // stores the field under `animal(kind:dog)` while the path carries the response key `animal`.
+    await MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
+
+    let operation = ArgumentAnimalQuery()
+    let streamMocker = AsyncStreamMocker<Data>()
+
+    let urlResponse = HTTPURLResponse.deferResponseMock()
+
+    // when
+    var actualResultsIterator = try await subject.parse(
+      response: HTTPResponse(
+        response: urlResponse,
+        chunks: streamMocker.getStream()
+      ),
+      for: JSONRequest.mock(operation: operation, fetchBehavior: .NetworkOnly),
+      includeCacheRecords: true
+    )
+    .getStream()
+    .makeAsyncIterator()
+
+    streamMocker.emit(
+      """
+      {
+        "data": {
+          "animal": {
+            "__typename": "Animal",
+            "id": "1",
+            "species": "Canis Familiaris"
+          }
+        },
+        "hasNext": true
+      }
+      """.data(using: .utf8)!
+    )
+
+    // then
+    let result1 = try await actualResultsIterator.next()
+    expect(result1?.cacheRecords).to(
+      equal(
+        RecordSet(records: [
+          Record(key: "QUERY_ROOT", ["animal(kind:dog)": CacheReference("Animal:1")]),
+          Record(key: "Animal:1", ["__typename": "Animal", "id": "1", "species": "Canis Familiaris"]),
+        ])
+      )
+    )
+
+    streamMocker.emit(
+      """
+      {
+        "incremental": [
+          {
+            "label": "deferredGenus",
+            "data": { "genus": "Canis" },
+            "path": ["animal"]
+          }
+        ],
+        "hasNext": false
+      }
+      """.data(using: .utf8)!
+    )
+
+    // then
+    let result2 = try await actualResultsIterator.next()
+    expect(result2?.cacheRecords).to(
+      equal(
+        RecordSet(records: [
+          Record(key: "QUERY_ROOT", ["animal(kind:dog)": CacheReference("Animal:1")]),
+          Record(
+            key: "Animal:1",
+            ["__typename": "Animal", "id": "1", "genus": "Canis", "species": "Canis Familiaris"]
+          ),
+        ])
+      )
+    )
+  }
+
+  func test__intercept__givenListIndexPathComponent_withNullSibling_resolvesToRealListElementRecord()
+    async throws
+  {
+    // given
+    // A deferred fragment on a list element must resolve through the index to the real `Friend:10`
+    // record. The list (stored as `[JSONValue?]`) includes a null sibling to exercise the index
+    // branch against the type the normalizer actually stores.
+    await MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
+
+    let operation = AnimalFriendsQuery()
+    let streamMocker = AsyncStreamMocker<Data>()
+
+    let urlResponse = HTTPURLResponse.deferResponseMock()
+
+    // when
+    var actualResultsIterator = try await subject.parse(
+      response: HTTPResponse(
+        response: urlResponse,
+        chunks: streamMocker.getStream()
+      ),
+      for: JSONRequest.mock(operation: operation, fetchBehavior: .NetworkOnly),
+      includeCacheRecords: true
+    )
+    .getStream()
+    .makeAsyncIterator()
+
+    streamMocker.emit(
+      """
+      {
+        "data": {
+          "animal": {
+            "__typename": "Animal",
+            "id": "1",
+            "friends": [
+              { "__typename": "Friend", "id": "10" },
+              null
+            ]
+          }
+        },
+        "hasNext": true
+      }
+      """.data(using: .utf8)!
+    )
+
+    _ = try await actualResultsIterator.next()
+
+    streamMocker.emit(
+      """
+      {
+        "incremental": [
+          {
+            "label": "deferredNickname",
+            "data": { "nickname": "Buster" },
+            "path": ["animal", "friends", 0]
+          }
+        ],
+        "hasNext": false
+      }
+      """.data(using: .utf8)!
+    )
+
+    // then
+    let result2 = try await actualResultsIterator.next()
+    expect(result2?.cacheRecords?["Friend:10"]).to(
+      equal(Record(key: "Friend:10", ["__typename": "Friend", "id": "10", "nickname": "Buster"]))
+    )
+    expect(result2?.cacheRecords?["QUERY_ROOT.animal.friends.0"]).to(beNil())
+  }
+
+  func test__intercept__givenMultiHopPath_resolvesAgainstContainerIntroducedByEarlierIncrement()
+    async throws
+  {
+    // given
+    // The first increment introduces `friend` (Friend:2); the second increment's path walks through
+    // that container, so it must resolve against records the first increment merged in.
+    await MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
+
+    let operation = AnimalNestedFriendQuery()
+    let streamMocker = AsyncStreamMocker<Data>()
+
+    let urlResponse = HTTPURLResponse.deferResponseMock()
+
+    // when
+    var actualResultsIterator = try await subject.parse(
+      response: HTTPResponse(
+        response: urlResponse,
+        chunks: streamMocker.getStream()
+      ),
+      for: JSONRequest.mock(operation: operation, fetchBehavior: .NetworkOnly),
+      includeCacheRecords: true
+    )
+    .getStream()
+    .makeAsyncIterator()
+
+    streamMocker.emit(
+      """
+      {
+        "data": {
+          "animal": { "__typename": "Animal", "id": "1" }
+        },
+        "hasNext": true
+      }
+      """.data(using: .utf8)!
+    )
+
+    _ = try await actualResultsIterator.next()
+
+    // First increment introduces the `friend` container.
+    streamMocker.emit(
+      """
+      {
+        "incremental": [
+          {
+            "label": "deferredFriend",
+            "data": {
+              "friend": { "__typename": "Friend", "id": "2", "name": "Buster" }
+            },
+            "path": ["animal"]
+          }
+        ],
+        "hasNext": true
+      }
+      """.data(using: .utf8)!
+    )
+
+    let result2 = try await actualResultsIterator.next()
+    expect(result2?.cacheRecords?["Friend:2"]).to(
+      equal(Record(key: "Friend:2", ["__typename": "Friend", "id": "2", "name": "Buster"]))
+    )
+
+    // Second increment resolves against the container the first increment introduced.
+    streamMocker.emit(
+      """
+      {
+        "incremental": [
+          {
+            "label": "deferredNickname",
+            "data": { "nickname": "B" },
+            "path": ["animal", "friend"]
+          }
+        ],
+        "hasNext": false
+      }
+      """.data(using: .utf8)!
+    )
+
+    // then
+    let result3 = try await actualResultsIterator.next()
+    expect(result3?.cacheRecords?["Friend:2"]).to(
+      equal(
+        Record(key: "Friend:2", ["__typename": "Friend", "id": "2", "name": "Buster", "nickname": "B"])
+      )
+    )
+    expect(result3?.cacheRecords?["QUERY_ROOT.animal.friend"]).to(beNil())
+  }
+
   // MARK: Mock Query Helpers
 
   typealias AnimalQuery = MockDeferredAnimalQuery
@@ -599,6 +918,203 @@ final class JSONResponseParsingInterceptorTests_IncrementalItems: XCTestCase {
           }
 
           var genus: String { __data["genus"] }
+        }
+      }
+    }
+  }
+
+  /// Selects the deferred container via an aliased field (`pet: animal`).
+  struct AliasedAnimalQuery: GraphQLQuery, @unchecked Sendable {
+    static var operationName: String { "AliasedAnimalQuery" }
+
+    static var operationDocument: OperationDocument {
+      .init(definition: .init("Mock Operation Definition"))
+    }
+
+    static var responseFormat: IncrementalDeferredResponseFormat {
+      IncrementalDeferredResponseFormat(deferredFragments: [
+        DeferredFragmentIdentifier(label: "deferredGenus", fieldPath: ["pet"]): AnAnimal.Animal.DeferredGenus.self
+      ])
+    }
+
+    typealias Data = AnAnimal
+    final class AnAnimal: MockSelectionSet, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {
+        [
+          .field("animal", alias: "pet", Animal.self)
+        ]
+      }
+
+      final class Animal: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .field("species", String.self),
+            .deferred(DeferredGenus.self, label: "deferredGenus"),
+          ]
+        }
+
+        final class DeferredGenus: MockTypeCase, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [.field("genus", String.self)]
+          }
+        }
+      }
+    }
+  }
+
+  /// Selects the deferred container via a field with arguments (`animal(kind: "dog")`).
+  struct ArgumentAnimalQuery: GraphQLQuery, @unchecked Sendable {
+    static var operationName: String { "ArgumentAnimalQuery" }
+
+    static var operationDocument: OperationDocument {
+      .init(definition: .init("Mock Operation Definition"))
+    }
+
+    static var responseFormat: IncrementalDeferredResponseFormat {
+      IncrementalDeferredResponseFormat(deferredFragments: [
+        DeferredFragmentIdentifier(label: "deferredGenus", fieldPath: ["animal"]): AnAnimal.Animal.DeferredGenus.self
+      ])
+    }
+
+    typealias Data = AnAnimal
+    final class AnAnimal: MockSelectionSet, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {
+        [
+          .field("animal", Animal.self, arguments: ["kind": "dog"])
+        ]
+      }
+
+      final class Animal: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .field("species", String.self),
+            .deferred(DeferredGenus.self, label: "deferredGenus"),
+          ]
+        }
+
+        final class DeferredGenus: MockTypeCase, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [.field("genus", String.self)]
+          }
+        }
+      }
+    }
+  }
+
+  /// A deferred fragment on the elements of a nullable list (`animal.friends: [Friend?]`).
+  struct AnimalFriendsQuery: GraphQLQuery, @unchecked Sendable {
+    static var operationName: String { "AnimalFriendsQuery" }
+
+    static var operationDocument: OperationDocument {
+      .init(definition: .init("Mock Operation Definition"))
+    }
+
+    static var responseFormat: IncrementalDeferredResponseFormat {
+      IncrementalDeferredResponseFormat(deferredFragments: [
+        DeferredFragmentIdentifier(label: "deferredNickname", fieldPath: ["animal", "friends"]):
+          AnAnimal.Animal.Friend.DeferredNickname.self
+      ])
+    }
+
+    typealias Data = AnAnimal
+    final class AnAnimal: MockSelectionSet, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {
+        [.field("animal", Animal.self)]
+      }
+
+      final class Animal: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .field("friends", [Friend?].self),
+          ]
+        }
+
+        final class Friend: MockSelectionSet, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("__typename", String.self),
+              .field("id", String.self),
+              .deferred(DeferredNickname.self, label: "deferredNickname"),
+            ]
+          }
+
+          final class DeferredNickname: MockTypeCase, @unchecked Sendable {
+            override class var __selections: [Selection] {
+              [.field("nickname", String.self)]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// A deferred fragment nested inside another deferred fragment's container, for multi-hop paths.
+  struct AnimalNestedFriendQuery: GraphQLQuery, @unchecked Sendable {
+    static var operationName: String { "AnimalNestedFriendQuery" }
+
+    static var operationDocument: OperationDocument {
+      .init(definition: .init("Mock Operation Definition"))
+    }
+
+    static var responseFormat: IncrementalDeferredResponseFormat {
+      IncrementalDeferredResponseFormat(deferredFragments: [
+        DeferredFragmentIdentifier(label: "deferredFriend", fieldPath: ["animal"]):
+          AnAnimal.Animal.DeferredFriend.self,
+        DeferredFragmentIdentifier(label: "deferredNickname", fieldPath: ["animal", "friend"]):
+          AnAnimal.Animal.Friend.DeferredNickname.self,
+      ])
+    }
+
+    typealias Data = AnAnimal
+    final class AnAnimal: MockSelectionSet, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {
+        [.field("animal", Animal.self)]
+      }
+
+      final class Animal: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .deferred(DeferredFriend.self, label: "deferredFriend"),
+          ]
+        }
+
+        final class DeferredFriend: MockTypeCase, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [.field("friend", Friend.self)]
+          }
+        }
+
+        final class Friend: MockSelectionSet, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("__typename", String.self),
+              .field("id", String.self),
+              .field("name", String.self),
+              .deferred(DeferredNickname.self, label: "deferredNickname"),
+            ]
+          }
+
+          final class DeferredNickname: MockTypeCase, @unchecked Sendable {
+            override class var __selections: [Selection] {
+              [.field("nickname", String.self)]
+            }
+          }
         }
       }
     }

--- a/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests_IncrementalItems.swift
+++ b/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests_IncrementalItems.swift
@@ -431,9 +431,181 @@ final class JSONResponseParsingInterceptorTests_IncrementalItems: XCTestCase {
     )
   }
 
+  func test__intercept__givenIdBasedCacheKey_incrementalRecordsMergeOntoRealRecordNotNaivePath()
+    async throws
+  {
+    // given
+    // Normalize `animal` by its `id`, so the initial chunk writes it as `Animal:1`, not `QUERY_ROOT.animal`.
+    await MockSchemaMetadata.stub_cacheKeyInfoForType_Object(IDCacheKeyProvider.resolver)
+
+    let operation = AnimalWithIDQuery()
+    let streamMocker = AsyncStreamMocker<Data>()
+
+    let urlResponse = HTTPURLResponse.deferResponseMock()
+
+    // when
+    var actualResultsIterator = try await subject.parse(
+      response: HTTPResponse(
+        response: urlResponse,
+        chunks: streamMocker.getStream()
+      ),
+      for: JSONRequest.mock(operation: operation, fetchBehavior: .NetworkOnly),
+      includeCacheRecords: true
+    )
+    .getStream()
+    .makeAsyncIterator()
+
+    streamMocker.emit(
+      """
+      {
+        "data": {
+          "animal": {
+            "__typename": "Animal",
+            "id": "1",
+            "species": "Canis Familiaris"
+          }
+        },
+        "hasNext": true
+      }
+      """.data(using: .utf8)!
+    )
+
+    // then
+    let result1 = try await actualResultsIterator.next()
+    expect(result1?.cacheRecords).to(
+      equal(
+        RecordSet(records: [
+          Record(
+            key: "QUERY_ROOT",
+            [
+              "animal": CacheReference("Animal:1")
+            ]
+          ),
+          Record(
+            key: "Animal:1",
+            [
+              "__typename": "Animal",
+              "id": "1",
+              "species": "Canis Familiaris",
+            ]
+          ),
+        ])
+      )
+    )
+
+    streamMocker.emit(
+      """
+      {
+        "incremental": [
+          {
+            "label": "deferredGenus",
+            "data": {
+              "genus": "Canis"
+            },
+            "path": [
+              "animal"
+            ]
+          }
+        ],
+        "hasNext": false
+      }
+      """.data(using: .utf8)!
+    )
+
+    // then
+    // The deferred `path: ["animal"]` must resolve against the initial records to the real `Animal:1`
+    // key. With the naive `QUERY_ROOT.animal` join this would land on a phantom record instead, and
+    // the merged `Animal:1` record would never receive `genus`.
+    let result2 = try await actualResultsIterator.next()
+    expect(result2?.cacheRecords).to(
+      equal(
+        RecordSet(records: [
+          Record(
+            key: "QUERY_ROOT",
+            [
+              "animal": CacheReference("Animal:1")
+            ]
+          ),
+          Record(
+            key: "Animal:1",
+            [
+              "__typename": "Animal",
+              "id": "1",
+              "genus": "Canis",
+              "species": "Canis Familiaris",
+            ]
+          ),
+        ])
+      )
+    )
+  }
+
   // MARK: Mock Query Helpers
 
   typealias AnimalQuery = MockDeferredAnimalQuery
+
+  /// Like ``MockDeferredAnimalQuery`` but selects `id` on `animal` so it normalizes by an id-based
+  /// cache key when `cacheKeyInfo` is configured. Used to verify deferred paths resolve to the real
+  /// record key rather than the naive `QUERY_ROOT.<path>` join.
+  struct AnimalWithIDQuery: GraphQLQuery, @unchecked Sendable {
+    static var operationName: String { "AnimalWithIDQuery" }
+
+    static var operationDocument: OperationDocument {
+      .init(definition: .init("Mock Operation Definition"))
+    }
+
+    static var responseFormat: IncrementalDeferredResponseFormat {
+      IncrementalDeferredResponseFormat(deferredFragments: [
+        DeferredFragmentIdentifier(label: "deferredGenus", fieldPath: ["animal"]): AnAnimal.Animal.DeferredGenus.self
+      ])
+    }
+
+    typealias Data = AnAnimal
+    final class AnAnimal: MockSelectionSet, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {
+        [
+          .field("animal", Animal.self)
+        ]
+      }
+
+      var animal: Animal { __data["animal"] }
+
+      final class Animal: AbstractMockSelectionSet<Animal.Fragments, MockSchemaMetadata>, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .field("species", String.self),
+            .deferred(DeferredGenus.self, label: "deferredGenus"),
+          ]
+        }
+
+        var species: String { __data["species"] }
+
+        struct Fragments: FragmentContainer {
+          let __data: DataDict
+          init(_dataDict: DataDict) {
+            __data = _dataDict
+            _deferredGenus = Deferred(_dataDict: _dataDict)
+          }
+
+          @Deferred var deferredGenus: DeferredGenus?
+        }
+
+        final class DeferredGenus: MockTypeCase, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("genus", String.self)
+            ]
+          }
+
+          var genus: String { __data["genus"] }
+        }
+      }
+    }
+  }
 
   final class CatQuery: MockQuery<CatQuery.CatSelectionSet>, @unchecked Sendable {
     final class CatSelectionSet: MockSelectionSet, @unchecked Sendable {

--- a/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests_IncrementalItems.swift
+++ b/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests_IncrementalItems.swift
@@ -859,6 +859,70 @@ final class JSONResponseParsingInterceptorTests_IncrementalItems: XCTestCase {
     expect(result3?.cacheRecords?["QUERY_ROOT.animal.friend"]).to(beNil())
   }
 
+  func test__intercept__givenAmbiguousPathField_whenIncludingCacheRecords_shouldThrowAmbiguousPathField()
+    async throws
+  {
+    // given
+    // `friend` is selected twice with differing arguments, so the response key `friend` maps to two
+    // fields with different cache keys. When the deferred path steps through `friend`, its real cache
+    // key is ambiguous — that must throw rather than silently fall back to a phantom record.
+    let operation = AmbiguousFriendAnimalQuery()
+    let streamMocker = AsyncStreamMocker<Data>()
+
+    let urlResponse = HTTPURLResponse.deferResponseMock()
+
+    // when
+    var actualResultsIterator = try await subject.parse(
+      response: HTTPResponse(
+        response: urlResponse,
+        chunks: streamMocker.getStream()
+      ),
+      for: JSONRequest.mock(operation: operation, fetchBehavior: .NetworkOnly),
+      includeCacheRecords: true
+    )
+    .getStream()
+    .makeAsyncIterator()
+
+    streamMocker.emit(
+      """
+      {
+        "data": {
+          "animal": {
+            "__typename": "Animal",
+            "friend": { "__typename": "Friend", "id": "10" }
+          }
+        },
+        "hasNext": true
+      }
+      """.data(using: .utf8)!
+    )
+
+    _ = try await actualResultsIterator.next()
+
+    streamMocker.emit(
+      """
+      {
+        "incremental": [
+          {
+            "label": "deferredNickname",
+            "data": { "nickname": "Buster" },
+            "path": ["animal", "friend"]
+          }
+        ],
+        "hasNext": false
+      }
+      """.data(using: .utf8)!
+    )
+
+    // then
+    do {
+      _ = try await actualResultsIterator.next()
+      fail("Expected IncrementalResponseError.ambiguousPathField to be thrown")
+    } catch {
+      expect(error as? IncrementalResponseError).to(equal(.ambiguousPathField("friend")))
+    }
+  }
+
   // MARK: Mock Query Helpers
 
   typealias AnimalQuery = MockDeferredAnimalQuery
@@ -1106,6 +1170,58 @@ final class JSONResponseParsingInterceptorTests_IncrementalItems: XCTestCase {
               .field("__typename", String.self),
               .field("id", String.self),
               .field("name", String.self),
+              .deferred(DeferredNickname.self, label: "deferredNickname"),
+            ]
+          }
+
+          final class DeferredNickname: MockTypeCase, @unchecked Sendable {
+            override class var __selections: [Selection] {
+              [.field("nickname", String.self)]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// Selects `friend` twice with differing arguments, so the response key `friend` maps to two
+  /// fields with different cache keys — an ambiguous deferred path container.
+  struct AmbiguousFriendAnimalQuery: GraphQLQuery, @unchecked Sendable {
+    static var operationName: String { "AmbiguousFriendAnimalQuery" }
+
+    static var operationDocument: OperationDocument {
+      .init(definition: .init("Mock Operation Definition"))
+    }
+
+    static var responseFormat: IncrementalDeferredResponseFormat {
+      IncrementalDeferredResponseFormat(deferredFragments: [
+        DeferredFragmentIdentifier(label: "deferredNickname", fieldPath: ["animal", "friend"]):
+          AnAnimal.Animal.Friend.DeferredNickname.self
+      ])
+    }
+
+    typealias Data = AnAnimal
+    final class AnAnimal: MockSelectionSet, @unchecked Sendable {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {
+        [.field("animal", Animal.self)]
+      }
+
+      final class Animal: MockSelectionSet, @unchecked Sendable {
+        override class var __selections: [Selection] {
+          [
+            .field("__typename", String.self),
+            .field("friend", Friend?.self, arguments: ["kind": "dog"]),
+            .field("friend", Friend?.self, arguments: ["kind": "cat"]),
+          ]
+        }
+
+        final class Friend: MockSelectionSet, @unchecked Sendable {
+          override class var __selections: [Selection] {
+            [
+              .field("__typename", String.self),
+              .field("id", String.self),
               .deferred(DeferredNickname.self, label: "deferredNickname"),
             ]
           }

--- a/Tests/ApolloTests/JSONResponseParser_IncrementalResponseParsingTests.swift
+++ b/Tests/ApolloTests/JSONResponseParser_IncrementalResponseParsingTests.swift
@@ -447,4 +447,61 @@ final class JSONResponseParser_IncrementalResponseParsingTests: XCTestCase {
     expect(dependentKeys).toNot(beNil())
     expect(dependentKeys).to(contain(CacheKey("QUERY_ROOT.animal.genus")))
   }
+
+  func
+    test__parsing__givenUnresolvablePath_whenIncludingCacheRecords__shouldThrowUnresolvablePath()
+    async throws
+  {
+    // With cache records available, a deferred path that cannot be walked to a real record must
+    // throw rather than silently fall back to the naive `QUERY_ROOT.<path>` join. Falling back would
+    // write the deferred fields onto a phantom record — the exact bug the resolution exists to fix.
+    // Here the path steps into the `species` scalar, so it cannot terminate on a record reference.
+    var (iterator, mocker) = try await setUpIteratorWithInitialResponse(includeCacheRecords: true)
+
+    mocker.emit(
+      """
+      {
+        "incremental": [{
+          "label": "deferredGenus",
+          "data": { "genus": "Canis" },
+          "path": ["animal", "species"]
+        }],
+        "hasNext": false
+      }
+      """.data(using: .utf8)!
+    )
+
+    do {
+      _ = try await iterator.next()
+      fail("Expected IncrementalResponseError.unresolvablePath to be thrown")
+    } catch {
+      expect(error as? IncrementalResponseError).to(equal(.unresolvablePath("animal.species")))
+    }
+  }
+
+  func test__parsing__givenResolvablePath_whenOmittingCacheRecords__shouldNotThrow()
+    async throws
+  {
+    // When cache records are not being produced, the root key never reaches the cache, so the naive
+    // path join is harmless and the resolution-against-records path (and its throw) is skipped
+    // entirely. Parsing must still succeed.
+    var (iterator, mocker) = try await setUpIteratorWithInitialResponse(includeCacheRecords: false)
+
+    mocker.emit(
+      """
+      {
+        "incremental": [{
+          "label": "deferredGenus",
+          "data": { "genus": "Canis" },
+          "path": ["animal"]
+        }],
+        "hasNext": false
+      }
+      """.data(using: .utf8)!
+    )
+
+    let result = try await iterator.next()
+    expect(result?.result.data?.animal.fragments.deferredGenus?.genus).to(equal("Canis"))
+    expect(result?.cacheRecords).to(beNil())
+  }
 }

--- a/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
@@ -31,13 +31,18 @@ extension JSONResponseParser {
 
     init(
       responseBody: JSONObject,
-      operationVariables: GraphQLOperation.Variables?
+      operationVariables: GraphQLOperation.Variables?,
+      existingRecords: RecordSet?
     ) throws {
       guard let path = responseBody["path"] as? [JSONValue] else {
         throw IncrementalResponseError.missingPath
       }
 
-      let rootKey = try CacheReference.rootCacheReference(for: Operation.operationType, path: path)
+      let rootKey = try CacheReference.rootCacheReference(
+        for: Operation.operationType,
+        path: path,
+        resolvingAgainst: existingRecords
+      )
 
       self.base = BaseResponseExecutionHandler(
         responseBody: responseBody,
@@ -146,14 +151,58 @@ extension JSONResponseParser {
 extension CacheReference {
   fileprivate static func rootCacheReference(
     for operationType: GraphQLOperationType,
-    path: [JSONValue]
+    path: [JSONValue],
+    resolvingAgainst records: RecordSet?
   ) throws -> CacheReference {
-    var keys: [String] = [rootCacheReference(for: operationType).key]
+    let rootKey = rootCacheReference(for: operationType).key
+
+    if let records,
+       let resolvedKey = resolveCacheKey(forPath: path, fromRootKey: rootKey, in: records) {
+      return CacheReference(resolvedKey)
+    }
+
+    var keys: [String] = [rootKey]
     for component in path {
       keys.append(try String(_jsonValue: component))
     }
 
     return CacheReference(keys.joined(separator: "."))
+  }
+
+  private static func resolveCacheKey(
+    forPath path: [JSONValue],
+    fromRootKey rootKey: String,
+    in records: RecordSet
+  ) -> String? {
+    var current: JSONValue? = CacheReference(rootKey)
+
+    for component in path {
+      switch current {
+      case let reference as CacheReference:
+        guard let fieldName = component as? String,
+              let record = records[reference.key] else {
+          return nil
+        }
+        current = record[fieldName]
+
+      case let list as [JSONValue]:
+        guard let index = pathIndex(from: component), list.indices.contains(index) else {
+          return nil
+        }
+        current = list[index]
+
+      default:
+        return nil
+      }
+    }
+
+    return (current as? CacheReference)?.key
+  }
+
+  private static func pathIndex(from component: JSONValue) -> Int? {
+    if let index = component as? Int { return index }
+    if let string = component as? String { return Int(string) }
+    return nil
   }
 }
 

--- a/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
@@ -6,6 +6,7 @@ public enum IncrementalResponseError: Error, LocalizedError, Equatable {
   case missingPath
   case missingLabel
   case missingDeferredSelectionSetType(String, String)
+  case unresolvablePath(String)
 
   public var errorDescription: String? {
     switch self {
@@ -19,6 +20,11 @@ public enum IncrementalResponseError: Error, LocalizedError, Equatable {
 
     case let .missingDeferredSelectionSetType(label, path):
       return "The operation does not have a deferred selection set for label '\(label)' at field path '\(path)'."
+
+    case let .unresolvablePath(path):
+      return "Could not resolve incremental response path '\(path)' to a record in the initial "
+        + "response's normalized cache records. The deferred container must be present in the "
+        + "initial response, so this indicates a malformed response or an unsupported selection shape."
     }
   }
 }
@@ -160,17 +166,26 @@ extension CacheReference {
   ) throws -> CacheReference {
     let rootKey = rootCacheReference(for: operationType).key
 
-    if let records,
-       let resolvedKey = resolveCacheKey(
+    // When cache records are available (`includeCacheRecords == true`), resolving the deferred path
+    // against them is authoritative. A resolution failure here is never benign: the only paths the
+    // naive join keys correctly are exactly the ones the walk also resolves, so falling back would
+    // silently write the deferred fields onto a phantom `rootKey.<path>` record — the very bug this
+    // resolution exists to fix. Surface it instead.
+    if let records {
+      guard let resolvedKey = resolveCacheKey(
         forPath: path,
         fromRootKey: rootKey,
         rootSelectionSet: rootSelectionSet,
         variables: variables,
         in: records
-       ) {
+      ) else {
+        throw IncrementalResponseError.unresolvablePath(pathDescription(path))
+      }
       return CacheReference(resolvedKey)
     }
 
+    // No cache records are being produced, so `rootKey` never reaches the cache and the naive join
+    // has no observable effect on the result. Preserve the original behavior for this path.
     var keys: [String] = [rootKey]
     for component in path {
       keys.append(try String(_jsonValue: component))
@@ -266,6 +281,10 @@ extension CacheReference {
     if let index = component as? Int { return index }
     if let string = component as? String { return Int(string) }
     return nil
+  }
+
+  private static func pathDescription(_ path: [JSONValue]) -> String {
+    path.map { (try? String(_jsonValue: $0)) ?? String(describing: $0) }.joined(separator: ".")
   }
 }
 

--- a/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
@@ -41,6 +41,8 @@ extension JSONResponseParser {
       let rootKey = try CacheReference.rootCacheReference(
         for: Operation.operationType,
         path: path,
+        rootSelectionSet: Operation.Data.self,
+        variables: operationVariables,
         resolvingAgainst: existingRecords
       )
 
@@ -152,12 +154,20 @@ extension CacheReference {
   fileprivate static func rootCacheReference(
     for operationType: GraphQLOperationType,
     path: [JSONValue],
+    rootSelectionSet: any SelectionSet.Type,
+    variables: GraphQLOperation.Variables?,
     resolvingAgainst records: RecordSet?
   ) throws -> CacheReference {
     let rootKey = rootCacheReference(for: operationType).key
 
     if let records,
-       let resolvedKey = resolveCacheKey(forPath: path, fromRootKey: rootKey, in: records) {
+       let resolvedKey = resolveCacheKey(
+        forPath: path,
+        fromRootKey: rootKey,
+        rootSelectionSet: rootSelectionSet,
+        variables: variables,
+        in: records
+       ) {
       return CacheReference(resolvedKey)
     }
 
@@ -172,20 +182,27 @@ extension CacheReference {
   private static func resolveCacheKey(
     forPath path: [JSONValue],
     fromRootKey rootKey: String,
+    rootSelectionSet: any SelectionSet.Type,
+    variables: GraphQLOperation.Variables?,
     in records: RecordSet
   ) -> String? {
     var current: JSONValue? = CacheReference(rootKey)
+    var currentSelectionSet: (any SelectionSet.Type)? = rootSelectionSet
 
     for component in path {
       switch current {
       case let reference as CacheReference:
-        guard let fieldName = component as? String,
-              let record = records[reference.key] else {
+        guard let responseKey = component as? String,
+              let record = records[reference.key],
+              let selectionSet = currentSelectionSet,
+              let field = field(matching: responseKey, in: selectionSet.__selections, variables: variables),
+              let cacheKey = try? field.cacheKey(with: variables) else {
           return nil
         }
-        current = record[fieldName]
+        current = record[cacheKey]
+        currentSelectionSet = objectType(of: field.type)
 
-      case let list as [JSONValue]:
+      case let list as [JSONValue?]:
         guard let index = pathIndex(from: component), list.indices.contains(index) else {
           return nil
         }
@@ -197,6 +214,52 @@ extension CacheReference {
     }
 
     return (current as? CacheReference)?.key
+  }
+
+  private static func field(
+    matching responseKey: String,
+    in selections: [Selection],
+    variables: GraphQLOperation.Variables?
+  ) -> Selection.Field? {
+    var matches: [Selection.Field] = []
+    collectFields(forResponseKey: responseKey, in: selections, into: &matches)
+
+    guard let first = matches.first else { return nil }
+    let firstCacheKey = try? first.cacheKey(with: variables)
+    for match in matches.dropFirst() where (try? match.cacheKey(with: variables)) != firstCacheKey {
+      return nil
+    }
+    return first
+  }
+
+  private static func collectFields(
+    forResponseKey responseKey: String,
+    in selections: [Selection],
+    into matches: inout [Selection.Field]
+  ) {
+    for selection in selections {
+      switch selection {
+      case let .field(field):
+        if field.responseKey == responseKey {
+          matches.append(field)
+        }
+      case let .fragment(fragment):
+        collectFields(forResponseKey: responseKey, in: fragment.__selections, into: &matches)
+      case let .inlineFragment(inlineFragment):
+        collectFields(forResponseKey: responseKey, in: inlineFragment.__selections, into: &matches)
+      case let .deferred(_, deferred, _):
+        collectFields(forResponseKey: responseKey, in: deferred.__selections, into: &matches)
+      case let .conditional(_, conditionalSelections):
+        collectFields(forResponseKey: responseKey, in: conditionalSelections, into: &matches)
+      }
+    }
+  }
+
+  private static func objectType(of outputType: Selection.Field.OutputType) -> (any SelectionSet.Type)? {
+    if case let .object(rootSelectionSetType) = outputType.namedType {
+      return rootSelectionSetType
+    }
+    return nil
   }
 
   private static func pathIndex(from component: JSONValue) -> Int? {

--- a/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/IncrementalResponseExecutionHandler.swift
@@ -7,6 +7,7 @@ public enum IncrementalResponseError: Error, LocalizedError, Equatable {
   case missingLabel
   case missingDeferredSelectionSetType(String, String)
   case unresolvablePath(String)
+  case ambiguousPathField(String)
 
   public var errorDescription: String? {
     switch self {
@@ -25,6 +26,11 @@ public enum IncrementalResponseError: Error, LocalizedError, Equatable {
       return "Could not resolve incremental response path '\(path)' to a record in the initial "
         + "response's normalized cache records. The deferred container must be present in the "
         + "initial response, so this indicates a malformed response or an unsupported selection shape."
+
+    case let .ambiguousPathField(responseKey):
+      return "Could not resolve incremental response path: the response key '\(responseKey)' matches "
+        + "multiple fields with differing cache keys in the operation's selections, so the deferred "
+        + "container's cache key is ambiguous."
     }
   }
 }
@@ -172,7 +178,7 @@ extension CacheReference {
     // silently write the deferred fields onto a phantom `rootKey.<path>` record — the very bug this
     // resolution exists to fix. Surface it instead.
     if let records {
-      guard let resolvedKey = resolveCacheKey(
+      guard let resolvedKey = try resolveCacheKey(
         forPath: path,
         fromRootKey: rootKey,
         rootSelectionSet: rootSelectionSet,
@@ -200,7 +206,7 @@ extension CacheReference {
     rootSelectionSet: any SelectionSet.Type,
     variables: GraphQLOperation.Variables?,
     in records: RecordSet
-  ) -> String? {
+  ) throws -> String? {
     var current: JSONValue? = CacheReference(rootKey)
     var currentSelectionSet: (any SelectionSet.Type)? = rootSelectionSet
 
@@ -210,7 +216,7 @@ extension CacheReference {
         guard let responseKey = component as? String,
               let record = records[reference.key],
               let selectionSet = currentSelectionSet,
-              let field = field(matching: responseKey, in: selectionSet.__selections, variables: variables),
+              let field = try field(matching: responseKey, in: selectionSet.__selections, variables: variables),
               let cacheKey = try? field.cacheKey(with: variables) else {
           return nil
         }
@@ -231,18 +237,24 @@ extension CacheReference {
     return (current as? CacheReference)?.key
   }
 
+  /// Returns the single field in `selections` matching `responseKey`, or `nil` if none matches.
+  ///
+  /// Throws `IncrementalResponseError.ambiguousPathField` if the response key matches more than one
+  /// field with differing cache keys — the deferred container's real cache key can't be determined
+  /// in that case, and (with cache records present) silently falling back would write onto a phantom
+  /// record, so this is surfaced rather than swallowed.
   private static func field(
     matching responseKey: String,
     in selections: [Selection],
     variables: GraphQLOperation.Variables?
-  ) -> Selection.Field? {
+  ) throws -> Selection.Field? {
     var matches: [Selection.Field] = []
     collectFields(forResponseKey: responseKey, in: selections, into: &matches)
 
     guard let first = matches.first else { return nil }
     let firstCacheKey = try? first.cacheKey(with: variables)
     for match in matches.dropFirst() where (try? match.cacheKey(with: variables)) != firstCacheKey {
-      return nil
+      throw IncrementalResponseError.ambiguousPathField(responseKey)
     }
     return first
   }

--- a/apollo-ios/Sources/Apollo/ResponseParsing/JSONResponseParser.swift
+++ b/apollo-ios/Sources/Apollo/ResponseParsing/JSONResponseParser.swift
@@ -162,7 +162,8 @@ public struct JSONResponseParser: Sendable {
     for item in incrementalItems {
       let (incrementalResult, incrementalCacheRecords) = try await executeIncrementalItem(
         itemBody: item,
-        for: Operation.self
+        for: Operation.self,
+        existingRecords: currentCacheRecords
       )
       try Task.checkCancellation()
 
@@ -178,11 +179,13 @@ public struct JSONResponseParser: Sendable {
 
   private func executeIncrementalItem<Operation: GraphQLOperation>(
     itemBody: JSONObject,
-    for operationType: Operation.Type
+    for operationType: Operation.Type,
+    existingRecords: RecordSet?
   ) async throws -> (IncrementalGraphQLResult, RecordSet?) {
     let incrementalExecutionHandler = try IncrementalResponseExecutionHandler<Operation>(
       responseBody: itemBody,
-      operationVariables: operationVariables
+      operationVariables: operationVariables,
+      existingRecords: existingRecords
     )
 
     return try await incrementalExecutionHandler.execute(includeCacheRecords: includeCacheRecords)


### PR DESCRIPTION
Fixes apollographql/apollo-ios#3380

## Problem

When a `@defer` query streams its response, each incremental chunk carries a GraphQL `path` (e.g. `["animal", "friend"]`) telling us where the data belongs. We turn that path into a normalized cache key so the deferred fields merge onto the record the initial chunk already wrote.

Today we build that key by naively joining the root key with the raw path components (`QUERY_ROOT.animal.friend`). But normalized records are keyed by their cache IDs, so the real chain is `QUERY_ROOT -> Animal:<id> -> ...`. The naive key matches nothing, so the deferred fields land on phantom records that nothing references. The real records never receive the deferred data, and a cache-first read comes back missing those fields.

## Fix

Instead of the naive join, walk the initial response's already-normalized `RecordSet` along the deferred `path` to find the object's real cache key, at parse time before the records reach the cache.

- `IncrementalResponseExecutionHandler` now takes the initial records and passes them to `rootCacheReference(for:path:resolvingAgainst:)`.
- `rootCacheReference` walks the records following references and list indices. If the walk completes it returns the real key; if any hop isn't a reference or list (deferred container was null/absent, or records weren't available), it falls back to the old join, so this is no worse than before for those edges.
- `JSONResponseParser.executeIncrementalResponses` seeds the walk with the initial chunk's records and keeps them current as each increment merges in.

Result: deferred fields merge onto the records the query already normalized, and the response is fully readable from cache.

## Why this approach

- Runs at parse time, before `cache.merge`, so records reach the cache already correctly keyed.
- Uses the initial response's own records as an authoritative path-to-key map, so there's no need to re-derive cache keys or know the schema here.
- Small, contained diff in the two response-parsing files.

## Testing

Added `test__intercept__givenIdBasedCacheKey_incrementalRecordsMergeOntoRealRecordNotNaivePath` to `JSONResponseParsingInterceptorTests_IncrementalItems`. It configures `cacheKeyInfo` so the initial chunk normalizes `animal` to an id-based key (`Animal:1`), streams a deferred increment with `path: ["animal"]`, and asserts the deferred field merges onto the real `Animal:1` record. Under the old naive join it lands on a phantom `QUERY_ROOT.animal` record, so this test fails without the fix and passes with it (verified by reverting the source change). The existing `includeCacheRecords: true` tests cover the fallback case and still pass unchanged.
