### PR TITLE
ci: fix publish-release job never running on release merges

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -105,27 +105,59 @@ This phase requires user verification before pushing.
    The subtree push must succeed before proceeding — the publish workflow checks
    out the upstream repos and needs the latest code.
 
-## Phase 5: Trigger "Publish Release" Workflow
+   Note the run ID. This run also contains the `publish-release` job that
+   auto-dispatches Phase 5, which you will inspect there.
 
-1. Run the publish workflow:
+## Phase 5: "Publish Release" Workflow
+
+Merging a `release/*` PR dispatches "Publish Release" automatically. The
+`publish-release` job in `pr-subtree-push.yml` runs once `split-subtrees` succeeds
+and dispatches the workflow on the PR's base branch.
+
+**Do not dispatch it yourself until you have confirmed the automatic dispatch did
+not happen.** Tagging is not idempotent — a second run fails when it tries to push
+tags that already exist, and it may leave duplicate draft releases behind.
+
+1. Check whether the automatic dispatch fired. Inspect the `publish-release` job in
+   the subtree run from Phase 4:
    ```
-   gh workflow run "Publish Release" --ref <branch>
+   gh run view <subtree-run-id> --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
+   ```
+   Then confirm a "Publish Release" run actually started:
+   ```
+   gh run list --workflow="Publish Release" --limit 3
    ```
 
-2. Monitor until complete:
+2. **If a run started**, monitor it and continue to step 4:
    ```
-   gh run list --workflow="Publish Release" --limit 1
    gh run watch <run-id> --exit-status
    ```
 
-3. The publish workflow performs these steps:
+3. **Fallback — if no run started**, dispatch it manually. Use the base branch
+   (`main` or `v1`), not the `release/*` branch — the workflow checks out the
+   upstream repos at the dispatched ref, and they only have `main` and `v1`:
+   ```
+   gh workflow run "Publish Release" --ref <branch>
+   gh run list --workflow="Publish Release" --limit 1
+   gh run watch <run-id> --exit-status
+   ```
+   Reasons the automatic dispatch may not fire:
+   - The PR head branch was not named `release/*` — only that prefix triggers the job
+   - `split-subtrees` failed, so the dependent job never ran
+   - `APOLLO_IOS_PAT` expired or lost SSO authorization
+
+   Report which case applied, since this step is meant to be automatic. If the job
+   was skipped for a reason not listed above, the gating condition may be broken
+   again — see `.github/workflows/pr-subtree-push.yml`.
+
+4. The publish workflow performs these steps:
    - Tags all three repos (apollo-ios-dev, apollo-ios, apollo-ios-codegen)
    - Extracts release notes from CHANGELOG.md
    - Creates draft releases on apollo-ios and apollo-ios-codegen
    - Dispatches XCFramework build to apollo-ios-xcframework repo
    - Pushes CocoaPods (v1 branch only)
 
-4. If the XCFramework dispatch fails (known issue on v1 — missing `localRef` param),
+5. If the XCFramework dispatch fails (known issue on v1 — missing `localRef` param),
    manually dispatch:
    ```
    gh workflow run release-new-version.yml \
@@ -135,7 +167,7 @@ This phase requires user verification before pushing.
    ```
    Monitor until complete.
 
-5. Report the status of each step to the user.
+6. Report the status of each step to the user.
 
 ## Phase 6: Review and Publish Draft Releases
 

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -155,17 +155,17 @@ tags that already exist, and it may leave duplicate draft releases behind.
    - Extracts release notes from CHANGELOG.md
    - Creates draft releases on apollo-ios and apollo-ios-codegen
    - Dispatches XCFramework build to apollo-ios-xcframework repo
-   - Pushes CocoaPods (v1 branch only)
 
-5. If the XCFramework dispatch fails (known issue on v1 — missing `localRef` param),
-   manually dispatch:
+5. If the XCFramework dispatch step fails, re-dispatch it manually. Both inputs are
+   required by the xcframework workflow:
    ```
    gh workflow run release-new-version.yml \
      -f localRef=<branch> \
      -f remoteRef=<version> \
      --repo apollographql/apollo-ios-xcframework
    ```
-   Monitor until complete.
+   `localRef` is the branch to check out in the apollo-ios-xcframework repo (`main`
+   or `v1`); `remoteRef` is the release tag to pull. Monitor until complete.
 
 6. Report the status of each step to the user.
 

--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -94,7 +94,7 @@ jobs:
         git push || echo "::warning::Failed to push updated history. This is non-fatal — the next successful run will re-sync subtree metadata."
 
   publish-release:
