### PR TITLE
Apply `additionalCapitalizationRules` to generated operation & fragment type names

### DIFF
--- a/Tests/ApolloCodegenInternalTestHelpers/MockFileManager.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockFileManager.swift
@@ -10,6 +10,7 @@ public class MockApolloFileManager: ApolloFileManager {
     case removeItem(_ handler: @Sendable (String) throws -> Void)
     case createFile(_ handler: @Sendable (String, Data?, FileAttributes?) -> Bool)
     case createDirectory(_ handler: @Sendable (String, Bool, FileAttributes?) throws -> Void)
+    case moveItem(_ handler: @Sendable (String, String) throws -> Void)
 
     // These are based on the return string from the #function macro. They are used in overriden
     // functions to lookup the provided closure. Be aware that if the function signature changes
@@ -20,6 +21,7 @@ public class MockApolloFileManager: ApolloFileManager {
       case .removeItem(_): return "removeItem(atPath:)"
       case .createFile(_): return "createFile(atPath:contents:attributes:)"
       case .createDirectory(_): return "createDirectory(atPath:withIntermediateDirectories:attributes:)"
+      case .moveItem(_): return "moveItem(atPath:toPath:)"
       }
     }
   }
@@ -58,6 +60,23 @@ public class MockApolloFileManager: ApolloFileManager {
   /// - Parameter closure: The mocked function closure.
   public func mock(closure: Closure) {
     _base.mock(closure: closure)
+  }
+
+  // MARK: Case sensitivity mocking
+
+  /// Mocks the case sensitivity of the volume reported for all paths.
+  ///
+  /// When not mocked, the volume's case sensitivity for the mock's fictitious paths cannot be
+  /// determined, so file name case adoption performs no additional file system calls unless a
+  /// test opts in.
+  public func mock(volumeIsCaseSensitive: Bool) {
+    volumeCaseSensitivityProvider = { _ in volumeIsCaseSensitive }
+  }
+
+  /// Mocks the on-disk casing reported for a path.
+  public func mock(onDiskCasedPath: String, forPath path: String) {
+    let fallback = onDiskCasedPathProvider
+    onDiskCasedPathProvider = { $0 == path ? onDiskCasedPath : fallback($0) }
   }
 
   private func didCall(closure: Closure) {
@@ -209,6 +228,27 @@ public class MockApolloFileManager: ApolloFileManager {
       }
 
       try handler(path, createIntermediates, attributes)
+    }
+
+    public override func moveItem(atPath srcPath: String, toPath dstPath: String) throws {
+      let key = #function
+
+      guard
+        let closure = closures[key],
+        case let .moveItem(handler) = closure else {
+        if strict {
+          XCTFail(missingClosureMessage(key))
+          return
+        } else {
+          return try super.moveItem(atPath: srcPath, toPath: dstPath)
+        }
+      }
+
+      defer {
+        didCall(closure: closure)
+      }
+
+      try handler(srcPath, dstPath)
     }
   }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -2096,6 +2096,230 @@ class ApolloCodegenTests: XCTestCase {
     await expect { await ApolloFileManager.default.doesFileExist(atPath: testInTestMocksFolderUserFile) }.to(beTrue())
   }
 
+  func test__fileDeletion__givenCapitalizationRuleChangesGeneratedFileNameCase_onCaseInsensitiveVolume_shouldNotDeleteRegeneratedFile() async throws {
+    // given
+    let isCaseSensitive = await ApolloFileManager.default.volumeSupportsCaseSensitiveNames(
+      forPath: directoryURL.path
+    )
+    try XCTSkipIf(isCaseSensitive != false, "This test requires a case-insensitive volume.")
+
+    try await createFile(containing: schemaData, named: "schema.graphqls")
+
+    try await createOperationFile(
+      type: .query,
+      named: "TestOperationById",
+      filename: "TestOperationById.graphql"
+    )
+
+    let queriesDirectory = "SchemaModule/Sources/Operations/Queries"
+
+    try await createFile(
+      filename: "TestOperationByIdQuery.graphql.swift",
+      inDirectory: queriesDirectory
+    )
+    let testFile = try await createFile(
+      filename: "TestGeneratedA.graphql.swift",
+      inDirectory: "SchemaModule"
+    )
+
+    // when
+    let config = ApolloCodegenConfiguration.mock(
+      input: .init(
+        schemaSearchPaths: ["schema*.graphqls"],
+        operationSearchPaths: ["*.graphql"]
+      ),
+      output: .init(
+        schemaTypes: .init(path: "SchemaModule",
+                           moduleType: .swiftPackage()),
+        operations: .inSchemaModule
+      ),
+      options: .init(
+        additionalCapitalizationRules: [
+          .init(term: .string("id"), strategy: .upper)
+        ],
+        markTypesNonisolated: false
+      )
+    )
+
+    try await ApolloCodegen.build(with: config, withRootURL: directoryURL)
+
+    // then
+    let regeneratedFile = directoryURL
+      .appendingPathComponent("\(queriesDirectory)/TestOperationByIDQuery.graphql.swift").path
+
+    await expect { await ApolloFileManager.default.doesFileExist(atPath: regeneratedFile) }.to(beTrue())
+
+    let regeneratedFileContents = try XCTUnwrap(
+      FileManager.default.contents(atPath: regeneratedFile)
+        .flatMap { String(data: $0, encoding: .utf8) }
+    )
+    expect(regeneratedFileContents).to(contain("TestOperationByIDQuery"))
+
+    await expect { await ApolloFileManager.default.doesFileExist(atPath: testFile) }.to(beFalse())
+  }
+
+  func test__fileDeletion__givenCapitalizationRuleChangesGeneratedFileNameCase_onCaseInsensitiveVolume_shouldRenameFileToNewCasing() async throws {
+    // given
+    let isCaseSensitive = await ApolloFileManager.default.volumeSupportsCaseSensitiveNames(
+      forPath: directoryURL.path
+    )
+    try XCTSkipIf(isCaseSensitive != false, "This test requires a case-insensitive volume.")
+
+    try await createFile(containing: schemaData, named: "schema.graphqls")
+
+    try await createOperationFile(
+      type: .query,
+      named: "TestOperationById",
+      filename: "TestOperationById.graphql"
+    )
+
+    let queriesDirectory = "SchemaModule/Sources/Operations/Queries"
+
+    try await createFile(
+      filename: "TestOperationByIdQuery.graphql.swift",
+      inDirectory: queriesDirectory
+    )
+
+    // when
+    let config = ApolloCodegenConfiguration.mock(
+      input: .init(
+        schemaSearchPaths: ["schema*.graphqls"],
+        operationSearchPaths: ["*.graphql"]
+      ),
+      output: .init(
+        schemaTypes: .init(path: "SchemaModule",
+                           moduleType: .swiftPackage()),
+        operations: .inSchemaModule
+      ),
+      options: .init(
+        additionalCapitalizationRules: [
+          .init(term: .string("id"), strategy: .upper)
+        ],
+        markTypesNonisolated: false
+      )
+    )
+
+    try await ApolloCodegen.build(with: config, withRootURL: directoryURL)
+
+    // then
+    // `doesFileExist(atPath:)` cannot distinguish paths differing only by case on a
+    // case-insensitive volume, so the directory entry name is asserted instead.
+    let directoryContents = try FileManager.default.contentsOfDirectory(
+      atPath: directoryURL.appendingPathComponent(queriesDirectory).path
+    )
+    expect(directoryContents).to(contain("TestOperationByIDQuery.graphql.swift"))
+    expect(directoryContents).notTo(contain("TestOperationByIdQuery.graphql.swift"))
+  }
+
+  func test__deleteExtraneousGeneratedFiles__givenOldPathMatchingWrittenFileCaseInsensitively_onCaseInsensitiveVolume_shouldNotDeleteFile() async throws {
+    // given
+    let subject = ApolloCodegen(
+      config: ApolloCodegen.ConfigurationContext(config: .mock(), rootURL: nil),
+      operationIdentifierFactory: OperationIdentifierFactory(),
+      itemsToGenerate: .code
+    )
+
+    let fileManager = MockApolloFileManager(strict: true)
+
+    await fileManager.mock(closure: .fileExists({ path, isDirectory in
+      isDirectory?.pointee = ObjCBool(!path.hasSuffix(".swift"))
+      return true
+    }))
+    await fileManager.mock(closure: .createFile({ path, data, attributes in
+      return true
+    }))
+
+    try await fileManager.createFile(
+      atPath: "/A/TestOperationByIDQuery.graphql.swift",
+      data: nil
+    )
+    await fileManager.mock(volumeIsCaseSensitive: false)
+
+    // when
+    // The mock is strict and `removeItem` is not mocked, so any deletion would fail the test.
+    try await subject.deleteExtraneousGeneratedFiles(
+      from: ["/A/TestOperationByIdQuery.graphql.swift"],
+      afterCodeGenerationUsing: fileManager
+    )
+
+    // then
+    await expect { await fileManager.allClosuresCalled }.to(beTrue())
+  }
+
+  func test__deleteExtraneousGeneratedFiles__givenOldPathMatchingWrittenFileCaseInsensitively_onCaseSensitiveVolume_shouldDeleteFile() async throws {
+    // given
+    let subject = ApolloCodegen(
+      config: ApolloCodegen.ConfigurationContext(config: .mock(), rootURL: nil),
+      operationIdentifierFactory: OperationIdentifierFactory(),
+      itemsToGenerate: .code
+    )
+
+    let fileManager = MockApolloFileManager(strict: true)
+
+    await fileManager.mock(closure: .fileExists({ path, isDirectory in
+      isDirectory?.pointee = ObjCBool(!path.hasSuffix(".swift"))
+      return true
+    }))
+    await fileManager.mock(closure: .createFile({ path, data, attributes in
+      return true
+    }))
+    await fileManager.mock(closure: .removeItem({ path in
+      expect(path).to(equal("/A/TestOperationByIdQuery.graphql.swift"))
+    }))
+
+    try await fileManager.createFile(
+      atPath: "/A/TestOperationByIDQuery.graphql.swift",
+      data: nil
+    )
+    await fileManager.mock(volumeIsCaseSensitive: true)
+
+    // when
+    try await subject.deleteExtraneousGeneratedFiles(
+      from: ["/A/TestOperationByIdQuery.graphql.swift"],
+      afterCodeGenerationUsing: fileManager
+    )
+
+    // then
+    await expect { await fileManager.allClosuresCalled }.to(beTrue())
+  }
+
+  func test__deleteExtraneousGeneratedFiles__givenOldPathNotMatchingAnyWrittenFile_onCaseInsensitiveVolume_shouldDeleteFile() async throws {
+    // given
+    let subject = ApolloCodegen(
+      config: ApolloCodegen.ConfigurationContext(config: .mock(), rootURL: nil),
+      operationIdentifierFactory: OperationIdentifierFactory(),
+      itemsToGenerate: .code
+    )
+
+    let fileManager = MockApolloFileManager(strict: true)
+
+    await fileManager.mock(closure: .fileExists({ path, isDirectory in
+      isDirectory?.pointee = ObjCBool(!path.hasSuffix(".swift"))
+      return true
+    }))
+    await fileManager.mock(closure: .createFile({ path, data, attributes in
+      return true
+    }))
+    await fileManager.mock(closure: .removeItem({ path in
+      expect(path).to(equal("/A/SomethingElse.graphql.swift"))
+    }))
+
+    try await fileManager.createFile(
+      atPath: "/A/TestOperationByIDQuery.graphql.swift",
+      data: nil
+    )
+    await fileManager.mock(volumeIsCaseSensitive: false)
+
+    // when
+    try await subject.deleteExtraneousGeneratedFiles(
+      from: ["/A/SomethingElse.graphql.swift"],
+      afterCodeGenerationUsing: fileManager
+    )
+
+    // then
+    await expect { await fileManager.allClosuresCalled }.to(beTrue())
+  }
+
   // MARK: Suffix Renaming Tests
 
   func test__fileRenaming__givenGeneratedPreSuffixFilesExist_withAppendSchemaFilenameSuffix_true_shouldRenameFileWithSuffix() async throws {

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -2211,6 +2211,86 @@ class ApolloCodegenTests: XCTestCase {
     expect(directoryContents).notTo(contain("TestOperationByIdQuery.graphql.swift"))
   }
 
+  func test__fileDeletion__givenCapitalizationRuleChangesGeneratedFragmentFileNameCase_onCaseInsensitiveVolume_shouldRenameAndNotDeleteRegeneratedFile() async throws {
+    // given
+    let isCaseSensitive = await ApolloFileManager.default.volumeSupportsCaseSensitiveNames(
+      forPath: directoryURL.path
+    )
+    try XCTSkipIf(isCaseSensitive != false, "This test requires a case-insensitive volume.")
+
+    try await createFile(containing: schemaData, named: "schema.graphqls")
+
+    try await createFile(
+      body: """
+      query TestQuery {
+        authors {
+          ...TestFragmentById
+        }
+      }
+
+      fragment TestFragmentById on Author {
+        id
+        name
+      }
+      """,
+      filename: "TestFragmentById.graphql"
+    )
+
+    let fragmentsDirectory = "SchemaModule/Sources/Fragments"
+
+    try await createFile(
+      filename: "TestFragmentById.graphql.swift",
+      inDirectory: fragmentsDirectory
+    )
+    let testFile = try await createFile(
+      filename: "TestGeneratedA.graphql.swift",
+      inDirectory: "SchemaModule"
+    )
+
+    // when
+    let config = ApolloCodegenConfiguration.mock(
+      input: .init(
+        schemaSearchPaths: ["schema*.graphqls"],
+        operationSearchPaths: ["*.graphql"]
+      ),
+      output: .init(
+        schemaTypes: .init(path: "SchemaModule",
+                           moduleType: .swiftPackage()),
+        operations: .inSchemaModule
+      ),
+      options: .init(
+        additionalCapitalizationRules: [
+          .init(term: .string("id"), strategy: .upper)
+        ],
+        markTypesNonisolated: false
+      )
+    )
+
+    try await ApolloCodegen.build(with: config, withRootURL: directoryURL)
+
+    // then
+    let regeneratedFile = directoryURL
+      .appendingPathComponent("\(fragmentsDirectory)/TestFragmentByID.graphql.swift").path
+
+    await expect { await ApolloFileManager.default.doesFileExist(atPath: regeneratedFile) }.to(beTrue())
+
+    let regeneratedFileContents = try XCTUnwrap(
+      FileManager.default.contents(atPath: regeneratedFile)
+        .flatMap { String(data: $0, encoding: .utf8) }
+    )
+    expect(regeneratedFileContents).to(contain("TestFragmentByID"))
+
+    // `doesFileExist(atPath:)` cannot distinguish paths differing only by case on a
+    // case-insensitive volume, so the directory entry name is asserted instead.
+    let directoryContents = try FileManager.default.contentsOfDirectory(
+      atPath: directoryURL.appendingPathComponent(fragmentsDirectory).path
+    )
+    expect(directoryContents).to(contain("TestFragmentByID.graphql.swift"))
+    expect(directoryContents).notTo(contain("TestFragmentById.graphql.swift"))
+
+    await expect { await ApolloFileManager.default.doesFileExist(atPath: testFile) }.to(beFalse())
+  }
+
   func test__deleteExtraneousGeneratedFiles__givenOldPathMatchingWrittenFileCaseInsensitively_onCaseInsensitiveVolume_shouldNotDeleteFile() async throws {
     // given
     let subject = ApolloCodegen(

--- a/Tests/ApolloCodegenTests/CapitalizerTests.swift
+++ b/Tests/ApolloCodegenTests/CapitalizerTests.swift
@@ -252,6 +252,30 @@ class CapitalizerTests: XCTestCase {
     expect("userId".renderAsTestMockFieldPropertyName(config: config)).to(equal("userId"))
   }
 
+  // MARK: - Type Name Rendering Integration
+
+  func test__asFragmentName__midWordAcronym__isCapitalized() {
+    let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .upper)])
+
+    expect("testFragmentById".asFragmentName(capitalizer: capitalizer))
+      .to(equal("TestFragmentByID"))
+  }
+
+  func test__asFragmentName__leadingAcronym__isCapitalizedForTypeName() {
+    // Unlike property names, a type name is `firstUppercased` before the capitalizer runs, so a
+    // leading acronym is fully capitalized (e.g. `idLookup` → `IDLookup`).
+    let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .upper)])
+
+    expect("idLookup".asFragmentName(capitalizer: capitalizer)).to(equal("IDLookup"))
+  }
+
+  func test__asFragmentName__noRules__isUnchanged() {
+    let capitalizer = Capitalizer(rules: [])
+
+    expect("testFragmentById".asFragmentName(capitalizer: capitalizer))
+      .to(equal("TestFragmentById"))
+  }
+
   // MARK: - CapitalizationRule Codable
 
   func test__capitalizationRule__roundTrips() throws {

--- a/Tests/ApolloCodegenTests/CapitalizerTests.swift
+++ b/Tests/ApolloCodegenTests/CapitalizerTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Nimble
+import GraphQLCompiler
 import ApolloCodegenInternalTestHelpers
 @testable import ApolloCodegenLib
 
@@ -262,11 +263,45 @@ class CapitalizerTests: XCTestCase {
   }
 
   func test__asFragmentName__leadingAcronym__isCapitalizedForTypeName() {
-    // Unlike property names, a type name is `firstUppercased` before the capitalizer runs, so a
-    // leading acronym is fully capitalized (e.g. `idLookup` → `IDLookup`).
+    // Unlike property names, a type name is `firstUppercased` both before the capitalizer runs
+    // (so rules see the type-name form of each word segment) and after (so the leading capital
+    // is always restored) — a leading acronym is fully capitalized (e.g. `idLookup` → `IDLookup`).
     let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .upper)])
 
     expect("idLookup".asFragmentName(capitalizer: capitalizer)).to(equal("IDLookup"))
