### PR TITLE
fix(websocket): close old connection in disconnectAndReconnect (#3649)

### DIFF
--- a/Tests/ApolloTests/WebSocket/WebSocketTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTests.swift
@@ -1615,6 +1615,38 @@ class WebSocketTests: XCTestCase, MockResponseProvider {
     _ = try await subscription.getAllValues()
   }
 
+  /// Regression test for https://github.com/apollographql/apollo-ios/issues/3649.
+  ///
+  /// When `disconnectAndReconnect()` replaces the connection, it must first close the old
+  /// connection. Otherwise the old `WebSocketConnection` is still strongly held by its
+  /// receive loop's Task (which stays parked in `receive()`), so the loop never completes,
+  /// `WebSocketConnection.deinit` never fires, and the underlying WebSocket task is never
+  /// cancelled — leaking the connection and its receive loop.
+  func testUpdateHeaderValues__whenReconnectIfConnected__shouldCloseOldConnection() async throws {
+    let task1 = MockWebSocketTask()
+    let task2 = MockWebSocketTask()
+    setUpTransport(tasks: [task1, task2])
+
+    // Connect and subscribe on task1.
+    task1.emit(.connectionAck(payload: nil))
+    let (subscription, _) = try await subscribe(on: task1, using: client)
+
+    // Sanity: the old connection's underlying task has not been cancelled yet.
+    expect(task1.cancelCode).to(beNil())
+
+    // Update headers with reconnect — this replaces the connection.
+    await networkTransport.updateHeaderValues(
+      ["Authorization": "Bearer token123"],
+      reconnectIfConnected: true
+    )
+
+    // The OLD connection's underlying WebSocket task must be cancelled so its receive loop
+    // terminates and the connection is not leaked.
+    await expect(task1.cancelCode).toEventually(equal(.goingAway))
+
+    _ = subscription
+  }
+
   // MARK: - updateConnectingPayload
 
   func testUpdateConnectingPayload__whenReconnectIfConnected__whenConnected__shouldReconnect() async throws {
@@ -1731,6 +1763,53 @@ class WebSocketTests: XCTestCase, MockResponseProvider {
     // Complete the subscription so it doesn't block.
     task2.emit(.complete(id: operationID))
     _ = try await subscription.getAllValues()
+  }
+
+  /// Regression test for https://github.com/apollographql/apollo-ios/issues/3649.
+  ///
+  /// When `disconnectAndReconnect()` replaces the connection without closing the old one, the
+  /// old connection's receive loop stays alive and keeps routing incoming messages into the
+  /// subscriber registry. Since active subscriptions are re-subscribed under the same operation
+  /// IDs on the new connection, a late `next` arriving on the stale connection would be
+  /// delivered to the subscriber as a duplicate. After the fix, the old connection is closed
+  /// and its receive loop is torn down, so stale messages never reach the subscriber.
+  func testUpdateConnectingPayload__whenReconnectIfConnected__shouldNotDeliverFromStaleConnection() async throws {
+    let task1 = MockWebSocketTask()
+    let task2 = MockWebSocketTask()
+    setUpTransport(tasks: [task1, task2])
+
+    // Connect and subscribe on task1.
+    task1.emit(.connectionAck(payload: nil))
+    let (subscription, operationID) = try await subscribe(on: task1, using: client)
+
+    // Trigger a reconnect that replaces the connection with task2.
+    await networkTransport.updateConnectingPayload(
+      ["authToken": "new-token"],
+      reconnectIfConnected: true
+    )
+
+    // The new connection acks and re-subscribes the still-active subscription under the same ID.
+    task2.emit(.connectionAck(payload: nil))
+    await expect(task2.clientSentMessages(ofType: "subscribe").count).toEventually(equal(1))
+    expect(task2.subscribeOperationID(at: 0)).to(equal(operationID))
+
+    // The stale (old) connection delivers a `next` for the same operation ID. If its receive
+    // loop is still alive, this is routed to the subscriber as a duplicate.
+    task1.emit(.next(id: operationID, payload: Self.reviewAddedPayload(stars: 1, commentary: "STALE from old connection")))
+
+    // Give the stale connection's receive loop time to (incorrectly) route the message.
+    try await Task.sleep(nanoseconds: 200_000_000)
+
+    // The new connection delivers the real result and completes the subscription.
+    task2.emit(.next(id: operationID, payload: Self.reviewAddedPayload(stars: 5, commentary: "From new connection")))
+    task2.emit(.complete(id: operationID))
+
+    let results = try await subscription.getAllValues()
+
+    // Only the new connection's result should be delivered — the stale connection's message
+    // must never reach the subscriber.
+    let commentaries: [String] = results.compactMap { $0.data?.reviewAdded?.commentary }
+    expect(commentaries).to(equal(["From new connection"]))
   }
 
   // MARK: - Pause / Resume

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -433,13 +433,9 @@ public actor WebSocketTransport: SubscriptionNetworkTransport, NetworkTransport 
 
   /// Disconnects the current WebSocket connection and immediately starts a new one.
   ///
-  /// Closes the old connection before replacing it. Closing cancels the underlying task, which
-  /// ends the old receive loop's stream — the loop then sees that `self.connection` no longer
-  /// matches `loopConnection` and exits without triggering reconnection. Without this close,
-  /// the old connection's `receive()` would block indefinitely, so its receive loop's `Task`
-  /// would never complete (leaking the task and connection) and the stale connection would keep
-  /// routing incoming messages to subscribers. Active subscribers will be resubscribed when the
-  /// new `connection_ack` arrives.
+  /// Closes the old connection before replacing it, which invalidates the old receive loop
+  /// (it will see that `self.connection` no longer matches and exit). Active subscribers will
+  /// be resubscribed when the new `connection_ack` arrives.
   private func disconnectAndReconnect() {
     connection.close()
     connection = WebSocketConnection(task: urlSession.webSocketTask(with: request))

--- a/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/apollo-ios/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -433,10 +433,15 @@ public actor WebSocketTransport: SubscriptionNetworkTransport, NetworkTransport 
 
   /// Disconnects the current WebSocket connection and immediately starts a new one.
   ///
-  /// Replaces the connection, which invalidates the old receive loop (it will see that
-  /// `self.connection` no longer matches and exit). Active subscribers will be resubscribed
-  /// when the new `connection_ack` arrives.
+  /// Closes the old connection before replacing it. Closing cancels the underlying task, which
+  /// ends the old receive loop's stream — the loop then sees that `self.connection` no longer
+  /// matches `loopConnection` and exits without triggering reconnection. Without this close,
+  /// the old connection's `receive()` would block indefinitely, so its receive loop's `Task`
+  /// would never complete (leaking the task and connection) and the stale connection would keep
+  /// routing incoming messages to subscribers. Active subscribers will be resubscribed when the
+  /// new `connection_ack` arrives.
   private func disconnectAndReconnect() {
+    connection.close()
     connection = WebSocketConnection(task: urlSession.webSocketTask(with: request))
     connectionState = .connecting
     startConnectionReceiveLoop()


### PR DESCRIPTION
### Summary

Fixes [#3649](https://github.com/apollographql/apollo-ios/issues/3649).

`WebSocketTransport.disconnectAndReconnect()` replaced `self.connection` without closing the old connection first. The old `WebSocketConnection` is strongly held by its receive loop's `Task` (via the captured `loopConnection`), which stays parked in `receive()` indefinitely because the underlying task was never cancelled.

This caused two problems:

1. **Leak** — the receive loop's `Task` never completes, so `WebSocketConnection.deinit` (the only thing that cancels the underlying task) never fires. The connection, its `Task`, and the underlying `URLSessionWebSocketTask` leak until the server happens to tear down the socket.
2. **Duplicate delivery** — the stale connection's receive loop keeps routing incoming messages into the subscriber registry. Since active subscriptions are re-subscribed under the **same** operation IDs on the new connection, a late `next` arriving on the stale connection is delivered to the subscriber as a duplicate.

`disconnectAndReconnect()` is reached via `updateHeaderValues(_:reconnectIfConnected:)` and `updateConnectingPayload(_:reconnectIfConnected:)` when the transport is connected.

### Fix

Close the old connection before replacing it, matching the existing `pause()` pattern:

```swift
private func disconnectAndReconnect() {
  connection.close()
  connection = WebSocketConnection(task: urlSession.webSocketTask(with: request))
  connectionState = .connecting
  startConnectionReceiveLoop()
}
```

`close()` cancels the old task → its `receive()` throws `URLError(.cancelled)` → the old stream ends → the loop's `guard self.connection === loopConnection` is now false → it returns without triggering `handleDisconnection`/reconnection. The old connection is torn down cleanly and stale messages stop flowing.

### Tests

Two regression tests added to `WebSocketTests`, both of which fail against the previous implementation and pass with the fix:

- `testUpdateHeaderValues__whenReconnectIfConnected__shouldCloseOldConnection` — asserts the old connection's underlying task is cancelled (`.goingAway`) on reconnect (the leak).
- `testUpdateConnectingPayload__whenReconnectIfConnected__shouldNotDeliverFromStaleConnection` — asserts a `next` emitted on the stale connection after reconnect never reaches the subscriber (the duplicate delivery).

Full `WebSocketTests` suite passes (111/111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
