### PR TITLE
Improve SQLiteDatabase extensibility by exposing DatabaseRow properties

### DIFF
--- a/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/apollo-ios/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -2,8 +2,8 @@ import Foundation
 import Apollo
 
 public struct DatabaseRow {
-  let cacheKey: CacheKey
-  let storedInfo: String
+  public let cacheKey: CacheKey
+  public let storedInfo: String
 
   public init(cacheKey: CacheKey, storedInfo: String) {
     self.cacheKey = cacheKey


### PR DESCRIPTION
This PR brings the same extensibility improvement that was previously introduced in(#1056 ) Apollo iOS v1 to the v2 in  implementation.
In v2, DatabaseRow is exposed through the public SQLiteDatabase protocol but its stored properties are not publicly accessible, which prevents wrapper/decorator implementations (e.g. encryption, compression, logging) from reusing ApolloSQLiteDatabase through composition.
This change makes the required DatabaseRow members public, allowing custom SQLiteDatabase implementations to inspect and transform row contents while continuing to leverage Apollo's existing SQLite implementation.

Reference: https://github.com/apollographql/apollo-ios-dev/pull/1056