+  }
+
+  func test__asFragmentName__lowerRule__leadingAcronymIsLowercased() {
+    // A `.lower` rule lowercases the leading acronym, then the trailing `firstUppercased`
+    // restores the leading capital: `IDDetails` → `idDetails` → `IdDetails`.
+    let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .lower)])
+
+    expect("IDDetails".asFragmentName(capitalizer: capitalizer)).to(equal("IdDetails"))
+  }
+
+  func test__asFragmentName__replaceRule__appliesRegardlessOfSourceCasing() {
+    let capitalizer = Capitalizer(rules: [
+      .init(term: .string("graphql"), strategy: .replace("graphQL"))
+    ])
+
+    expect("GraphqlConfig".asFragmentName(capitalizer: capitalizer)).to(equal("GraphQLConfig"))
+    expect("graphqlConfig".asFragmentName(capitalizer: capitalizer)).to(equal("GraphQLConfig"))
+  }
+
+  func test__asFragmentName__ruleResultCollidesWithReservedTypeName__isSuffixed() {
+    // The reserved-type-name check runs on the final post-rule name: `Id` → `ID` collides with
+    // the reserved `ID` type name, so the fragment is suffixed.
+    let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .upper)])
+
+    expect("Id".asFragmentName(capitalizer: capitalizer)).to(equal("ID_Fragment"))
+  }
+
+  func test__asFragmentName__ruleResultAvoidsReservedTypeName__isNotSuffixed() {
+    // Conversely, a rule that renames away from a reserved type name avoids a stale suffix:
+    // `ID` → `Id` no longer collides, so no `_Fragment` suffix is added.
+    let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .lower)])
+
+    expect("ID".asFragmentName(capitalizer: capitalizer)).to(equal("Id"))
   }
 
   func test__asFragmentName__noRules__isUnchanged() {
@@ -274,6 +309,45 @@ class CapitalizerTests: XCTestCase {
 
     expect("testFragmentById".asFragmentName(capitalizer: capitalizer))
       .to(equal("TestFragmentById"))
+  }
+
+  func test__generatedDefinitionName__operationWithLowerRule__lowercasesLeadingAcronym() {
+    let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .lower)])
+    let operation = CompilationResult.OperationDefinition.mock(name: "IDLookup", type: .query)
+
+    expect(operation.generatedDefinitionName(capitalizer: capitalizer))
+      .to(equal("IdLookupQuery"))
+  }
+
+  func test__generatedDefinitionName__operationWithReplaceRule__replacesLeadingSegment() {
+    let capitalizer = Capitalizer(rules: [
+      .init(term: .string("graphql"), strategy: .replace("graphQL"))
+    ])
+    let operation = CompilationResult.OperationDefinition.mock(
+      name: "GraphqlSettings",
+      type: .mutation
+    )
+
+    expect(operation.generatedDefinitionName(capitalizer: capitalizer))
+      .to(equal("GraphQLSettingsMutation"))
+  }
+
+  func test__generatedDefinitionName__fragmentWithLowerRule__matchesAsFragmentName() {
+    let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .lower)])
+    let fragment = CompilationResult.FragmentDefinition.mock("IDDetails")
+
+    expect(fragment.generatedDefinitionName(capitalizer: capitalizer)).to(equal("IdDetails"))
+  }
+
+  func test__generatedDefinitionName__ruleMatchingOperationTypeSuffix__appliesToAppendedSuffix() {
+    // The operation-type suffix is appended before the rules run, so a rule can match it.
+    let capitalizer = Capitalizer(rules: [
+      .init(term: .string("query"), strategy: .replace("QUERY"))
+    ])
+    let operation = CompilationResult.OperationDefinition.mock(name: "TestOperation", type: .query)
+
+    expect(operation.generatedDefinitionName(capitalizer: capitalizer))
+      .to(equal("TestOperationQUERY"))
   }
 
   // MARK: - CapitalizationRule Codable

--- a/Tests/ApolloCodegenTests/CapitalizerTests.swift
+++ b/Tests/ApolloCodegenTests/CapitalizerTests.swift
@@ -339,6 +339,26 @@ class CapitalizerTests: XCTestCase {
     expect(fragment.generatedDefinitionName(capitalizer: capitalizer)).to(equal("IdDetails"))
   }
 
