### PR TITLE
Improve SQLiteDatabase extensibility by exposing DatabaseRow properties

### DIFF
--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -4,8 +4,8 @@ import Apollo
 #endif
 
 public struct DatabaseRow {
-  let cacheKey: CacheKey
-  let storedInfo: String
+  public let cacheKey: CacheKey
+  public let storedInfo: String
 
   public init(cacheKey: CacheKey, storedInfo: String) {
     self.cacheKey = cacheKey


### PR DESCRIPTION
**Background**

`SQLiteNormalizedCache` already provides a clean abstraction through the `SQLiteDatabase` protocol, allowing consumers to provide their own database implementation.

A previous change (#664) made the DatabaseRow initializer public, enabling external implementations of the `SQLiteDatabase` protocol. However, one limitation still exists: while DatabaseRow can now be instantiated, its stored properties remain inaccessible outside the module.
This prevents developers from fully leveraging the `SQLiteDatabase` abstraction for wrapper or decorator implementations.


**The Problem**
SQLiteDatabase exposes the following API:
<img width="568" height="31" alt="image" src="https://github.com/user-attachments/assets/b0fb662c-3024-4be6-b849-f6277e54afe6" />

Although `DatabaseRow` itself is public and now has a public initializer, its stored properties (cacheKey and storedInfo) are still internal.
This makes it impossible to inspect or transform rows returned from another `SQLiteDatabase` implementation. As a result, consumers cannot build wrapper implementations around `ApolloSQLiteDatabase` without duplicating Apollo's SQLite implementation.

This extensibility could also benefit other use cases such as:
- Transparent encryption/decryption
- Compression
- Logging and diagnostics
- Metrics collection
- Custom caching policies
- Data transformation


**Proposed Change**
Expose the `DatabaseRow` stored properties by making them public:
<img width="264" height="43" alt="image" src="https://github.com/user-attachments/assets/5cac5919-7ac4-49ab-971a-7c4e19d6c81a" />

This complements the public initializer introduced in #664 and makes DatabaseRow fully usable by external implementations of the public SQLiteDatabase protocol.


**Testing**
This change only expands the public API surface and does not modify any runtime behavior or database logic.
Existing tests continue to pass, and no behavioral changes are introduced.