### PR TITLE
Fix flaky cancellation test: replace polling with async wait

### DIFF
--- a/Tests/ApolloTests/CancellationHandlingInterceptor.swift
+++ b/Tests/ApolloTests/CancellationHandlingInterceptor.swift
@@ -2,8 +2,14 @@ import Apollo
 import ApolloAPI
 import Foundation
 
-final class CancellationTestingInterceptor: GraphQLInterceptor {
-  private(set) nonisolated(unsafe) var hasBeenCancelled = false
+final class CancellationTestingInterceptor: GraphQLInterceptor, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _hasBeenCancelled = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  var hasBeenCancelled: Bool {
+    lock.withLock { _hasBeenCancelled }
+  }
 
   func intercept<Request: GraphQLRequest>(
     request: Request,
@@ -14,12 +20,40 @@ final class CancellationTestingInterceptor: GraphQLInterceptor {
       return await next(request)
 
     } catch is CancellationError {
-      self.hasBeenCancelled = true
+      markCancelled()
       throw CancellationError()
     }
   }
 
   func cancel() {
-    self.hasBeenCancelled = true
+    markCancelled()
+  }
+
+  /// Suspends until cancellation has been detected and `hasBeenCancelled` is `true`.
+  ///
+  /// Use this in tests instead of `toEventually(beTrue())` to avoid flakiness caused by
+  /// polling across multiple cooperative-scheduler hops.
+  func waitForCancellation() async {
+    await withCheckedContinuation { continuation in
+      lock.withLock {
+        if _hasBeenCancelled {
+          continuation.resume()
+        } else {
+          waiters.append(continuation)
+        }
+      }
+    }
+  }
+
+  private func markCancelled() {
+    var pending: [CheckedContinuation<Void, Never>] = []
+    lock.withLock {
+      _hasBeenCancelled = true
+      pending = waiters
+      waiters.removeAll()
+    }
+    for continuation in pending {
+      continuation.resume()
+    }
   }
 }

--- a/Tests/ApolloTests/RequestChainNetworkTransportTests.swift
+++ b/Tests/ApolloTests/RequestChainNetworkTransportTests.swift
@@ -194,9 +194,19 @@ class RequestChainNetworkTransportTests: XCTestCase, MockResponseProvider {
       }
     }
 
+    // Yield to let the task start and the inner stream task begin executing
+    // before we cancel, so the cancellation propagation path is exercised.
+    await Task.yield()
+
     task.cancel()
 
-    await expect(cancellationInterceptor.hasBeenCancelled).toEventually(beTrue())
+    // Await the cancellation signal directly rather than polling with `toEventually`.
+    // Cancellation propagates across multiple cooperative-scheduler hops
+    // (outer task → stream onTermination → inner task → checkCancellation), so
+    // polling is both fragile under CI load and subject to a data race on the flag.
+    await cancellationInterceptor.waitForCancellation()
+
+    expect(cancellationInterceptor.hasBeenCancelled).to(beTrue())
   }
 
   // MARK: - Subscription State Tests


### PR DESCRIPTION
## Summary

Fixes `test__cancellingTask__propogatesTaskCancellationToInterceptors` in `RequestChainNetworkTransportTests`, which was flaky in overnight CI runs.

- **Root cause 1 — polling race**: `toEventually(beTrue())` polls every ~10ms for up to 1 second. Cancellation propagates across 4–5 cooperative-scheduler hops (`task.cancel()` → outer task wakes → stream `onTermination` → inner `executingInAsyncTask` task cancelled → `Task.checkCancellation()` throws → flag written). Under CI load this chain can exceed the timeout.
- **Root cause 2 — data race**: `nonisolated(unsafe) var hasBeenCancelled` bypasses Swift's concurrency checker but provides no synchronization — the write from the inner task and the read from Nimble's polling task are a real data race.
- **Root cause 3 — unguarded cancel**: `task.cancel()` was called with no preceding `await`, so the outer task might not have started before cancellation was requested, making the propagation path non-deterministic.

## Changes

**`CancellationTestingInterceptor`**
- Replace `nonisolated(unsafe) var` with `NSLock`-protected state
- Add `waitForCancellation() async` that suspends via `CheckedContinuation` and resumes the instant cancellation is detected (no polling, no timeout)

**`RequestChainNetworkTransportTests`**
- Add `await Task.yield()` before `task.cancel()` to ensure the inner stream task has started
- Replace `toEventually(beTrue())` with `await waitForCancellation()` + synchronous `to(beTrue())`

## Test plan

- [x] Run `test__cancellingTask__propogatesTaskCancellationToInterceptors` locally to confirm it passes
- [ ] Confirm no regressions in `ApolloTests` suite
- [ ] Watch overnight CI for absence of the flaky failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)