+  func test__generatedFileName__fragmentWithUpperRule__matchesGeneratedDefinitionName() {
+    // The file name shares the type name's normalization, so the rules see the
+    // `firstUppercased` name and the leading acronym is capitalized just like the type name.
+    let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .upper)])
+    let fragment = CompilationResult.FragmentDefinition.mock("idDetails")
+
+    expect(fragment.generatedFileName(capitalizer: capitalizer)).to(equal("IDDetails"))
+    expect(fragment.generatedDefinitionName(capitalizer: capitalizer)).to(equal("IDDetails"))
+  }
+
+  func test__generatedFileName__ruleResultCollidesWithReservedTypeName__isNotSuffixed() {
+    // The type name is escaped to `ID_Fragment`, but file names never carry the reserved-name
+    // suffix — mirroring schema types, whose file names omit their reserved name suffixes.
+    let capitalizer = Capitalizer(rules: [.init(term: .string("id"), strategy: .upper)])
+    let fragment = CompilationResult.FragmentDefinition.mock("Id")
+
+    expect(fragment.generatedFileName(capitalizer: capitalizer)).to(equal("ID"))
+    expect(fragment.generatedDefinitionName(capitalizer: capitalizer)).to(equal("ID_Fragment"))
+  }
+
   func test__generatedDefinitionName__ruleMatchingOperationTypeSuffix__appliesToAppendedSuffix() {
     // The operation-type suffix is appended before the rules run, so a rule can match it.
     let capitalizer = Capitalizer(rules: [

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
@@ -34,7 +34,7 @@ class FragmentFileGeneratorTests: XCTestCase {
 
   // MARK: Test Helpers
 
-  private func buildSubject() async throws {
+  private func buildSubject(config: ApolloCodegenConfiguration = .mock()) async throws {
     let schemaSDL = """
     type Animal {
       species: String
@@ -47,10 +47,10 @@ class FragmentFileGeneratorTests: XCTestCase {
 
     let ir = try await IRBuilder.mock(schema: schemaSDL, document: operationDocument)
     irFragment = await ir.build(fragment: ir.compilationResult.fragments[0])
-    
+
     subject = FragmentFileGenerator(
       irFragment: irFragment,
-      config: ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock())
+      config: ApolloCodegen.ConfigurationContext(config: config)
     )
   }
 
@@ -74,6 +74,56 @@ class FragmentFileGeneratorTests: XCTestCase {
 
     // then
     expect(self.subject.fileName).to(equal(expected))
+  }
+
+  func test__properties__givenGraphQLFragmentWithCapitalizationRules_shouldReturnFileName_withRulesApplied() async throws {
+    // given
+    operationDocument = """
+    query AllAnimals {
+      animals {
+        ...IDDetails
+      }
+    }
+
+    fragment IDDetails on Animal {
+      species
+    }
+    """
+
+    try await buildSubject(config: .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .lower)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    )))
+
+    // then
+    // File names apply the rules to the raw fragment name (no leading-capital normalization),
+    // so the lowercased leading segment stays lowercase, unlike the generated type name `IdDetails`.
+    expect(self.subject.fileName).to(equal("idDetails"))
+  }
+
+  func test__properties__givenGraphQLFragmentWithReplaceCapitalizationRule_shouldReturnFileName_withReplacementApplied() async throws {
+    // given
+    operationDocument = """
+    query AllAnimals {
+      animals {
+        ...GraphqlConfig
+      }
+    }
+
+    fragment GraphqlConfig on Animal {
+      species
+    }
+    """
+
+    try await buildSubject(config: .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("graphql"), strategy: .replace("graphQL"))],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    )))
+
+    // then
+    expect(self.subject.fileName).to(equal("graphQLConfig"))
   }
 
   func test__properties__givenGraphQLFragment_shouldOverwrite() async throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
@@ -66,14 +66,12 @@ class FragmentFileGeneratorTests: XCTestCase {
     expect(self.subject.target).to(equal(expected))
   }
 
-  func test__properties__givenGraphQLFragment_shouldReturnFileName_matchingFragmentDefinitionName() async throws {
+  func test__properties__givenGraphQLFragment_shouldReturnFileName_matchingGeneratedTypeName() async throws {
     // given
     try await buildSubject()
 
-    let expected = irFragment.definition.name
-
     // then
-    expect(self.subject.fileName).to(equal(expected))
+    expect(self.subject.fileName).to(equal("AnimalDetails"))
   }
 
   func test__properties__givenGraphQLFragmentWithCapitalizationRules_shouldReturnFileName_withRulesApplied() async throws {
@@ -97,9 +95,59 @@ class FragmentFileGeneratorTests: XCTestCase {
     )))
 
     // then
-    // File names apply the rules to the raw fragment name (no leading-capital normalization),
-    // so the lowercased leading segment stays lowercase, unlike the generated type name `IdDetails`.
-    expect(self.subject.fileName).to(equal("idDetails"))
+    expect(self.subject.fileName).to(equal("IdDetails"))
+  }
+
+  func test__properties__givenLowercaseFragmentWithUpperCapitalizationRule_shouldReturnFileName_matchingGeneratedTypeName() async throws {
+    // given
+    operationDocument = """
+    query AllAnimals {
+      animals {
+        ...idDetails
+      }
+    }
+
+    fragment idDetails on Animal {
+      species
+    }
+    """
+
+    try await buildSubject(config: .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .upper)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    )))
+
+    // then
+    // The rules run on the `firstUppercased` name, matching the generated type name `IDDetails` —
+    // the `upper` strategy would not fire on the raw name's lowercase leading segment.
+    expect(self.subject.fileName).to(equal("IDDetails"))
+  }
+
+  func test__properties__givenFragmentWithRuleResultCollidingWithReservedTypeName_shouldReturnFileName_withoutFragmentSuffix() async throws {
+    // given
+    operationDocument = """
+    query AllAnimals {
+      animals {
+        ...Id
+      }
+    }
+
+    fragment Id on Animal {
+      species
+    }
+    """
+
+    try await buildSubject(config: .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .upper)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    )))
+
+    // then
+    // The generated type name is escaped to `ID_Fragment`, but — like schema types, whose file
+    // names omit their reserved name suffixes — the file name never carries `_Fragment`.
+    expect(self.subject.fileName).to(equal("ID"))
   }
 
   func test__properties__givenGraphQLFragmentWithReplaceCapitalizationRule_shouldReturnFileName_withReplacementApplied() async throws {
@@ -123,7 +171,7 @@ class FragmentFileGeneratorTests: XCTestCase {
     )))
 
     // then
-    expect(self.subject.fileName).to(equal("graphQLConfig"))
+    expect(self.subject.fileName).to(equal("GraphQLConfig"))
   }
 
   func test__properties__givenGraphQLFragment_shouldOverwrite() async throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationFileGeneratorTests.swift
@@ -30,7 +30,7 @@ class OperationFileGeneratorTests: XCTestCase {
 
   // MARK: Test Helpers
 
-  private func buildSubject() async throws {
+  private func buildSubject(config: ApolloCodegenConfiguration = .mock()) async throws {
     let schemaSDL = """
     type Animal {
       species: String
@@ -44,8 +44,8 @@ class OperationFileGeneratorTests: XCTestCase {
     let ir = try await IRBuilder.mock(schema: schemaSDL, document: operationDocument)
     irOperation = await ir.build(operation: ir.compilationResult.operations[0])
 
-    let config = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock())
-    
+    let config = ApolloCodegen.ConfigurationContext(config: config)
+
     subject = OperationFileGenerator(irOperation: irOperation, operationIdentifier: nil, config: config)
   }
 
@@ -67,6 +67,26 @@ class OperationFileGeneratorTests: XCTestCase {
 
     // then
     expect(self.subject.fileName).to(equal("AllAnimalsQuery"))
+  }
+
+  func test__properties__givenIrOperationWithCapitalizationRules_shouldReturnFileName_withRulesApplied() async throws {
+    // given
+    operationDocument = """
+    query IDLookup {
+      animals {
+        species
+      }
+    }
+    """
+
+    try await buildSubject(config: .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .lower)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    )))
+
+    // then
+    expect(self.subject.fileName).to(equal("IdLookupQuery"))
   }
 
   func test__properties__givenIrOperation_shouldOverwrite() async throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/DeferredFragmentsMetadataTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/DeferredFragmentsMetadataTemplateTests.swift
@@ -458,6 +458,63 @@ class DeferredFragmentsMetadataTemplateTests: XCTestCase {
     )
   }
   
+  func test__render__givenDeferredNamedFragmentWithCapitalizationRules_rendersDeferMetadataWithCapitalizedTypeName() async throws {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      interface Animal {
+        id: String
+        species: String
+      }
+      """.appendingDeferDirective()
+
+    document = """
+      query TestOperation {
+        allAnimals {
+          __typename
+          id
+          ...IDDetails @defer(label: "details")
+        }
+      }
+
+      fragment IDDetails on Animal {
+        species
+      }
+      """
+
+    configContext = .init(config: .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .lower)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    )))
+
+    // when
+    try await buildSubjectAndOperation()
+
+    // then
+    let rendered = renderSubject()
+
+    expect(rendered).to(equalLineByLine("""
+      // MARK: - Deferred Fragment Metadata
+
+      public typealias ResponseFormat = IncrementalDeferredResponseFormat
+      enum DeferredFragmentIdentifiers {
+        static let details = DeferredFragmentIdentifier(label: "details", fieldPath: ["allAnimals"])
+      }
+
+      public static let responseFormat: ResponseFormat = IncrementalDeferredResponseFormat(
+        deferredFragments: [
+          DeferredFragmentIdentifiers.details: IdDetails.self,
+        ]
+      )
+      """,
+      ignoringExtraLines: false)
+    )
+  }
+
   func test__render__givenDeferredNamedFragmentOnDifferentTypeCase_rendersDeferMetadata() async throws {
     schemaSDL = """
       type Query {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -99,6 +99,41 @@ final class FragmentTemplateTests: XCTestCase, @unchecked Sendable {
     expect(String(actual.reversed())).to(equalLineByLine("\n}", ignoringExtraLines: true))
   }
 
+  func test__render__givenFragmentWithCapitalizationRules_capitalizesTypeNameButNotSource() async throws {
+    // given
+    let document = """
+      fragment TestFragmentById on Query {
+        allAnimals {
+          species
+        }
+      }
+      """
+
+    let expected =
+      """
+      struct TestFragmentByID: TestSchema.SelectionSet, Fragment {
+        static var fragmentDefinition: StaticString {
+          #"fragment TestFragmentById on Query { __typename allAnimals { __typename species } }"#
+        }
+      """
+
+    // when
+    let (_, template) = try await buildFragmentTemplate(
+      named: "TestFragmentById",
+      config: .mock(options: .init(
+        additionalCapitalizationRules: [.init(term: .string("id"), strategy: .upper)],
+        schemaDocumentation: .exclude,
+        markTypesNonisolated: false
+      )),
+      document: document
+    )
+
+    let actual = render(template)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
   func test__render__givenFragment_generatesFragmentDeclarationWithoutDefinition() async throws {
     // given
     let expected =

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -134,6 +134,108 @@ final class FragmentTemplateTests: XCTestCase, @unchecked Sendable {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
+  func test__render__givenFragmentWithLowerCapitalizationRule_lowercasesTypeNameButNotSource() async throws {
+    // given
+    let document = """
+      fragment IDDetails on Query {
+        allAnimals {
+          species
+        }
+      }
+      """
+
+    let expected =
+      """
+      struct IdDetails: TestSchema.SelectionSet, Fragment {
+        static var fragmentDefinition: StaticString {
+          #"fragment IDDetails on Query { __typename allAnimals { __typename species } }"#
+        }
+      """
+
+    // when
+    let (_, template) = try await buildFragmentTemplate(
+      named: "IDDetails",
+      config: .mock(options: .init(
+        additionalCapitalizationRules: [.init(term: .string("id"), strategy: .lower)],
+        schemaDocumentation: .exclude,
+        markTypesNonisolated: false
+      )),
+      document: document
+    )
+
+    let actual = render(template)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__render__givenFragmentWithReplaceCapitalizationRule_replacesTypeNameSegment() async throws {
+    // given
+    let document = """
+      fragment GraphqlConfig on Query {
+        allAnimals {
+          species
+        }
+      }
+      """
+
+    let expected =
+      """
+      struct GraphQLConfig: TestSchema.SelectionSet, Fragment {
+        static var fragmentDefinition: StaticString {
+          #"fragment GraphqlConfig on Query { __typename allAnimals { __typename species } }"#
+        }
+      """
+
+    // when
+    let (_, template) = try await buildFragmentTemplate(
+      named: "GraphqlConfig",
+      config: .mock(options: .init(
+        additionalCapitalizationRules: [.init(term: .string("graphql"), strategy: .replace("graphQL"))],
+        schemaDocumentation: .exclude,
+        markTypesNonisolated: false
+      )),
+      document: document
+    )
+
+    let actual = render(template)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__render__givenFragmentWithCapitalizationRuleResultingInReservedName_rendersEscapedName() async throws {
+    // given
+    let document = """
+      fragment Id on Query {
+        allAnimals {
+          species
+        }
+      }
+      """
+
+    let expected =
+      """
+      struct ID_Fragment: TestSchema.SelectionSet, Fragment {
+      """
+
+    // when
+    let (_, template) = try await buildFragmentTemplate(
+      named: "Id",
+      config: .mock(options: .init(
+        additionalCapitalizationRules: [.init(term: .string("id"), strategy: .upper)],
+        schemaDocumentation: .exclude,
+        markTypesNonisolated: false
+      )),
+      document: document
+    )
+
+    let actual = render(template)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
   func test__render__givenFragment_generatesFragmentDeclarationWithoutDefinition() async throws {
     // given
     let expected =

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
@@ -100,6 +100,38 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equal(["ModuleA"]))
   }
 
+  // MARK: - Capitalization Rules
+
+  func test__generate__givenLocalCacheMutationWithCapitalizationRules_capitalizesTypeName() async throws {
+    // given
+    document = """
+      query TestOperationById @apollo_client_ios_localCacheMutation {
+        allAnimals {
+          species
+        }
+      }
+      """
+
+    config = .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .upper)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    ))
+
+    let expected =
+      """
+      struct TestOperationByIDLocalCacheMutation: LocalCacheMutation {
+      """
+
+    // when
+    try await buildSubjectAndOperation(named: "TestOperationById")
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
   // MARK: - Access Level Tests
 
   func

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
@@ -132,6 +132,99 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
+  func test__generate__givenLocalCacheMutationWithLowercaseCapitalizationRule_lowercasesAcronymInTypeName() async throws {
+    // given
+    document = """
+      query IDLookup @apollo_client_ios_localCacheMutation {
+        allAnimals {
+          species
+        }
+      }
+      """
+
+    config = .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .lower)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    ))
+
+    let expected =
+      """
+      struct IdLookupLocalCacheMutation: LocalCacheMutation {
+      """
+
+    // when
+    try await buildSubjectAndOperation(named: "IDLookup")
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__generate__givenLocalCacheMutationWithReplaceCapitalizationRule_replacesTermInTypeName() async throws {
+    // given
+    document = """
+      query GraphqlSettings @apollo_client_ios_localCacheMutation {
+        allAnimals {
+          species
+        }
+      }
+      """
+
+    config = .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("graphql"), strategy: .replace("graphQL"))],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    ))
+
+    let expected =
+      """
+      struct GraphQLSettingsLocalCacheMutation: LocalCacheMutation {
+      """
+
+    // when
+    try await buildSubjectAndOperation(named: "GraphqlSettings")
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__generate__givenLocalCacheMutationFragmentWithCapitalizationRules_capitalizesFragmentTypeName() async throws {
+    // given
+    document = """
+      query TestOperation {
+        allAnimals {
+          ...IDDetails
+        }
+      }
+
+      fragment IDDetails on Animal @apollo_client_ios_localCacheMutation {
+        species
+      }
+      """
+
+    config = .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .lower)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    ))
+
+    let expected = """
+      struct IdDetails: TestSchema.MutableSelectionSet, Fragment {
+      """
+
+    // when
+    try await buildSubjectAndFragment(named: "IDDetails")
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 1, ignoringExtraLines: true))
+  }
+
   // MARK: - Access Level Tests
 
   func

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -325,6 +325,93 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
+  func test__generate__givenSubscriptionWithCapitalizationRules_capitalizesTypeNameButNotOperationNameOrSource() async throws {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      type Subscription {
+        streamAnimals: [Animal!]
+      }
+
+      type Animal {
+        species: String!
+      }
+      """
+
+    document = """
+      subscription TestOperationById {
+        streamAnimals {
+          species
+        }
+      }
+      """
+
+    config = .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .upper)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    ))
+
+    let expected =
+      """
+      struct TestOperationByIDSubscription: GraphQLSubscription {
+        static let operationName: String = "TestOperationById"
+        static let operationDocument: ApolloAPI.OperationDocument = .init(
+          definition: .init(
+            #\"subscription TestOperationById { streamAnimals { __typename species } }\"#
+      """
+
+    // when
+    try await buildSubjectAndOperation(named: "TestOperationById")
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__generate__givenSubscriptionWithoutCapitalizationRules_doesNotCapitalizeTypeName() async throws {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      type Subscription {
+        streamAnimals: [Animal!]
+      }
+
+      type Animal {
+        species: String!
+      }
+      """
+
+    document = """
+      subscription TestOperationById {
+        streamAnimals {
+          species
+        }
+      }
+      """
+
+    let expected =
+      """
+      struct TestOperationByIdSubscription: GraphQLSubscription {
+        static let operationName: String = "TestOperationById"
+      """
+
+    // when
+    try await buildSubjectAndOperation(named: "TestOperationById")
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
   // MARK: - Selection Set Declaration
 
   func test__generate__givenOperationSelectionSet_rendersDeclaration() async throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -412,6 +412,88 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
+  func test__generate__givenQueryWithLowerRuleOnLeadingSegmentOfName_typeNameKeepsLeadingCapitalAndOperationNameUnchanged() async throws {
+    // given
+    document = """
+      query IDLookup {
+        allAnimals {
+          species
+        }
+      }
+      """
+
+    config = .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .lower)],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    ))
+
+    let expected =
+      """
+      struct IdLookupQuery: GraphQLQuery {
+        static let operationName: String = "IDLookup"
+        static let operationDocument: ApolloAPI.OperationDocument = .init(
+          definition: .init(
+            #\"query IDLookup { allAnimals { __typename species } }\"#
+      """
+
+    // when
+    try await buildSubjectAndOperation(named: "IDLookup")
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__generate__givenMutationWithReplaceRuleLowercaseLeadingReplacement_typeNameKeepsLeadingCapitalAndOperationNameUnchanged() async throws {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      type Mutation {
+        addAnimal: Animal!
+      }
+
+      type Animal {
+        species: String!
+      }
+      """
+
+    document = """
+      mutation GraphqlFeed {
+        addAnimal {
+          species
+        }
+      }
+      """
+
+    config = .mock(options: .init(
+      additionalCapitalizationRules: [.init(term: .string("graphql"), strategy: .replace("graphQL"))],
+      schemaDocumentation: .exclude,
+      markTypesNonisolated: false
+    ))
+
+    let expected =
+      """
+      struct GraphQLFeedMutation: GraphQLMutation {
+        static let operationName: String = "GraphqlFeed"
+        static let operationDocument: ApolloAPI.OperationDocument = .init(
+          definition: .init(
+            #\"mutation GraphqlFeed { addAnimal { __typename species } }\"#
+      """
+
+    // when
+    try await buildSubjectAndOperation(named: "GraphqlFeed")
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
   // MARK: - Selection Set Declaration
 
   func test__generate__givenOperationSelectionSet_rendersDeclaration() async throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
@@ -41,7 +41,8 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     operationIdentifier: String? = nil,
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackage(),
     operations: ApolloCodegenConfiguration.OperationsFileOutput = .inSchemaModule,
-    operationDocumentFormat: ApolloCodegenConfiguration.OperationDocumentFormat = .definition    
+    operationDocumentFormat: ApolloCodegenConfiguration.OperationDocumentFormat = .definition,
+    additionalCapitalizationRules: [CapitalizationRule] = []
   ) async throws {
     ir = try await .mock(schema: schemaSDL, document: document)
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
@@ -50,6 +51,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     config = .mock(
       output: .mock(moduleType: moduleType, operations: operations),
       options: .init(
+        additionalCapitalizationRules: additionalCapitalizationRules,
         operationDocumentFormat: operationDocumentFormat,
         markTypesNonisolated: false
       )
@@ -181,6 +183,39 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
       definition: .init(
         #"query NameQuery { ...nameFragment }"#,
         fragments: [NameFragment.self]
+      ))
+    """
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__generate__givenIncludesFragment_withCapitalizationRuleMatchingFragmentName_generatesFragmentsListWithCapitalizationRulesApplied() async throws {
+    // given
+    document =
+    """
+    query NameQuery {
+      ...IDDetails
+    }
+
+    fragment IDDetails on Query {
+      name
+    }
+    """
+
+    try await buildSubjectAndOperation(
+      operationDocumentFormat: .definition,
+      additionalCapitalizationRules: [.init(term: .string("id"), strategy: .lower)]
+    )
+
+    // when
+    let actual = try renderDocumentType()
+
+    // then
+    let expected =
+    """
+    public static let operationDocument: ApolloAPI.OperationDocument = .init(
+      definition: .init(
+        #"query NameQuery { ...IDDetails }"#,
+        fragments: [IdDetails.self]
       ))
     """
     expect(actual).to(equalLineByLine(expected))

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -30,6 +30,7 @@ class SelectionSetTemplateTests: XCTestCase {
   func buildSubjectAndOperation(
     named operationName: String = "TestOperation",
     configOutput: ApolloCodegenConfiguration.FileOutput = .mock(),
+    capitalizationRules: [ApolloCodegenLib.CapitalizationRule] = [],
     inflectionRules: [ApolloCodegenLib.InflectionRule] = [],
     schemaDocumentation: ApolloCodegenConfiguration.Composition = .exclude,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = .exclude,
@@ -42,6 +43,7 @@ class SelectionSetTemplateTests: XCTestCase {
       schemaNamespace: "TestSchema",
       output: configOutput,
       options: .init(
+        additionalCapitalizationRules: capitalizationRules,
         additionalInflectionRules: inflectionRules,
         schemaDocumentation: schemaDocumentation,
         warningsOnDeprecatedUsage: warningsOnDeprecatedUsage,
@@ -11683,6 +11685,48 @@ class SelectionSetTemplateTests: XCTestCase {
     )
 
     let actual = subject.test_render(inlineFragment: predators_asPet.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 1, ignoringExtraLines: true))
+  }
+
+  func test__render_conditionalFragmentOnQueryRoot__givenCapitalizationRules_rendersRootEntityTypeWithCapitalizedOperationName() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      name: String!
+    }
+    """
+
+    document = """
+    query TestOperationById($a: Boolean!) {
+      ...Details @include(if: $a)
+    }
+
+    fragment Details on Query {
+      name
+    }
+    """
+
+    let expected = """
+    /// IfA
+    public struct IfA: TestSchema.InlineFragment {
+      @_spi(Unsafe) public let __data: DataDict
+      @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public typealias RootEntityType = TestOperationByIDQuery.Data
+    """
+
+    // when
+    try await buildSubjectAndOperation(
+      named: "TestOperationById",
+      capitalizationRules: [.init(term: .string("id"), strategy: .upper)]
+    )
+    let query_ifA = try XCTUnwrap(
+      operation[field: "query"]?[if: "a"]
+    )
+
+    let actual = subject.test_render(inlineFragment: query_ifA.computed)
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 1, ignoringExtraLines: true))

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -69,10 +69,11 @@ class SelectionSetTemplateTests: XCTestCase {
     named fragmentName: String,
     in ir: IRBuilderTestWrapper,
     configOutput: ApolloCodegenConfiguration.FileOutput = .mock(),
+    capitalizationRules: [ApolloCodegenLib.CapitalizationRule] = [],
     inflectionRules: [ApolloCodegenLib.InflectionRule] = [],
     schemaDocumentation: ApolloCodegenConfiguration.Composition = .exclude,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = .exclude,
-    conversionStrategies: ApolloCodegenConfiguration.ConversionStrategies = .init(),    
+    conversionStrategies: ApolloCodegenConfiguration.ConversionStrategies = .init(),
   ) async throws -> FragmentTemplate {
     let fragmentDefinition = try XCTUnwrap(ir.compilationResult[fragment: fragmentName])
     let fragment = await ir.build(fragment: fragmentDefinition)
@@ -80,6 +81,7 @@ class SelectionSetTemplateTests: XCTestCase {
       schemaNamespace: "TestSchema",
       output: configOutput,
       options: .init(
+        additionalCapitalizationRules: capitalizationRules,
         additionalInflectionRules: inflectionRules,
         schemaDocumentation: schemaDocumentation,
         warningsOnDeprecatedUsage: warningsOnDeprecatedUsage,
@@ -1689,6 +1691,51 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // when
     try await buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
+  }
+
+  func test__render_selections__givenFragmentsWithCapitalizationRules_rendersFragmentSelectionsWithCapitalizedFragmentName() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ...IDDetails
+      }
+    }
+
+    fragment IDDetails on Animal {
+      species
+    }
+    """
+
+    let expected = """
+      @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .fragment(IdDetails.self),
+      ] }
+    """
+
+    // when
+    try await buildSubjectAndOperation(
+      capitalizationRules: [.init(term: .string("id"), strategy: .lower)]
+    )
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "allAnimals"]?.selectionSet
     )
@@ -4630,6 +4677,63 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // when
     try await buildSubjectAndOperation()
+    let predator_asPet = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?[field: "predator"]?[as: "Pet"]
+    )
+
+    let actual = subject.test_render(inlineFragment: predator_asPet.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__render_mergedSources__givenTypeCaseMergedFromFragmentWithCapitalizationRules_rendersMergedSourcesWithCapitalizedFragmentName() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+      predator: Animal!
+    }
+
+    interface Pet {
+      name: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ...IDDetails
+        predator {
+          species
+        }
+      }
+    }
+
+    fragment IDDetails on Animal {
+      predator {
+        ... on Pet {
+          name
+        }
+      }
+    }
+    """
+
+    let expected = """
+      @_spi(Execution) public static var __mergedSources: [any ApolloAPI.SelectionSet.Type] { [
+        TestOperationQuery.Data.AllAnimal.Predator.self,
+        IdDetails.Predator.AsPet.self
+      ] }
+    """
+
+    // when
+    try await buildSubjectAndOperation(
+      capitalizationRules: [.init(term: .string("id"), strategy: .lower)]
+    )
     let predator_asPet = try XCTUnwrap(
       operation[field: "query"]?[field: "allAnimals"]?[field: "predator"]?[as: "Pet"]
     )
@@ -8130,6 +8234,53 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // when
     try await buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, forSection: .selectionSet.namedFragmentAccessors))
+  }
+
+  func test__render_fragmentAccessor__givenFragmentWithCapitalizationRules_rendersFragmentAccessorWithCapitalizedTypeName() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ...IDDetails
+      }
+    }
+
+    fragment IDDetails on Animal {
+      species
+    }
+    """
+
+    let expected = """
+      public struct Fragments: FragmentContainer {
+        @_spi(Unsafe) public let __data: DataDict
+        @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public var iDDetails: IdDetails { _toFragment() }
+      }
+    """
+
+    // when
+    try await buildSubjectAndOperation(
+      capitalizationRules: [.init(term: .string("id"), strategy: .lower)]
+    )
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "allAnimals"]?.selectionSet
     )
@@ -11730,6 +11881,100 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 1, ignoringExtraLines: true))
+  }
+
+  func test__render_conditionalFragmentOnQueryRoot__givenLowercaseCapitalizationRule_rendersRootEntityTypeWithCapitalizedOperationName() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      name: String!
+    }
+    """
+
+    document = """
+    query IDLookup($a: Boolean!) {
+      ...Details @include(if: $a)
+    }
+
+    fragment Details on Query {
+      name
+    }
+    """
+
+    let expected = """
+    /// IfA
+    public struct IfA: TestSchema.InlineFragment {
+      @_spi(Unsafe) public let __data: DataDict
+      @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public typealias RootEntityType = IdLookupQuery.Data
+    """
+
+    // when
+    try await buildSubjectAndOperation(
+      named: "IDLookup",
+      capitalizationRules: [.init(term: .string("id"), strategy: .lower)]
+    )
+    let query_ifA = try XCTUnwrap(
+      operation[field: "query"]?[if: "a"]
+    )
+
+    let actual = subject.test_render(inlineFragment: query_ifA.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 1, ignoringExtraLines: true))
+  }
+
+  func test__render_inlineFragmentInFragment__givenCapitalizationRules_rendersRootEntityTypeWithCapitalizedFragmentName() async throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    interface Pet implements Animal {
+      species: String!
+      name: String!
+    }
+    """
+
+    document = """
+    fragment IDDetails on Animal {
+      ... on Pet {
+        name
+      }
+    }
+    """
+
+    let expected = """
+      /// AsPet
+      public struct AsPet: TestSchema.InlineFragment {
+        @_spi(Unsafe) public let __data: DataDict
+        @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public typealias RootEntityType = IdDetails
+    """
+
+    // when
+    ir = try await IRBuilderTestWrapper(.mock(schema: schemaSDL, document: document))
+    let fragmentTemplate = try await buildFragment(
+      named: "IDDetails",
+      in: ir,
+      capitalizationRules: [.init(term: .string("id"), strategy: .lower)]
+    )
+
+    let actual = fragmentTemplate.renderBodyTemplate(nonFatalErrorRecorder: .init()).description
+
+    // then
+    expect(actual).to(equalLineByLine(
+      expected,
+      after: .selectionSet.inlineFragmentAccessors,
+      ignoringExtraLines: true)
+    )
   }
 
   func test__render_conditionalFragmentOnQueryRoot__rendersRootEntityType() async throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_ErrorHandling_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_ErrorHandling_Tests.swift
