### PR TITLE
ci: fix publish-release job never running on release merges (v1)

### DIFF
--- a/.github/workflows/pr-subtree-push.yml
+++ b/.github/workflows/pr-subtree-push.yml
@@ -94,7 +94,7 @@ jobs:
         git push || echo "::warning::Failed to push updated history. This is non-fatal — the next successful run will re-sync subtree metadata."
 
   publish-release:
-    if: success('split-subtrees') && startsWith(github.ref, 'refs/heads/release/')
+    if: ${{ github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/') }}
     needs: split-subtrees
     runs-on: ubuntu-latest
     name: Publish Release
@@ -106,6 +106,6 @@ jobs:
       - name: Trigger publish-release workflow
         shell: bash
         run: |
-          gh workflow run publish-release.yml
+          gh workflow run publish-release.yml --ref ${{ github.event.pull_request.base.ref }}
         env:
           GH_TOKEN: ${{ secrets.APOLLO_IOS_PAT }}


### PR DESCRIPTION
## Summary

Backport of #1071 to the `v1` release line. The `v1` branch carries a byte-identical copy of the broken `publish-release` job, so it needs the same two-line fix.

## Problem

The `publish-release` job in `.github/workflows/pr-subtree-push.yml` has never run. Its condition had two independent bugs:

```yaml
if: success('split-subtrees') && startsWith(github.ref, 'refs/heads/release/')
```

1. **`github.ref` never matches.** The workflow is triggered by `pull_request_target`, so `github.ref` evaluates to `refs/pull/<N>/merge` — never `refs/heads/release/*`.
2. **`success()` takes no arguments.** `success('split-subtrees')` evaluated falsey, so the job would have skipped regardless. `needs: split-subtrees` already gates on the dependency succeeding.

Since `pull_request_target` uses the workflow file from the **base** branch, PRs into `v1` run this copy — fixing `main` alone would leave v1 releases unautomated.

## Fix

```yaml
if: ${{ github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/') }}
```

Verified the same assumptions hold on `v1`: `create-release-pr.yml` on this branch produces `release/<version>` branches, and `publish-release.yml` on this branch checks out the upstream repos at `github.ref_name`.

## The `--ref` change matters more here

```diff
-gh workflow run publish-release.yml
+gh workflow run publish-release.yml --ref ${{ github.event.pull_request.base.ref }}
```

`gh workflow run` with no `--ref` dispatches against the repository's **default branch** (`main`). On this branch that is actively wrong: once the job started firing, a merged `release/1.x.x` → `v1` PR would have dispatched `publish-release.yml` on `main`, tagging `main` and cutting a v1 release from the wrong branch entirely.

Using `base.ref` keeps v1 releases on `v1` and matches the manual invocation documented in the publish-release skill.

## Note for reviewers

Once this merges, merging a v1 release PR will automatically dispatch the publish workflow (tags, draft releases). Releases remain drafts requiring manual publish. This makes Phase 5 of the publish-release skill redundant for v1 as well; running both would fail on the second tag push.

Separately, v1 releases must still be published with `--latest=false` so they don't displace the 2.x release as latest — unchanged by this PR, but worth remembering when the automation starts firing.

## Test plan

- [x] YAML parses
- [x] Verified `release/` branch naming and `ref_name` usage on the `v1` copies of `create-release-pr.yml` and `publish-release.yml`
- [ ] Real validation is the next v1 release PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
