### PR TITLE
ci: stop publishing to CocoaPods on release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -93,16 +93,3 @@ jobs:
           gh workflow run release-new-version.yml -f localRef=${{ github.ref_name }} -f remoteRef=${{ env.RELEASE_VERSION }} --repo "apollographql/apollo-ios-xcframework"
         env:
           GH_TOKEN: ${{ secrets.APOLLO_IOS_PAT }}
-
-      # Push Pods for Apollo iOS and Test Support
-      - name: Push Cocoapods
-        shell: bash
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: |
-          export COCOAPODS_VALIDATOR_SKIP_XCODEBUILD=true:$PATH
-          gem install cocoapods
-          set -eo pipefail
-          cd apollo-ios
-          pod trunk push Apollo.podspec --allow-warnings
-          pod trunk push ApolloTestSupport.podspec --synchronous --allow-warnings


### PR DESCRIPTION
## Summary

We no longer distribute apollo-ios via CocoaPods trunk, so this removes the **Push Cocoapods** step from the v1 `publish-release` workflow (the last use of `COCOAPODS_TRUNK_TOKEN` in the release path). The step had been failing anyway — the trunk token is expired/unverified.

Only the `v1` branch had this step (`main` / 2.x already dropped CocoaPods).

## Follow-up (not in this PR)

Other CocoaPods references still exist on `v1` if we want to fully retire it — flagging for a separate decision rather than expanding scope here:
- `.github/actions/run-cocoapods-integration-tests/action.yml`
- `.github/workflows/ci-tests.yml` (invokes the integration-tests action)
- `.github/workflows/release-check.yml`
- `.github/PULL_REQUEST_TEMPLATE/pull-request-template-release.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)