@@ -33,7 +33,8 @@ class SelectionSetTemplate_ErrorHandling_Tests: XCTestCase {
 
   func buildSubjectAndOperation(
     named operationName: String = "ConflictingQuery",
-    fieldMerging: ApolloCodegenConfiguration.FieldMerging = .all
+    fieldMerging: ApolloCodegenConfiguration.FieldMerging = .all,
+    capitalizationRules: [ApolloCodegenLib.CapitalizationRule] = []
   ) async throws {
     ir = try await IRBuilderTestWrapper(.mock(schema: schemaSDL, document: document))
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
@@ -44,6 +45,11 @@ class SelectionSetTemplate_ErrorHandling_Tests: XCTestCase {
     let config = ApolloCodegenConfiguration.mock(
       schemaNamespace: "TestSchema",
       output: .mock(moduleType: .swiftPackage(), operations: .inSchemaModule),
+      options: .init(
+        additionalCapitalizationRules: capitalizationRules,
+        schemaDocumentation: .exclude,
+        markTypesNonisolated: false
+      ),
       experimentalFeatures: .init(
         fieldMerging: fieldMerging
       )
@@ -751,6 +757,53 @@ class SelectionSetTemplate_ErrorHandling_Tests: XCTestCase {
 
     // when
     try await buildSubjectAndOperation()
+    _ = subject.renderBody()
+
+    // then
+    expect(self.errorRecorder.recordedErrors.count).to(equal(1))
+    expect(self.errorRecorder.recordedErrors.first).to(equal(expectedError))
+  }
+
+  func
+    test__validation__selectionSet_typeConflicts_withCapitalizedNamedFragmentFieldCollision_shouldReturnNonFatalError()
+    async throws
+  {
+    schemaSDL = """
+      type Query {
+          allAnimals: [Animal!]
+      }
+
+      type Animal {
+          species: String!
+          idDetails: Animal
+      }
+      """
+
+    document = """
+      query ConflictingQuery {
+          allAnimals {
+            idDetails {
+              species
+            }
+            ...IDDetails
+          }
+      }
+
+      fragment IDDetails on Animal {
+          species
+      }
+      """
+
+    let expectedError = ApolloCodegen.NonFatalError.typeNameConflict(
+      name: "idDetails",
+      conflictingName: "IDDetails",
+      containingObject: "ConflictingQuery.Data.AllAnimal"
+    )
+
+    // when
+    try await buildSubjectAndOperation(
+      capitalizationRules: [.init(term: .string("id"), strategy: .lower)]
+    )
     _ = subject.renderBody()
 
     // then

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_FulfilledAndDeferredFragments_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_FulfilledAndDeferredFragments_Tests.swift
@@ -32,7 +32,8 @@ class SelectionSetTemplate_FulfilledAndDeferredFragment_Tests: XCTestCase {
     named operationName: String = "TestOperation",
     schemaNamespace: String = "TestSchema",
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackage(),
-    operations: ApolloCodegenConfiguration.OperationsFileOutput = .inSchemaModule
+    operations: ApolloCodegenConfiguration.OperationsFileOutput = .inSchemaModule,
+    capitalizationRules: [ApolloCodegenLib.CapitalizationRule] = []
   ) async throws {
     ir = try await IRBuilderTestWrapper(.mock(schema: schemaSDL, document: document))
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
@@ -40,7 +41,10 @@ class SelectionSetTemplate_FulfilledAndDeferredFragment_Tests: XCTestCase {
     let config = ApolloCodegenConfiguration.mock(
       schemaNamespace: schemaNamespace,
       output: .mock(moduleType: moduleType, operations: operations),
-      options: .init(markTypesNonisolated: false)
+      options: .init(
+        additionalCapitalizationRules: capitalizationRules,
+        markTypesNonisolated: false
+      )
     )
     let mockTemplateRenderer = MockTemplateRenderer(
       target: .operationFile(),
@@ -338,6 +342,56 @@ class SelectionSetTemplate_FulfilledAndDeferredFragment_Tests: XCTestCase {
 
     // when
     try await buildSubjectAndOperation()
+
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+  }
+
+  func test__render_givenNamedFragmentSelectionWithCapitalizationRules_fulfilledFragmentsIncludeCapitalizedTypeNames()
+    async throws
+  {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      interface Animal {
+        species: String!
+      }
+      """
+
+    document = """
+      query IDLookup {
+        allAnimals {
+          ...IDDetails
+        }
+      }
+
+      fragment IDDetails on Animal {
+        species
+      }
+      """
+
+    let expected =
+      """
+        @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+          IdLookupQuery.Data.AllAnimal.self,
+          IdDetails.self
+        ] }
+      """
+
+    // when
+    try await buildSubjectAndOperation(
+      named: "IDLookup",
+      capitalizationRules: [.init(term: .string("id"), strategy: .lower)]
+    )
 
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "allAnimals"]?.selectionSet
@@ -1486,5 +1540,87 @@ class SelectionSetTemplate_FulfilledAndDeferredFragment_Tests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+  }
+
+  func test__render__givenDeferredNamedFragmentWithCapitalizationRules_rendersCapitalizedDeferredFragmentTypeName()
+    async throws
+  {
+    // given
+    schemaSDL = """
+      type Query {
+        allAnimals: [Animal!]
+      }
+
+      interface Animal {
+        id: String!
+        species: String!
+      }
+      """.appendingDeferDirective()
+
+    document = """
+      query TestOperation {
+        allAnimals {
+          __typename
+          id
+          ...IDDetails @defer(label: "details")
+        }
+      }
+
+      fragment IDDetails on Animal {
+        species
+      }
+      """
+
+    // when
+    try await buildSubjectAndOperation(
+      capitalizationRules: [.init(term: .string("id"), strategy: .lower)]
+    )
+
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?.selectionSet
+    )
+
+    let actual = subject.test_render(childEntity: allAnimals.computed)
+
+    // then
+    expect(actual).to(equalLineByLine(
+      """
+        @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .deferred(IdDetails.self, label: "details"),
+        ] }
+      """,
+      atLine: 9,
+      ignoringExtraLines: true
+    ))
+
+    expect(actual).to(equalLineByLine(
+      """
+        @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+          TestOperationQuery.Data.AllAnimal.self
+        ] }
+        @_spi(Execution) public static var __deferredFragments: [any ApolloAPI.Deferrable.Type] { [
+          IdDetails.self
+        ] }
+      """,
+      atLine: 14,
+      ignoringExtraLines: true
+    ))
+
+    expect(actual).to(equalLineByLine(
+      """
+        public struct Fragments: FragmentContainer {
+          @_spi(Unsafe) public let __data: DataDict
+          @_spi(Unsafe) public init(_dataDict: DataDict) {
+            __data = _dataDict
+            _iDDetails = Deferred(_dataDict: _dataDict)
+          }
+
+          @Deferred public var iDDetails: IdDetails?
+        }
+      """,
+      forSection: .selectionSet.namedFragmentAccessors
+    ))
   }
 }

--- a/Tests/ApolloCodegenTests/FileManagerExtensionTests.swift
+++ b/Tests/ApolloCodegenTests/FileManagerExtensionTests.swift
@@ -561,6 +561,148 @@ class FileManagerExtensionTests: XCTestCase {
     }.notTo(throwError())
   }
 
+  // MARK: File Name Case Adoption
+
+  func test_createFile_givenExistingFileNameDiffersOnlyByCase_onCaseInsensitiveVolume_shouldRenameFileToNewCasing() async throws {
+    // given
+    let subject = ApolloFileManager(base: FileManager.default)
+    let directoryPath = self.uniquePath
+    let originalPath = URL(fileURLWithPath: directoryPath).appendingPathComponent("CaseTest.swift").path
+    let recasedPath = URL(fileURLWithPath: directoryPath).appendingPathComponent("CASETest.swift").path
+
+    addTeardownBlock {
+      try? FileManager.default.removeItem(atPath: directoryPath)
+    }
+
+    try await subject.createFile(atPath: originalPath, data: "Original".data(using: .utf8))
+
+    let isCaseSensitive = await subject.volumeSupportsCaseSensitiveNames(forPath: originalPath)
+    try XCTSkipIf(isCaseSensitive != false, "This test requires a case-insensitive volume.")
+
+    // when
+    try await subject.createFile(atPath: recasedPath, data: "Recased".data(using: .utf8))
+
+    // then
+    let directoryContents = try FileManager.default.contentsOfDirectory(atPath: directoryPath)
+    expect(directoryContents).to(contain("CASETest.swift"))
+    expect(directoryContents).notTo(contain("CaseTest.swift"))
+    await expect { await subject.writtenFiles }.to(contain(recasedPath))
+  }
+
+  func test_createFile_givenExistingFileNameDiffersOnlyByCase_whenVolumeIsCaseInsensitive_shouldMoveFileToAdoptNewCasing() async throws {
+    // given
+    let directoryPath = "/A"
+    let onDiskPath = "/A/CaseTest.swift"
+    let requestedPath = "/A/CASETest.swift"
+    let mocked = MockApolloFileManager()
+
+    await mocked.mock(volumeIsCaseSensitive: false)
+    await mocked.mock(onDiskCasedPath: onDiskPath, forPath: requestedPath)
+
+    await mocked.mock(closure: .fileExists({ path, isDirectory in
+      switch path {
+      case directoryPath: isDirectory?.pointee = true
+      case requestedPath: isDirectory?.pointee = false
+      default: fail("Unknown path - \(path)")
+      }
+
+      return true
+
+    }))
+    await mocked.mock(closure: .moveItem({ srcPath, dstPath in
+      expect(srcPath).to(equal(onDiskPath))
+      expect(dstPath).to(equal(requestedPath))
+    }))
+    await mocked.mock(closure: .createFile({ path, data, attr in
+      expect(path).to(equal(requestedPath))
+
+      return true
+
+    }))
+
+    // then
+    await expect {
+      try await mocked.createFile(atPath: requestedPath, data: self.uniqueData)
+    }.notTo(throwError())
+    await expect { await mocked.allClosuresCalled }.to(beTrue())
+  }
+
+  func test_createFile_givenCaseSensitiveVolume_shouldNotPerformFileNameCaseAdoption() async throws {
+    // given
+    let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
+    let mocked = MockApolloFileManager()
+
+    await mocked.mock(volumeIsCaseSensitive: true)
+
+    await mocked.mock(closure: .fileExists({ path, isDirectory in
+      expect(path).to(equal(parentPath))
+      expect(isDirectory).notTo(beNil())
+
+      isDirectory?.pointee = true
+      return true
+
+    }))
+    let expectedPath = self.uniquePath
+    let expectedData = self.uniqueData
+    await mocked.mock(closure: .createFile({ path, data, attr in
+      expect(path).to(equal(expectedPath))
+      expect(data).to(equal(expectedData))
+      expect(attr).to(beNil())
+
+      return true
+
+    }))
+
+    // then
+    // The mock is strict and reports a case-sensitive volume, so any file system call made to
+    // adopt file name casing would fail the test.
+    await expect {
+      try await mocked.createFile(atPath: self.uniquePath, data:self.uniqueData)
+    }.notTo(throwError())
+    await expect { await mocked.allClosuresCalled }.to(beTrue())
+  }
+
+  func test_createFile_givenFileNameCaseAdoptionFails_shouldNotThrow_shouldStillCreateFile() async throws {
+    // given
+    let directoryPath = "/A"
+    let onDiskPath = "/A/CaseTest.swift"
+    let requestedPath = "/A/CASETest.swift"
+    let mocked = MockApolloFileManager()
+
+    await mocked.mock(volumeIsCaseSensitive: false)
+    await mocked.mock(onDiskCasedPath: onDiskPath, forPath: requestedPath)
+
+    await mocked.mock(closure: .fileExists({ path, isDirectory in
+      switch path {
+      case directoryPath: isDirectory?.pointee = true
+      case requestedPath: isDirectory?.pointee = false
+      default: fail("Unknown path - \(path)")
+      }
+
+      return true
+
+    }))
+    await mocked.mock(closure: .moveItem({ [uniqueError] srcPath, dstPath in
+      expect(srcPath).to(equal(onDiskPath))
+      expect(dstPath).to(equal(requestedPath))
+
+      throw uniqueError!
+    }))
+    await mocked.mock(closure: .createFile({ path, data, attr in
+      expect(path).to(equal(requestedPath))
+
+      return true
+
+    }))
+
+    // then
+    await expect {
+      try await mocked.createFile(atPath: requestedPath, data: self.uniqueData)
+    }.notTo(throwError())
+    await expect { await mocked.writtenFiles }.to(contain(requestedPath))
+    await expect { await mocked.allClosuresCalled }.to(beTrue())
+  }
+
   func test_createContainingDirectory_givenFileExistsAndIsDirectory_shouldReturnEarly() async throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -656,9 +656,19 @@ public final class ApolloCodegen: Sendable {
     from oldGeneratedFilePaths: Set<String>,
     afterCodeGenerationUsing fileManager: ApolloFileManager
   ) async throws {
-    let filePathsToDelete = await oldGeneratedFilePaths.subtracting(fileManager.writtenFiles)
+    let writtenFiles = await fileManager.writtenFiles
+    let caseFoldedWrittenFiles = Set(writtenFiles.map { $0.lowercased() })
 
-    for path in filePathsToDelete {
+    for path in oldGeneratedFilePaths.subtracting(writtenFiles) {
+      // On a case-insensitive volume, a path differing from a written file only by case refers
+      // to the same file; deleting it would delete the newly generated output. When the volume's
+      // case sensitivity cannot be determined, the path is also skipped — leaving a stale file
+      // behind is preferable to deleting fresh output.
+      if caseFoldedWrittenFiles.contains(path.lowercased()),
+        await fileManager.volumeSupportsCaseSensitiveNames(forPath: path) != true {
+        continue
+      }
+
       try await fileManager.deleteFile(atPath: path)
     }
   }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration.swift
@@ -650,10 +650,16 @@ public struct ApolloCodegenConfiguration: Codable, Equatable, Sendable {
     /// Any non-default rules for capitalization you wish to include.
     ///
     /// Rules are applied to the names of generated field accessors, initializer parameters,
-    /// enum cases, input object fields, and test mock fields, following SwiftFormat's
-    /// `acronyms` convention: an acronym is only capitalized when its first character is
-    /// already uppercase, so the leading `id` in `idToken` is preserved while the `Id` in
-    /// `userId` becomes `ID`. Schema and selection set *type* names are not affected.
+    /// enum cases, input object fields, test mock fields, and the generated Swift *type* names
+    /// of GraphQL operations and fragments (e.g. `…ByIdSubscription` → `…ByIDSubscription`),
+    /// following SwiftFormat's `acronyms` convention: an acronym is only capitalized when its
+    /// first character is already uppercase, so the leading `id` in `idToken` is preserved while
+    /// the `Id` in `userId` becomes `ID`.
+    ///
+    /// An operation's `operationName`, the GraphQL document sent to the server, and the
+    /// persisted-query/operation-manifest identifiers are *never* changed — only the generated
+    /// Swift identifiers are. Schema type names and field-derived nested selection set type names
+    /// are not affected.
     public let additionalCapitalizationRules: [CapitalizationRule]
     /// Any non-default rules for pluralization or singularization you wish to include.
     public let additionalInflectionRules: [InflectionRule]

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration.swift
@@ -660,6 +660,12 @@ public struct ApolloCodegenConfiguration: Codable, Equatable, Sendable {
     /// persisted-query/operation-manifest identifiers are *never* changed — only the generated
     /// Swift identifiers are. Schema type names and field-derived nested selection set type names
     /// are not affected.
+    ///
+    /// Generated type names always begin with a capital letter: after the rules are applied, the
+    /// first character of an operation or fragment type name is re-capitalized, so a `lower` or
+    /// `replace` rule matching the leading word segment affects only the remainder of that
+    /// segment (e.g. a `lower` rule on `id` renders fragment `IDDetails` as `IdDetails`, not
+    /// `idDetails`).
     public let additionalCapitalizationRules: [CapitalizationRule]
     /// Any non-default rules for pluralization or singularization you wish to include.
     public let additionalInflectionRules: [InflectionRule]

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration.swift
@@ -666,6 +666,9 @@ public struct ApolloCodegenConfiguration: Codable, Equatable, Sendable {
     /// `replace` rule matching the leading word segment affects only the remainder of that
     /// segment (e.g. a `lower` rule on `id` renders fragment `IDDetails` as `IdDetails`, not
     /// `idDetails`).
+    ///
+    /// Generated operation and fragment file names match the generated type names, except that
+    /// the reserved type name `_Fragment` suffix never appears in file names.
     public let additionalCapitalizationRules: [CapitalizationRule]
     /// Any non-default rules for pluralization or singularization you wish to include.
     public let additionalInflectionRules: [InflectionRule]

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
@@ -13,5 +13,5 @@ struct FragmentFileGenerator: FileGenerator {
     config: config
   ) }
   var target: FileTarget { .fragment(irFragment.definition) }
-  var fileName: String { irFragment.definition.name }
+  var fileName: String { config.capitalizer.apply(to: irFragment.definition.name) }
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
@@ -13,5 +13,5 @@ struct FragmentFileGenerator: FileGenerator {
     config: config
   ) }
   var target: FileTarget { .fragment(irFragment.definition) }
-  var fileName: String { config.capitalizer.apply(to: irFragment.definition.name) }
+  var fileName: String { irFragment.definition.generatedFileName(capitalizer: config.capitalizer) }
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/OperationFileGenerator.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/FileGenerators/OperationFileGenerator.swift
@@ -24,5 +24,5 @@ struct OperationFileGenerator: FileGenerator {
   }
 
   var target: FileTarget { .operation(irOperation.definition) }
-  var fileName: String { irOperation.definition.generatedDefinitionName }
+  var fileName: String { irOperation.definition.generatedDefinitionName(capitalizer: config.capitalizer) }
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/FileManager+Apollo.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/FileManager+Apollo.swift
@@ -87,10 +87,16 @@ public class ApolloFileManager {
   ///       If `false` the function will exit without writing the file if it already exists.
   ///       This will not throw an error.
   ///       Defaults to `false.
+  ///
+  /// On a case-insensitive volume, overwriting an existing file whose on-disk name differs from
+  /// `path` only by case first renames the file so its directory entry adopts the casing of
+  /// `path`.
   public func createFile(atPath path: String, data: Data? = nil, overwrite: Bool = true) throws {
     try createContainingDirectoryIfNeeded(forPath: path)
 
     if !overwrite && doesFileExist(atPath: path) { return }
+
+    adoptFileNameCasingIfNeeded(atPath: path)
 
     guard base.createFile(atPath: path, contents: data, attributes: nil) else {
       throw FileManagerPathError.cannotCreateFile(at: path)
@@ -104,6 +110,79 @@ public class ApolloFileManager {
     try base.moveItem(atPath: oldPath, toPath: newPath)
 
     writtenFiles.insert(newPath)
+  }
+
+  // MARK: Case Sensitivity
+
+  private var volumeCaseSensitivityCache: [String: Bool] = [:]
+
+  /// Queries whether the volume containing the given directory treats file names that differ
+  /// only by case as distinct files, or `nil` when this cannot be determined.
+  /// Replaceable in tests to simulate volume behavior deterministically.
+  var volumeCaseSensitivityProvider: @Sendable (_ directoryPath: String) -> Bool? = {
+    directoryPath in
+    let resourceValues = try? URL(fileURLWithPath: directoryPath, isDirectory: true)
+      .resourceValues(forKeys: [.volumeSupportsCaseSensitiveNamesKey])
+    return resourceValues?.volumeSupportsCaseSensitiveNames
+  }
+
+  /// Queries the canonical path for an existing file, with the on-disk casing of its name, or
+  /// `nil` when this cannot be determined.
+  /// Replaceable in tests to simulate volume behavior deterministically.
+  var onDiskCasedPathProvider: @Sendable (_ path: String) -> String? = { path in
+    let resourceValues = try? URL(fileURLWithPath: path)
+      .resourceValues(forKeys: [.canonicalPathKey])
+    return resourceValues?.canonicalPath
+  }
+
+  /// Whether the volume containing `path` treats file names that differ only by case as
+  /// distinct files.
+  ///
+  /// Returns `nil` when the volume's capability cannot be determined; callers must choose the
+  /// failure mode that is safe for their operation.
+  func volumeSupportsCaseSensitiveNames(forPath path: String) -> Bool? {
+    let directoryPath = URL(fileURLWithPath: path).deletingLastPathComponent().path
+    if let cached = volumeCaseSensitivityCache[directoryPath] { return cached }
+
+    guard let isCaseSensitive = volumeCaseSensitivityProvider(directoryPath) else { return nil }
+
+    volumeCaseSensitivityCache[directoryPath] = isCaseSensitive
+    return isCaseSensitive
+  }
+
+  /// The canonical path for an existing file, with the on-disk casing of its name, or `nil` if
+  /// it cannot be determined.
+  func onDiskCasedPath(forPath path: String) -> String? {
+    onDiskCasedPathProvider(path)
+  }
+
+  /// On a case-insensitive volume, writing to a path whose on-disk file name differs only by
+  /// case would update the file's contents while keeping the old directory entry name. This
+  /// renames the file first so the directory entry adopts the casing of `path`.
+  ///
+  /// Skipped when the volume's case sensitivity cannot be determined — a stale directory entry
+  /// name is preferable to renaming on an unknown file system.
+  func adoptFileNameCasingIfNeeded(atPath path: String) {
+    guard
+      volumeSupportsCaseSensitiveNames(forPath: path) == false,
+      let onDiskPath = onDiskCasedPath(forPath: path)
+    else { return }
+
+    let onDiskName = URL(fileURLWithPath: onDiskPath).lastPathComponent
+    let targetName = URL(fileURLWithPath: path).lastPathComponent
+    guard
+      onDiskName != targetName,
+      onDiskName.caseInsensitiveCompare(targetName) == .orderedSame
+    else { return }
+
+    do {
+      try base.moveItem(atPath: onDiskPath, toPath: path)
+    } catch {
+      CodegenLogger.log(
+        "Unable to rename \(onDiskPath) to adopt the casing of \(targetName): \(error)",
+        logLevel: .warning
+      )
+    }
   }
 
   /// Creates the containing directory (including all intermediate directories) for the given file URL if necessary.

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/IR+Formatting.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/IR+Formatting.swift
@@ -44,10 +44,10 @@ extension IR.Entity.Location.FieldComponent {
 extension IR.Entity.Location.SourceDefinition {
 
   /// Takes the associated `IR.Entity.Location.SourceDefinition` and formats it into a selection set name
-  func formattedSelectionSetName() -> String {
+  func formattedSelectionSetName(capitalizer: Capitalizer) -> String {
     switch self {
     case .operation: return "Data"
-    case let .namedFragment(fragment): return fragment.generatedDefinitionName
+    case let .namedFragment(fragment): return fragment.generatedDefinitionName(capitalizer: capitalizer)
     }
   }
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/SelectionSetValidationContext.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/SelectionSetValidationContext.swift
@@ -23,7 +23,8 @@ struct SelectionSetValidationContext {
       SelectionSetNameGenerator.generatedSelectionSetName(
         for: selections.typeInfo,
         format: .fullyQualified,
-        pluralizer: config.pluralizer
+        pluralizer: config.pluralizer,
+        capitalizer: config.capitalizer
       )
     }
 
@@ -55,7 +56,7 @@ struct SelectionSetValidationContext {
     referencedTypeNames.merge(typeNamesForEntityFields) { (current, _) in current }
 
     IteratorSequence(selections.makeNamedFragmentIterator()).forEach { fragmentSpread in
-      if let existingTypeName = referencedTypeNames[fragmentSpread.fragment.generatedDefinitionName] {
+      if let existingTypeName = referencedTypeNames[fragmentSpread.fragment.generatedDefinitionName(capitalizer: config.capitalizer)] {
         errorRecorder.record(error:
           ApolloCodegen.NonFatalError.typeNameConflict(
             name: existingTypeName,

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/DeferredFragmentsMetadataTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/DeferredFragmentsMetadataTemplate.swift
@@ -117,7 +117,8 @@ struct DeferredFragmentsMetadataTemplate {
         let selectionSetName = SelectionSetNameGenerator.generatedSelectionSetName(
           for: fragment.typeInfo,
           format: .omittingRoot,
-          pluralizer: config.pluralizer
+          pluralizer: config.pluralizer,
+          capitalizer: config.capitalizer
         )
 
         deferredPathTypeInfo.append(DeferredPathTypeInfo(
@@ -137,7 +138,7 @@ struct DeferredFragmentsMetadataTemplate {
         deferredPathTypeInfo.append(DeferredPathTypeInfo(
           path: path,
           deferCondition: deferCondition,
-          typeName: fragment.definition.name.asFragmentName
+          typeName: fragment.definition.name.asFragmentName(capitalizer: config.capitalizer)
         ))
       }
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -22,7 +22,7 @@ struct FragmentTemplate: TemplateRenderer {
     return TemplateString(
     """
     \(config.nonisolatedModifier)\(accessControlRenderer(for: .parent).render())\
-    struct \(fragment.generatedDefinitionName.asFragmentName): \
+    struct \(fragment.generatedDefinitionName.asFragmentName(capitalizer: config.capitalizer)): \
     \(fragment.renderedSelectionSetType(config)), Fragment\
     \(if: fragment.isIdentifiable, ", Identifiable")\
      {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -22,7 +22,7 @@ struct FragmentTemplate: TemplateRenderer {
     return TemplateString(
     """
     \(config.nonisolatedModifier)\(accessControlRenderer(for: .parent).render())\
-    struct \(fragment.generatedDefinitionName.asFragmentName(capitalizer: config.capitalizer)): \
+    struct \(fragment.generatedDefinitionName(capitalizer: config.capitalizer)): \
     \(fragment.renderedSelectionSetType(config)), Fragment\
     \(if: fragment.isIdentifiable, ", Identifiable")\
      {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -21,7 +21,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
     return TemplateString(
     """
     \(config.nonisolatedModifier)\(accessControlRenderer(for: .parent).render())\
-    struct \(operation.generatedDefinitionName): LocalCacheMutation {
+    struct \(operation.generatedDefinitionName(capitalizer: config.capitalizer)): LocalCacheMutation {
       \(memberAccessControl)static let operationType: GraphQLOperationType = .\(operation.definition.operationType.rawValue)
 
       \(section: VariableProperties(operation.definition.variables))

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -71,7 +71,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
   private func OperationDeclaration() -> TemplateString {
     return """
     \(config.nonisolatedModifier)\(accessControl.parent.render())\
-    struct \(operation.generatedDefinitionName): \
+    struct \(operation.generatedDefinitionName(capitalizer: config.capitalizer)): \
     \(operation.definition.operationType.renderedProtocolName) {
       \(accessControl.member.render())\
     static let operationName: String = "\(operation.definition.name)"
@@ -96,7 +96,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
           \(operation.definition.source.formattedSource())\(if: includeFragments, ",")
           \(if: includeFragments, """
             fragments: [\(operation.referencedFragments.map {
-              "\($0.name.asFragmentName).self"
+              "\($0.name.asFragmentName(capitalizer: config.capitalizer)).self"
             }, separator: ", ")]
             """
           )

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
@@ -17,6 +17,14 @@ extension CompilationResult.OperationDefinition {
     nameWithSuffix.firstUppercased
   }
 
+  /// The generated type name with any configured capitalization rules applied.
+  ///
+  /// Only the generated Swift type name is affected — the operation's ``name`` (used for the
+  /// `operationName` literal and everything sent to the server) is never changed.
+  func generatedDefinitionName(capitalizer: Capitalizer) -> String {
+    capitalizer.apply(to: generatedDefinitionName)
+  }
+
   private var nameWithSuffix: String {
     func getSuffix() -> String {
       if isLocalCacheMutation {
@@ -46,11 +54,19 @@ extension IR.Operation {
     definition.generatedDefinitionName
   }
 
+  func generatedDefinitionName(capitalizer: Capitalizer) -> String {
+    definition.generatedDefinitionName(capitalizer: capitalizer)
+  }
+
 }
 
 extension CompilationResult.FragmentDefinition {
   var generatedDefinitionName: String {
     name.firstUppercased
+  }
+
+  func generatedDefinitionName(capitalizer: Capitalizer) -> String {
+    capitalizer.apply(to: generatedDefinitionName)
   }
 }
 
@@ -58,6 +74,10 @@ extension IR.NamedFragment {
 
   var generatedDefinitionName: String {
     definition.generatedDefinitionName
+  }
+
+  func generatedDefinitionName(capitalizer: Capitalizer) -> String {
+    definition.generatedDefinitionName(capitalizer: capitalizer)
   }
 
 }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
@@ -77,6 +77,15 @@ extension CompilationResult.FragmentDefinition {
   func generatedDefinitionName(capitalizer: Capitalizer) -> String {
     name.asFragmentName(capitalizer: capitalizer)
   }
+
+  /// The name of the generated file for the fragment.
+  ///
+  /// Matches ``generatedDefinitionName(capitalizer:)`` except that the reserved type name
+  /// `_Fragment` suffix never appears in file names, mirroring schema types, whose file names
+  /// also omit their reserved name suffixes (`render(as: .filename)`).
+  func generatedFileName(capitalizer: Capitalizer) -> String {
+    name.asNormalizedFragmentName(capitalizer: capitalizer)
+  }
 }
 
 extension IR.NamedFragment {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
@@ -19,10 +19,14 @@ extension CompilationResult.OperationDefinition {
 
   /// The generated type name with any configured capitalization rules applied.
   ///
+  /// The result always begins with a capital letter: the name is `firstUppercased` again after
+  /// the rules run, so a rule that lowercases the leading word segment affects only the rest of
+  /// that segment.
+  ///
   /// Only the generated Swift type name is affected — the operation's ``name`` (used for the
   /// `operationName` literal and everything sent to the server) is never changed.
   func generatedDefinitionName(capitalizer: Capitalizer) -> String {
-    capitalizer.apply(to: generatedDefinitionName)
+    capitalizer.apply(to: generatedDefinitionName).firstUppercased
   }
 
   private var nameWithSuffix: String {
@@ -65,8 +69,13 @@ extension CompilationResult.FragmentDefinition {
     name.firstUppercased
   }
 
+  /// The generated type name with any configured capitalization rules applied.
+  ///
+  /// Equivalent to `asFragmentName(capitalizer:)` on ``name``: the result always begins with a
+  /// capital letter, and names that collide with reserved type names are suffixed with
+  /// `_Fragment`.
   func generatedDefinitionName(capitalizer: Capitalizer) -> String {
-    capitalizer.apply(to: generatedDefinitionName)
+    name.asFragmentName(capitalizer: capitalizer)
   }
 }
 

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -17,7 +17,11 @@ extension String {
     return SwiftKeywords.TypeNamesToSuffix.contains(uppercasedName) ?
             "\(uppercasedName)_Fragment" : uppercasedName
   }
-  
+
+  func asFragmentName(capitalizer: Capitalizer) -> String {
+    capitalizer.apply(to: asFragmentName)
+  }
+
   var asTestMockFieldPropertyName: String {
     escapeIf(in: SwiftKeywords.TestMockFieldNamesToEscape)
   }

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -15,13 +15,20 @@ extension String {
   /// Renders the string as a generated fragment type name with any configured capitalization
   /// rules applied.
   ///
-  /// The name is `firstUppercased` both before the rules run (so rules match the type-name form
-  /// of each word segment) and after (so the type name always begins with a capital letter).
-  /// Names that collide with reserved type names are then suffixed with `_Fragment`.
+  /// Names that collide with reserved type names are suffixed with `_Fragment`.
   func asFragmentName(capitalizer: Capitalizer) -> String {
-    let name = capitalizer.apply(to: firstUppercased).firstUppercased
+    let name = asNormalizedFragmentName(capitalizer: capitalizer)
     return SwiftKeywords.TypeNamesToSuffix.contains(name) ?
             "\(name)_Fragment" : name
+  }
+
+  /// Normalizes the string as a generated fragment name, without reserved type name escaping.
+  /// Shared by the generated fragment type name and file name so the two cannot drift apart.
+  ///
+  /// The name is `firstUppercased` both before the rules run (so rules match the type-name form
+  /// of each word segment) and after (so the name always begins with a capital letter).
+  func asNormalizedFragmentName(capitalizer: Capitalizer) -> String {
+    capitalizer.apply(to: firstUppercased).firstUppercased
   }
 
   var asTestMockFieldPropertyName: String {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -12,14 +12,16 @@ extension String {
     "\(self)_SelectionSet" : self
   }
   
-  var asFragmentName: String {
-    let uppercasedName = self.firstUppercased
-    return SwiftKeywords.TypeNamesToSuffix.contains(uppercasedName) ?
-            "\(uppercasedName)_Fragment" : uppercasedName
-  }
-
+  /// Renders the string as a generated fragment type name with any configured capitalization
+  /// rules applied.
+  ///
+  /// The name is `firstUppercased` both before the rules run (so rules match the type-name form
+  /// of each word segment) and after (so the type name always begins with a capital letter).
+  /// Names that collide with reserved type names are then suffixed with `_Fragment`.
   func asFragmentName(capitalizer: Capitalizer) -> String {
-    capitalizer.apply(to: asFragmentName)
+    let name = capitalizer.apply(to: firstUppercased).firstUppercased
+    return SwiftKeywords.TypeNamesToSuffix.contains(name) ?
+            "\(name)_Fragment" : name
   }
 
   var asTestMockFieldPropertyName: String {

--- a/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/apollo-ios-codegen/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -151,7 +151,8 @@ struct SelectionSetTemplate {
     /// \(SelectionSetNameGenerator.generatedSelectionSetName(
           for: selectionSet.typeInfo,
           format: .omittingRoot,
-          pluralizer: config.pluralizer))
+          pluralizer: config.pluralizer,
+          capitalizer: config.capitalizer))
     \(if: config.options.schemaDocumentation == .include, """
       ///
       /// Parent Type: `\(selectionSet.typeInfo.parentType.render(as: .typename()))`
@@ -225,7 +226,8 @@ struct SelectionSetTemplate {
       for: selectionSet.typeInfo,
       to: selectionSet.scopePath.last.value.scopePath.head,
       format: .fullyQualified,
-      pluralizer: config.pluralizer
+      pluralizer: config.pluralizer,
+      capitalizer: config.capitalizer
     )
 
     return """
@@ -251,7 +253,8 @@ struct SelectionSetTemplate {
         let selectionSetName = SelectionSetNameGenerator.generatedSelectionSetName(
           for: $0,
           format: .fullyQualified,
-          pluralizer: config.pluralizer
+          pluralizer: config.pluralizer,
+          capitalizer: config.capitalizer
         )
         return "\(selectionSetName).self"
       })
@@ -414,7 +417,7 @@ struct SelectionSetTemplate {
 
     } else {
       return """
-      .fragment(\(fragment.definition.name.asFragmentName).self)
+      .fragment(\(fragment.definition.name.asFragmentName(capitalizer: config.capitalizer)).self)
       """
     }
   }
@@ -436,7 +439,7 @@ struct SelectionSetTemplate {
     """
     .deferred(\
     \(ifLet: deferCondition.variable, { "if: \"\($0)\", " })\
-    \(fragment.definition.name.asFragmentName).self, label: "\(deferCondition.label)")
+    \(fragment.definition.name.asFragmentName(capitalizer: config.capitalizer)).self, label: "\(deferCondition.label)")
     """
   }
 
@@ -455,7 +458,8 @@ struct SelectionSetTemplate {
         for: selectionSet,
         to: node,
         format: .fullyQualified,
-        pluralizer: config.pluralizer
+        pluralizer: config.pluralizer,
+        capitalizer: config.capitalizer
       )
 
       fulfilledFragments.append(selectionSetName)
@@ -465,7 +469,8 @@ struct SelectionSetTemplate {
       fulfilledFragments
         .append(
           contentsOf: source.generatedSelectionSetNamesOfFullfilledFragments(
-            pluralizer: config.pluralizer
+            pluralizer: config.pluralizer,
+            capitalizer: config.capitalizer
           )
         )
     }
@@ -489,7 +494,8 @@ struct SelectionSetTemplate {
         let selectionSetName = SelectionSetNameGenerator.generatedSelectionSetName(
           for: inlineFragmentSpread.typeInfo,
           format: .fullyQualified,
-          pluralizer: config.pluralizer
+          pluralizer: config.pluralizer,
+          capitalizer: config.capitalizer
         )
         deferredFragments.append(selectionSetName)
       }
@@ -497,7 +503,7 @@ struct SelectionSetTemplate {
 
     for namedFragment in directSelections.namedFragments.values.elements {
       if namedFragment.typeInfo.isDeferred {
-        deferredFragments.append(namedFragment.fragment.generatedDefinitionName)
+        deferredFragments.append(namedFragment.fragment.generatedDefinitionName(capitalizer: config.capitalizer))
       }
     }
 
@@ -651,7 +657,7 @@ struct SelectionSetTemplate {
   ) -> TemplateString {
     let name = fragment.definition.name
     let propertyName = name.firstLowercased
-    let typeName = name.asFragmentName
+    let typeName = name.asFragmentName(capitalizer: config.capitalizer)
     let isOptional =
       fragment.inclusionConditions != nil
       && !scope.matches(fragment.inclusionConditions.unsafelyUnwrapped)
@@ -661,7 +667,7 @@ struct SelectionSetTemplate {
       \(if: isDeferred,
           DeferredFragmentAccessorTemplate(
             propertyName: fragment.definition.name.firstLowercased,
-            typeName: fragment.definition.name.asFragmentName
+            typeName: fragment.definition.name.asFragmentName(capitalizer: config.capitalizer)
           )
       , else:
           """
@@ -828,7 +834,7 @@ private class SelectionSetNameCache {
     let location = typeInfo.entity.location
     return location.fieldPath?.last.value
       .formattedSelectionSetName(with: config.pluralizer)
-      ?? location.source.formattedSelectionSetName()
+      ?? location.source.formattedSelectionSetName(capitalizer: config.capitalizer)
   }
 
 }
@@ -859,7 +865,8 @@ extension IR.ComputedSelectionSet {
       .first.unsafelyUnwrapped
       .generatedSelectionSetNamePath(
         from: typeInfo,
-        pluralizer: config.pluralizer
+        pluralizer: config.pluralizer,
+        capitalizer: config.capitalizer
       )
   }
 
@@ -877,12 +884,14 @@ extension IR.MergedSelections.MergedSource {
 
   fileprivate func generatedSelectionSetNamePath(
     from targetTypeInfo: IR.SelectionSet.TypeInfo,
-    pluralizer: Pluralizer
+    pluralizer: Pluralizer,
+    capitalizer: Capitalizer
   ) -> String {
     if let fragment = fragment {
       return generatedSelectionSetNameForMergedEntity(
         in: fragment,
-        pluralizer: pluralizer
+        pluralizer: pluralizer,
+        capitalizer: capitalizer
       )
     }
 
@@ -911,7 +920,8 @@ extension IR.MergedSelections.MergedSource {
       return SelectionSetNameGenerator.generatedSelectionSetName(
         for: self,
         format: .fullyQualified,
-        pluralizer: pluralizer
+        pluralizer: pluralizer,
+        capitalizer: capitalizer
       )
     }
 
@@ -974,9 +984,10 @@ extension IR.MergedSelections.MergedSource {
 
   private func generatedSelectionSetNameForMergedEntity(
     in fragment: IR.NamedFragment,
-    pluralizer: Pluralizer
+    pluralizer: Pluralizer,
+    capitalizer: Capitalizer
   ) -> String {
-    var selectionSetNameComponents: [String] = [fragment.generatedDefinitionName]
+    var selectionSetNameComponents: [String] = [fragment.generatedDefinitionName(capitalizer: capitalizer)]
 
     let rootEntityScopePath = typeInfo.scopePath.head
     if let rootEntityTypeConditionPath = rootEntityScopePath.value.scopePath.head.next {
@@ -1003,7 +1014,8 @@ extension IR.MergedSelections.MergedSource {
   }
 
   fileprivate func generatedSelectionSetNamesOfFullfilledFragments(
-    pluralizer: Pluralizer
+    pluralizer: Pluralizer,
+    capitalizer: Capitalizer
   ) -> [String] {
     let entityRootNameInFragment =
       SelectionSetNameGenerator
@@ -1011,7 +1023,8 @@ extension IR.MergedSelections.MergedSource {
         for: self,
         to: typeInfo.scopePath.last.value.scopePath.head,
         format: .fullyQualified,
-        pluralizer: pluralizer
+        pluralizer: pluralizer,
+        capitalizer: capitalizer
       )
 
     var fulfilledFragments: [String] = [entityRootNameInFragment]
@@ -1048,13 +1061,15 @@ struct SelectionSetNameGenerator {
     for selectionSet: ComputedSelectionSet,
     to toNode: LinkedList<IR.ScopeCondition>.Node? = nil,
     format: Format,
-    pluralizer: Pluralizer
+    pluralizer: Pluralizer,
+    capitalizer: Capitalizer
   ) -> String {
     generatedSelectionSetName(
       for: selectionSet.typeInfo,
       to: toNode,
       format: format,
-      pluralizer: pluralizer
+      pluralizer: pluralizer,
+      capitalizer: capitalizer
     )
   }
 
@@ -1062,13 +1077,15 @@ struct SelectionSetNameGenerator {
     for mergedSource: IR.MergedSelections.MergedSource,
     to toNode: LinkedList<IR.ScopeCondition>.Node? = nil,
     format: Format,
-    pluralizer: Pluralizer
+    pluralizer: Pluralizer,
+    capitalizer: Capitalizer
   ) -> String {
     generatedSelectionSetName(
       for: mergedSource.typeInfo,
       to: toNode,
       format: format,
-      pluralizer: pluralizer
+      pluralizer: pluralizer,
+      capitalizer: capitalizer
     )
   }
 
@@ -1076,7 +1093,8 @@ struct SelectionSetNameGenerator {
     for typeInfo: IR.SelectionSet.TypeInfo,
     to toNode: LinkedList<IR.ScopeCondition>.Node? = nil,
     format: Format,
-    pluralizer: Pluralizer
+    pluralizer: Pluralizer,
+    capitalizer: Capitalizer
   ) -> String {
     var components: [String] = []
 
@@ -1086,9 +1104,9 @@ struct SelectionSetNameGenerator {
       let sourceName: String = {
         switch typeInfo.entity.location.source {
         case let .operation(operation):
-          return "\(operation.generatedDefinitionName).Data"
+          return "\(operation.generatedDefinitionName(capitalizer: capitalizer)).Data"
         case let .namedFragment(fragment):
-          return fragment.generatedDefinitionName
+          return fragment.generatedDefinitionName(capitalizer: capitalizer)
         }
       }()
       components.append(sourceName)


### PR DESCRIPTION
## Summary

Follow-on to #1037 which introduced the opt-in `additionalCapitalizationRules` change which applied the rules to property-level names only — field accessors, initializer parameters, enum cases, input-object fields, and test-mock fields. 

This PR extends the same opt-in rules to the generated Swift type names of GraphQL operations and named fragments (the `struct` names).

## Changes

- Adds capitalizer-aware overloads `generatedDefinitionName(capitalizer:)` (operations, fragments, local cache mutations)
- Threads the existing `Capitalizer` alongside `Pluralizer` so every reference to an operation/fragment type name stays consistent
- Updates the `additionalCapitalizationRules` doc comment.
- Only generated Swift identifiers change & fully opt-in so `Capitalizer.apply(to:)` returns its input unchanged when no rules are configured

## Example

```swift
// additionalCapitalizationRules = [ { "term": { "string": "id" }, "strategy": "upper" } ]

// before
public struct SomethingByIdSubscription: GraphQLSubscription {
  public static let operationName: String = "SomethingById"   // unchanged
}

// after
public struct SomethingByIDSubscription: GraphQLSubscription {
  public static let operationName: String = "SomethingById"   // still unchanged
}
```

## File-name re-casing & pruning

This PR re-cases generated file names to match the type names. The pre-existing pruner behavior that made case-only renames unsafe on case-insensitive volumes (default macOS) is fixed here as well:

- `deleteExtraneousGeneratedFiles` skips old paths that differ from a written file's path only by case unless the volume is detected as case-sensitive (`URLResourceKey.volumeSupportsCaseSensitiveNamesKey`, memoized per parent directory; unknown ⇒ skip, so detection failure can never delete fresh output).
- `ApolloFileManager.createFile` renames an existing file whose on-disk name differs from the requested path only by case before writing, so the directory entry adopts the new casing and case-insensitive/case-sensitive checkouts generate identical file names.
- Fragment file names now derive from the same normalization helper as the fragment type names (`asNormalizedFragmentName(capitalizer:)`), mirroring operations — previously rules ran on the raw name for files but the `firstUppercased` name for types, so `.upper` rules and case-sensitive regex terms could make them drift. The reserved-name `_Fragment` suffix never appears in file names, matching schema types whose file names also omit their reserved-name suffixes.

Covered by end-to-end regression tests (skipped on case-sensitive volumes) and deterministic unit tests for both volume modes.