### PR TITLE
Fix drifted commands and version pins in CLAUDE.md

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -37,7 +37,6 @@ jobs:
               - 'Tests/ApolloInternalTestHelpers/**'
               - 'apollo-ios/**'
             tuist:
-              - '.tuist-version'
               - '.mise.toml'
 
   tuist-generation:

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "xcode": {
+      "type": "stdio",
+      "command": "xcrun",
+      "args": ["mcpbridge"],
+      "env": {}
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,35 +33,48 @@ This is the apollo-ios-dev repository, a development environment for the Apollo 
 - [apollo-ios-pagination](https://github.com/apollographql/apollo-ios-pagination) - Pagination support
 
 ### Requirements
-- Xcode 26.1+
-- Swift 6.1 (packages support Swift 5 backward compatibility via `swiftLanguageModes`)
-- Tuist 4.119.1 (pinned in `.mise.toml`; install via [Mise](https://mise.jdx.dev/) or `curl -Ls https://install.tuist.io | bash`)
-- Node.js v22 (only needed for GraphQL compiler JS tests)
+- **Xcode 26.1+** — the supported floor for local development. Nothing in the repo enforces this floor; CI pins an exact version via `XCODE_VERSION` in the workflows under `.github/workflows/` (currently `26.5`) and runs on `macos-26` runners, so CI is normally ahead of the floor. If you change the floor, update it here — there is no file to derive it from.
+- **Swift 6.1** — `swift-tools-version:6.1` in each `Package.swift`; packages support Swift 5 backward compatibility via `swiftLanguageModes: [.v6, .v5]`.
+- **Tuist** — the pinned version lives in `.mise.toml`, which is the single source of truth. Do not restate the version in prose; read the file. Install via [Mise](https://mise.jdx.dev/) (`mise install` picks up the pin) or `curl -Ls https://install.tuist.io | bash`.
+- **Node.js v22** — only needed for GraphQL compiler JS tests.
 
 ### Initial Setup
 1. Install Tuist (see requirements above)
-2. Generate workspace: `tuist generate`
-3. Use `ApolloDev.xcworkspace` for all development (NOT the .xcodeproj)
+2. Configure the repo's git hooks: `make repo-setup` (points `core.hooksPath` at `.githooks/`)
+3. Generate workspace: `tuist generate`
+4. Use `ApolloDev.xcworkspace` for all development (NOT the .xcodeproj)
 
 ## Common Commands
 
-### Building and Testing
+`make` targets live in lowercase `makefile` files: one at the repo root, one in `apollo-ios/`, and one in `apollo-ios-codegen/`. Note the lowercase name — `find . -name Makefile` will not match them.
+
+### Building
 - Generate Xcode workspace: `tuist generate`
-- Build (codegen package): `cd apollo-ios-codegen && make build`
-- Build CLI: `cd apollo-ios-codegen && make build-cli`
-- Run tests (codegen): `cd apollo-ios-codegen && make test`
+- Build a package the way CI does: `cd <apollo-ios|apollo-ios-codegen|apollo-ios-pagination> && swift build` (see the `run-swift-builds` job in `.github/workflows/ci-tests.yml`)
+- Build codegen package (release config): `cd apollo-ios-codegen && make build` (`swift build -c release`)
+- Clean build artifacts: `cd apollo-ios-codegen && make clean` (`swift package clean`)
+- Wipe build directory: `cd apollo-ios-codegen && make wipe` (`rm -rf .build`)
+
+### Testing
+**There is no `swift test` in this repo.** None of the three `Package.swift` manifests declares a `testTarget`, so `swift test` fails with `error: no tests found; create a target in the 'Tests' directory`.
+
+All Swift tests run through the Xcode schemes and test plans in `ApolloDev.xcworkspace`. See [Schemes → Test Plans Mapping](#schemes--test-plans-mapping) below for the full list, and [Running Tests via Command Line](#running-tests-via-command-line) for the `xcodebuild` invocation. Codegen tests specifically run under the `ApolloCodegenTests` scheme.
+
+Script-driven tests that do work from the command line:
 - Test all codegen configurations: `./scripts/run-test-codegen-configurations.sh`
-- Test with project validation: `./scripts/run-test-codegen-configurations.sh -t`
+- Same, with project validation: `./scripts/run-test-codegen-configurations.sh -t` (this is what CI runs)
+- GraphQL compiler JS tests: `cd apollo-ios-codegen/Sources/GraphQLCompiler/JavaScript && npm install && npm test`
 
 ### Code Generation
 - Run codegen for test projects: `./scripts/run-codegen.sh`
-- Build CLI with universal binary: `cd apollo-ios-codegen && make build-cli-universal`
-- Archive CLI for release: `cd apollo-ios-codegen && make archive-cli-for-release`
 
-### Package Management
-- Archive CLI to apollo-ios package: `make archive-cli-to-apollo-package`
-- Clean build artifacts: `cd apollo-ios-codegen && make clean`
-- Wipe build directory: `cd apollo-ios-codegen && make wipe`
+### CLI and Release
+- Build CLI: `cd apollo-ios-codegen && make build-cli`
+- Build CLI as a universal binary: `cd apollo-ios-codegen && make build-cli-universal`
+- Archive CLI for release: `cd apollo-ios-codegen && make archive-cli-for-release` (universal build + `apollo-ios-cli.tar.gz`)
+- Archive CLI into the apollo-ios package: `make archive-cli-to-apollo-package` (from the repo root — archives, then copies the tarball to `apollo-ios/CLI/`). This is the step run by the `Archive CLI` job in `.github/workflows/create-release-pr.yml`; `publish-release.yml` then attaches `apollo-ios/CLI/apollo-ios-cli.tar.gz` to the GitHub release.
+- Unpack the vendored CLI tarball: `cd apollo-ios && make unpack-cli`
+- Set version numbers across both packages: `./scripts/set-version.sh <version>`
 
 ## Repository Structure
 - **Sources/**: Test API implementations (AnimalKingdomAPI, StarWarsAPI, GitHubAPI, etc.)
@@ -115,6 +128,7 @@ Primary CI is **GitHub Actions** (`.github/workflows/ci-tests.yml`). CircleCI (`
 
 ## Tool Preferences
 
+- **Xcode MCP server setup**: the tools below come from the `xcode` MCP server, configured in `.mcp.json` at the repo root as `xcrun mcpbridge`. It ships with Xcode (requires Xcode 26+), so no install is needed, but Claude Code will ask you to approve the project-scoped server the first time you open the repo. If you decline, or `xcrun mcpbridge` is unavailable, none of the tools below exist in your session — fall back to the `xcodebuild` invocations under [Running Tests via Command Line](#running-tests-via-command-line).
 - **Use the Xcode MCP tools** (`BuildProject`, `RunSomeTests`, `RunAllTests`, `GetTestList`, etc.) for building and running tests instead of invoking `xcodebuild` directly via Bash.
 - **Running tests**: Always use `RunSomeTests` (or `RunAllTests`) from the Xcode MCP. Do NOT run `xcodebuild test` via Bash. Use `GetTestList` to discover available tests and their identifiers first.
 - **Known issue — `RunSomeTests` schema bug**: `RunSomeTests` currently returns a `-32602` schema validation error after tests complete, even though the tests ran successfully. To verify test results, call `XcodeListNavigatorIssues` with `severity: "error"` — zero errors means all tests passed.

--- a/apollo-ios-codegen/makefile
+++ b/apollo-ios-codegen/makefile
@@ -23,6 +23,3 @@ archive-cli-for-release:
 	make build-cli-universal; \
 	tar -czf apollo-ios-cli.tar.gz apollo-ios-cli; \
 	echo "Attach apollo-ios-cli.tar.gz to the GitHub release"
-
-test: 
-	swift test

--- a/claude/apollo-ios-codegen.md
+++ b/claude/apollo-ios-codegen.md
@@ -33,15 +33,16 @@ Defined in `Sources/CodegenCLI/Commands/`:
 - `Initialize` — Create initial configuration file
 - `GenerateOperationManifest` — Create persisted queries manifest
 
-## Build Commands (Makefile)
+## Build Commands
+Targets live in `makefile` (lowercase) in this directory.
 - `make build` — Build release target
 - `make build-cli` — Build CLI for current platform
 - `make build-cli-universal` — Universal binary (arm64 + x86_64)
-- `make test` — Run swift test
+- `make archive-cli-for-release` — Universal binary + `apollo-ios-cli.tar.gz`
 - `make clean` / `make wipe` — Clean build artifacts
 
 ## Testing
-Tests live in the parent `apollo-ios-dev` repo. Use the `ApolloCodegenTests` scheme with `Apollo-CodegenTestPlan`.
+This package declares no `testTarget`, so `swift test` finds nothing to run. Tests live in the parent `apollo-ios-dev` repo — use the `ApolloCodegenTests` scheme with `Apollo-CodegenTestPlan`.
 
 ## Dependencies
 - InflectorKit (pluralization), swift-collections (OrderedCollections), swift-argument-parser (CLI)


### PR DESCRIPTION
`CLAUDE.md` had drifted from the repo: it named a stale Tuist version, an Xcode floor with no stated relationship to CI, and a test command that cannot work. Each item below was verified against the repo rather than assumed.

## Tuist version pin

`CLAUDE.md` said `Tuist 4.119.1`; `.mise.toml` pins `4.202.0`. Rather than just bumping the number, the version is now gone from prose and `.mise.toml` is named as the source of truth, so it cannot drift again.

## `make test` was genuinely broken

None of the three `Package.swift` manifests declares a `testTarget`. Confirmed by running it:

```
$ cd apollo-ios-codegen && swift test --list-tests
error: no tests found; create a target in the 'Tests' directory
```

The `test` target in `apollo-ios-codegen/makefile` only wrapped `swift test`, so it failed identically. Removed the target, and removed the same claim from `claude/apollo-ios-codegen.md` — the file `CLAUDE.md` requires reading before working in that subtree, and so the most likely place to send someone to the broken command. Both docs now point at the `ApolloCodegenTests` scheme, which is how codegen tests actually run.

**The other `make` targets were fine and are kept.** They looked missing because the files are named `makefile` (lowercase), so a case-sensitive search for `Makefile` misses all three. That's now documented, along with `repo-setup`, `unpack-cli` and `set-version.sh`, which existed but were undocumented.

## Xcode version

`CLAUDE.md` said `26.1+`, CI pins `26.5`. Nothing in the repo derives a floor, so rather than invent a new one, 26.1 is kept as the stated floor with the CI pin (`XCODE_VERSION`, `macos-26` runners) called out explicitly as expected to run ahead.

## Stale CI paths-filter

Dropped the `.tuist-version` entry from the `tuist` filter in `ci-tests.yml`. The history shows it's dead, not aspirational:

```
git log --diff-filter=D -- .tuist-version   → ad48be647
git log --diff-filter=A -- .mise.toml       → ad48be647
```

The same commit deleted `.tuist-version` and added `.mise.toml` — the pin migrated and the filter entry was left behind. It was the only remaining reference in the repo, and `run-tuist-generation` uses `jdx/mise-action@v4`, which reads `.mise.toml`. So `.mise.toml` was already the sole working trigger and **this is a no-op for CI behavior**.

## `.mcp.json`

The Tool Preferences section already told Claude to use the Xcode MCP tools, but no `.mcp.json` was committed, so the server only existed for people who had configured it locally. Committed it. It runs `xcrun mcpbridge`, which ships with Xcode (`/Applications/Xcode.app/Contents/Developer/usr/bin/mcpbridge`), so it needs no install — only first-open approval. Added a note about the `xcodebuild` fallback if declined.

## Reviewer notes

- ⚠️ **`apollo-ios-codegen/makefile` is inside a subtree**, so removing the `test` target **will be pushed to `apollographql/apollo-ios-codegen`** on merge. That is intended — the target is equally broken there — but it makes this more than a docs-only PR. The other four files are dev-repo-only.
- No build tooling was changed to make the docs true; the only tooling edits are the two deletions above, both of dead code.
- Verified after editing: the makefile's tabs are intact and all seven remaining targets resolve; `ci-tests.yml` re-parses and **all 13 paths across all four filters** now exist; every command and path `CLAUDE.md` references resolves, except `ApolloDev.xcworkspace`, which is `tuist generate` output and gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)