-    if: success('split-subtrees') && startsWith(github.ref, 'refs/heads/release/')
+    if: ${{ github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/') }}
     needs: split-subtrees
     runs-on: ubuntu-latest
     name: Publish Release
@@ -106,6 +106,6 @@ jobs:
       - name: Trigger publish-release workflow
         shell: bash
         run: |
-          gh workflow run publish-release.yml
+          gh workflow run publish-release.yml --ref ${{ github.event.pull_request.base.ref }}
         env:
           GH_TOKEN: ${{ secrets.APOLLO_IOS_PAT }}


### PR DESCRIPTION
## Problem

The `publish-release` job in `.github/workflows/pr-subtree-push.yml` has **never run**. It was observed as `skipped` on [run 32412971272](https://github.com/apollographql/apollo-ios-dev/actions/runs/32412971272) (PR #1070, Release 2.4.0) even though `split-subtrees` succeeded.

Its condition had two independent bugs:

```yaml
if: success('split-subtrees') && startsWith(github.ref, 'refs/heads/release/')
```

1. **`github.ref` never matches.** The workflow is triggered by `pull_request_target`, so `github.ref` evaluates to `refs/pull/<N>/merge` — never `refs/heads/release/*`.
2. **`success()` takes no arguments.** `success('split-subtrees')` evaluated falsey, so the job would have skipped regardless of the first condition. `needs: split-subtrees` already gates on the dependency succeeding, so the call is redundant as well as wrong.

## Fix

```yaml
if: ${{ github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/') }}
```

Gates on the PR head branch, which is the actual release branch name. Verified against PR #1070: head `release/2.4.0`, base `main`, merged. The `release/` prefix is guaranteed by `create-release-pr.yml`, the only producer of these branches.

## Also: `--ref` on the dispatch

```diff
-gh workflow run publish-release.yml
+gh workflow run publish-release.yml --ref ${{ github.event.pull_request.base.ref }}
```

This is a latent bug that would have bitten on the first v1 release once the job started firing. `gh workflow run` with no `--ref` dispatches against the **default branch**, so a merged `release/1.x.x` → `v1` PR would have tagged `main` and cut a release from the wrong branch. `publish-release.yml` checks out apollo-ios and apollo-ios-codegen at `github.ref_name`, so the dispatch ref determines which release line gets tagged.

Passing `base.ref` dispatches on `main` for main releases and `v1` for v1 releases, matching the manual invocation documented in the publish-release skill (`gh workflow run "Publish Release" --ref <branch>`).

## Companion PR

The `v1` branch carries a byte-identical copy of this job with the same two bugs. Backported in https://github.com/apollographql/apollo-ios-dev/pull/1072.

## Skill update included

Phase 5 of `.claude/skills/publish-release/SKILL.md` previously told the operator to always dispatch "Publish Release" manually. Once this PR merges, that becomes a double-trigger: the automation dispatches it on merge, and the manual run then fails when it tries to push tags that already exist.

Phase 5 now verifies the automatic dispatch fired, and **keeps the manual dispatch as an explicit fallback** for the cases where the job legitimately won't run:

- The PR head branch wasn't named `release/*`
- `split-subtrees` failed, so the dependent job never ran
- `APOLLO_IOS_PAT` expired or lost SSO authorization

It also now records that the manual fallback must target the base branch (`main`/`v1`), not the `release/*` branch — `publish-release.yml` checks out the upstream repos at the dispatched ref, and those repos only ever have `main` and `v1`.

Only the `main`/v2 copy of the skill is updated here. #1072 changes the v1 workflow but not the skill, since the skill is shared tooling that lives on this branch.

Two pre-existing stale claims in the same file are corrected while we're here, both verified against the workflows on both branches:

- **"Pushes CocoaPods (v1 branch only)"** — removed. CocoaPods publishing was deleted from `publish-release.yml` in #1062; neither the `main` nor the `v1` copy has a pod step.
- **"known issue on v1 — missing `localRef` param"** — removed. That was fixed in #928 (commit `9f4d0b26b`); both branches now pass `localRef` and `remoteRef`, and the xcframework workflow declares both as required inputs. The manual re-dispatch recipe stays as a fallback for a failed dispatch step, minus the obsolete cause, plus a note on what each input means.

## Test plan

- [x] YAML parses; skill frontmatter parses and code fences balance
- [x] Condition verified against PR #1070's actual head/base refs
- [x] Verified every path and workflow name the skill references still exists
- [x] Verified the CocoaPods and `localRef` claims against both branches' workflows and the xcframework repo's declared inputs
- [ ] Real validation is the next release PR merge — the job should run instead of skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)