### PR TITLE
ci: bump Create Release PR timeout from 5 to 20 minutes

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   create-release-pr:
     runs-on: macos-26
-    timeout-minutes: 5
+    timeout-minutes: 20
     name: "Create Release PR"
     steps:
     - name: Set Xcode Version


### PR DESCRIPTION
## Summary

The `Create Release PR` workflow had a `timeout-minutes: 5` cap on its single job. On slower branches (observed while cutting the `v1` `release/1.25.7` branch) the job was cancelled mid-"Archive CLI"/"Commit and Push", which left the release branch pushed but **no PR created**, requiring manual recovery.

This bumps the timeout to 20 minutes to give the archive + documentation-generation steps room to finish.

## Context

Found while running the release workflow for `main` (2.3.0) and `v1` (1.25.7). The v1 run was cancelled twice at the 5-minute mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)