### PR TITLE
ci: set git user.email in configure-git so subtree split can commit

### DIFF
--- a/.github/actions/configure-git/action.yml
+++ b/.github/actions/configure-git/action.yml
@@ -16,8 +16,4 @@ runs:
     shell: bash
     run: |
       git config --global user.name "${{ inputs.user }}"
-      # user.email must be set explicitly. `git subtree split --squash --rejoin`
-      # writes commits, and newer runner images resolve the hostname to
-      # `(none)`, so git refuses the auto-detected `runner@host.(none)` address
-      # ("unable to auto-detect email address") and the split fails.
       git config --global user.email "${{ inputs.email }}"

--- a/.github/actions/configure-git/action.yml
+++ b/.github/actions/configure-git/action.yml
@@ -4,6 +4,10 @@ inputs:
     description: "The user name to use for commits."
     required: false
     default: gh-action-runner
+  email:
+    description: "The email address to use for commits."
+    required: false
+    default: gh-action-runner@users.noreply.github.com
 description: Configures appropriate git settings for the github action workflows.
 runs:
   using: "composite"
@@ -12,3 +16,8 @@ runs:
     shell: bash
     run: |
       git config --global user.name "${{ inputs.user }}"
+      # user.email must be set explicitly. `git subtree split --squash --rejoin`
+      # writes commits, and newer runner images resolve the hostname to
+      # `(none)`, so git refuses the auto-detected `runner@host.(none)` address
+      # ("unable to auto-detect email address") and the split fails.
+      git config --global user.email "${{ inputs.email }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Context is distributed across multiple files rather than kept in one large root 
 
 When working in a nested subdirectory within a subtree (e.g., `apollo-ios/Sources/Apollo/Caching/`), also check for and read any matching deeper context files in `claude/` (e.g., `claude/apollo-ios/Sources/Apollo/Execution/*.md`).
 
+**When writing or editing code anywhere in this repository, follow the conventions in `claude/code-style.md`.**
+
 These files live in `claude/` instead of inside the subtree directories because anything inside a subtree directory gets pushed to the upstream repo. The `claude/` directory is not auto-discovered, so you must read these files yourself.
 
 **Non-subtree context** (Tests, Sources, scripts, etc.) can use CLAUDE.md files directly in those directories since they are not affected by subtree pushes. For example, `Tests/CLAUDE.md` or `Sources/AnimalKingdomAPI/CLAUDE.md`. These are auto-discovered normally.

--- a/claude/ci-subtree-troubleshooting.md
+++ b/claude/ci-subtree-troubleshooting.md
@@ -48,6 +48,22 @@ During the label rollover, runs landed on either image at random, so failures lo
 
 **⚠️ Local vs CI git divergence:** different git versions implement `subtree split` differently (the optimization was present ≤2.53, removed in 2.54). Both algorithms have so far agreed on this repo's history, but for any local recovery split intended to be pushed upstream, use the vendored script (`scripts/vendor/git-subtree-2.53.0.sh`, with `GIT_EXEC_PATH="$(git --exec-path)"` exported and on `PATH`) — that is exactly what CI runs, so its hashes are the canonical ones.
 
+## Historical incident: missing committer email in split (July 2026)
+
+**Symptoms:** Every subtree split step failed at the same point:
+
+```
+Author identity unknown
+
+*** Please tell me who you are.
+...
+fatal: unable to auto-detect email address (got 'runner@runnervm3jd5f.(none)')
+```
+
+**How it happened:** `git subtree split --squash --rejoin` writes commits (the squash commit and the rejoin), which need a committer identity. The `configure-git` action only ever set `user.name`, never `user.email`. Historically git filled the email in by auto-detecting `runner@<hostname>` — but a newer `ubuntu-latest` runner image resolves the hostname to `(none)`, and git refuses an auto-detected `...(none)` address rather than committing with it. No `user.email` was configured to fall back on, so the split aborted before producing a SHA. `Push Subtrees` is gated on `if: success()`, so nothing was pushed and no rejoin metadata reached `main`.
+
+**Fix:** Added an explicit `user.email` (input `email`, default `gh-action-runner@users.noreply.github.com`) to `.github/actions/configure-git`. All five workflows that use `configure-git` inherit the fix. Do not rely on git's hostname auto-detection in CI — always set `user.email` explicitly.
+
 ## Historical incident: stale-upstream pull conflict (May 2026)
 
 Fixed in PR #989; root cause prevention in PR #990 (approx — match by date).

--- a/claude/code-style.md
+++ b/claude/code-style.md
@@ -1,0 +1,21 @@
+# Code Style
+
+Conventions for code written in this repository (including the `apollo-ios`,
+`apollo-ios-codegen`, and `apollo-ios-pagination` subtrees). These live in
+`claude/` rather than a subtree directory so they are not pushed upstream.
+
+## Comments
+
+Strive to write self-documenting code that does not need comments. Clear naming
+and structure should carry the meaning before a comment does.
+
+- **Do not add a comment for every change or fix.** A fix does not need an
+  inline explanation just because it was a fix. Rationale for *why* a change was
+  made belongs in the commit message (and, for CI/infra, in the relevant doc
+  such as `claude/ci-subtree-troubleshooting.md`) — not in an inline comment.
+- **Public symbol documentation** explains *what* a symbol does and how to use
+  it — not *why* the code was written the way it was.
+- **Inline comments within a function body** should be as concise as possible.
+  Prefer them for organizing and signposting longer bodies of code for
+  readability. Only explain the code itself in genuinely complex situations
+  where the intent is not clear from the code alone.


### PR DESCRIPTION
## Problem

The `PR Subtree Push` job for #1052 failed in the split step with:

```
fatal: unable to auto-detect email address (got 'runner@runnervm3jd5f.(none)')
```

## Root cause

`git subtree split --squash --rejoin` writes commits (the squash + rejoin), which need a committer identity. The shared `configure-git` action only ever set `user.name` — never `user.email`. Git had been silently filling the email in by auto-detecting `runner@<hostname>`. A newer `ubuntu-latest` runner image now resolves the hostname to `(none)`, and git refuses to commit with an auto-detected `...(none)` address. With no `user.email` to fall back on, every split aborted.

Because `Push Subtrees` is gated on `if: success()`, nothing was pushed to upstream — no harm done, but the sync didn't happen. It's self-healing: the next successful run carries #1052's changes upstream automatically (splits walk full history).

## Fix

Add an explicit `user.email` input (default `gh-action-runner@users.noreply.github.com`) to `.github/actions/configure-git`. All five workflows that use the action inherit the fix. Incident recorded in `claude/ci-subtree-troubleshooting.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)