### PR TITLE
Make ApolloClientOperationTests cancellation tests deterministic

### DIFF
--- a/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
+++ b/Tests/ApolloInternalTestHelpers/MockNetworkTransport.swift
@@ -10,13 +10,16 @@ public final class MockNetworkTransport: NetworkTransport, UploadingNetworkTrans
 
   public init(
     mockServer: MockGraphQLServer = MockGraphQLServer(),
-    store: ApolloStore
+    store: ApolloStore,
+    additionalGraphQLInterceptors: [any GraphQLInterceptor] = []
   ) {
     self.mockServer = mockServer
     let session = MockSession(server: mockServer)
     self.requestChainTransport = RequestChainNetworkTransport(
       urlSession: session,
-      interceptorProvider: MockInterceptorProvider(),
+      interceptorProvider: MockInterceptorProvider(
+        additionalGraphQLInterceptors: additionalGraphQLInterceptors
+      ),
       store: store,
       endpointURL: TestURL.mockServer.url
     )
@@ -57,8 +60,12 @@ public final class MockNetworkTransport: NetworkTransport, UploadingNetworkTrans
   }
 
   private struct MockInterceptorProvider: InterceptorProvider {
+    let additionalGraphQLInterceptors: [any GraphQLInterceptor]
+
     func graphQLInterceptors<Operation: GraphQLOperation>(for operation: Operation) -> [any GraphQLInterceptor] {
-      return DefaultInterceptorProvider.shared.graphQLInterceptors(for: operation) + [TaskLocalRequestInterceptor()]
+      return DefaultInterceptorProvider.shared.graphQLInterceptors(for: operation)
+        + [TaskLocalRequestInterceptor()]
+        + additionalGraphQLInterceptors
     }
   }
 

--- a/Tests/ApolloTests/ApolloClientOperationTests.swift
+++ b/Tests/ApolloTests/ApolloClientOperationTests.swift
@@ -71,17 +71,32 @@ final class ApolloClientOperationTests: XCTestCase {
 
   // MARK: - Cancellation Tests
 
+  /// Builds a client whose request chain suspends in flight until the enclosing task is cancelled, so that
+  /// cancellation is always observed at a known point regardless of how the task and `cancel()` interleave.
+  private func makeClientSuspendingUntilCancelled() -> ApolloClient {
+    let store = ApolloStore(cache: self.cache)
+    return ApolloClient(
+      networkTransport: MockNetworkTransport(
+        mockServer: self.server,
+        store: store,
+        additionalGraphQLInterceptors: [CancellationTestingInterceptor(suspendsUntilCancelled: true)]
+      ),
+      store: store
+    )
+  }
+
   func test__fetch__givenSingleResponse_cancelledBeforeResultReturned_throwsCancellationError() async throws {
+    let client = makeClientSuspendingUntilCancelled()
     let query = MockQuery<MockSelectionSet>()
 
-    let task = Task { [client] in
+    let task = Task {
       try await client.fetch(query: query, cachePolicy: .networkOnly)
     }
 
     task.cancel()
 
     switch await task.result {
-      case .success:
+    case .success:
       XCTFail("Expected task to fail with a CancellationError")
     case .failure(let error):
       XCTAssertTrue(error is CancellationError)
@@ -89,16 +104,17 @@ final class ApolloClientOperationTests: XCTestCase {
   }
 
   func test__performMutation__givenSingleResponse_cancelledBeforeResultReturned_throwsCancellationError() async throws {
+    let client = makeClientSuspendingUntilCancelled()
     let mutation = MockMutation<MockSelectionSet>()
 
-    let task = Task { [client] in
+    let task = Task {
       try await client.perform(mutation: mutation)
     }
 
     task.cancel()
 
     switch await task.result {
-      case .success:
+    case .success:
       XCTFail("Expected task to fail with a CancellationError")
     case .failure(let error):
       XCTAssertTrue(error is CancellationError)
@@ -106,16 +122,17 @@ final class ApolloClientOperationTests: XCTestCase {
   }
 
   func test__upload__givenSingleResponse_cancelledBeforeResultReturned_throwsCancellationError() async throws {
+    let client = makeClientSuspendingUntilCancelled()
     let query = MockQuery<MockSelectionSet>()
 
-    let task = Task { [client] in
+    let task = Task {
       try await client.upload(operation: query, files: [])
     }
 
     task.cancel()
 
     switch await task.result {
-      case .success:
+    case .success:
       XCTFail("Expected task to fail with a CancellationError")
     case .failure(let error):
       XCTAssertTrue(error is CancellationError)

--- a/Tests/ApolloTests/CancellationHandlingInterceptor.swift
+++ b/Tests/ApolloTests/CancellationHandlingInterceptor.swift
@@ -3,6 +3,7 @@ import ApolloAPI
 import Foundation
 
 final class CancellationTestingInterceptor: GraphQLInterceptor, @unchecked Sendable {
+  private let suspendsUntilCancelled: Bool
   private let lock = NSLock()
   private var _hasBeenCancelled = false
   private var waiters: [CheckedContinuation<Void, Never>] = []
@@ -11,10 +12,25 @@ final class CancellationTestingInterceptor: GraphQLInterceptor, @unchecked Senda
     lock.withLock { _hasBeenCancelled }
   }
 
+  /// - Parameter suspendsUntilCancelled: When `true`, the interceptor holds the request chain in flight instead
+  /// of calling `next`, suspending until the task is cancelled and then throwing a `CancellationError`.
+  init(suspendsUntilCancelled: Bool = false) {
+    self.suspendsUntilCancelled = suspendsUntilCancelled
+  }
+
   func intercept<Request: GraphQLRequest>(
     request: Request,
     next: (Request) async -> InterceptorResultStream<Request>
   ) async throws -> InterceptorResultStream<Request> {
+    if suspendsUntilCancelled {
+      await withTaskCancellationHandler {
+        await waitForCancellation()
+      } onCancel: {
+        markCancelled()
+      }
+      throw CancellationError()
+    }
+
     do {
       try Task.checkCancellation()
       return await next(request)


### PR DESCRIPTION
## Problem

Three tests in `Tests/ApolloTests/ApolloClientOperationTests.swift` are racy:

- `test__fetch__givenSingleResponse_cancelledBeforeResultReturned_throwsCancellationError`
- `test__performMutation__givenSingleResponse_cancelledBeforeResultReturned_throwsCancellationError`
- `test__upload__givenSingleResponse_cancelledBeforeResultReturned_throwsCancellationError`

Each creates a `Task`, calls `task.cancel()` immediately, and asserts the result is a `CancellationError`. Whether that actually happens depends on how the task body and the cancellation interleave. No `MockGraphQLServer` expectation is registered in these tests, so when the task wins the race the chain reaches the server and `MockGraphQLServer.ServerError.unexpectedRequest` is thrown instead, failing `XCTAssertTrue(error is CancellationError)`.

This is what CI run 34273399131 hit: only the mutation test failed, while `fetch` and `upload` passed in the same run — the signature of a race rather than a regression, since all three go through the same `RequestChain.kickoffRequestInterceptors` path.

## Fix

Rather than trying to win the race, park the request chain at a known point so cancellation is always what ends it.

- `CancellationTestingInterceptor` gains an opt-in `suspendsUntilCancelled` mode. Instead of calling `next`, it holds the chain in flight and throws a `CancellationError` once the task is cancelled. It uses `withTaskCancellationHandler`, whose handler fires immediately when the task is *already* cancelled, so both orderings — cancel-before-start and cancel-while-in-flight — resolve deterministically with no yield, sleep, or polling. The existing non-parking behavior is unchanged and still the default, so `RequestChainNetworkTransportTests.test__cancellingTask__propogatesTaskCancellationToInterceptors` (PR #1069) keeps exercising the same path.
- `MockNetworkTransport.init` gains an `additionalGraphQLInterceptors` parameter so tests can install extra interceptors alongside the existing defaults and `TaskLocalRequestInterceptor`.

## Verification

A temporary repro harness that forced the chain in flight (100 ms delay before `cancel()`) was used to confirm the diagnosis and the fix:

| Configuration | Result |
| --- | --- |
| Before the change | **3/3 failed** (`unexpectedRequest`, not `CancellationError`) |
| With the gate interceptor | **150/150 passed** |

Plus:

- The three tests in isolation: **600/600 passed** (200 iterations, `-run-tests-until-failure`).
- Full `Apollo-CITestPlan` parallel suite: **1006 passed / 0 failed**, three consecutive runs.

## Note on `MockSession`

`MockNetworkTransport`'s `MockSession: ApolloURLSession` does not call `try Task.checkCancellation()`, unlike `URLSession`'s conformance in `apollo-ios/Sources/Apollo/ApolloURLSession.swift`. That was evaluated as the potential root fix and **does not resolve the failure mode** — under the repro harness it still failed 3/3, because the request is already past that check by the time cancellation lands. Since it fixes nothing here and changes behavior for every other test using `MockNetworkTransport`, it was left out. It may still be worth doing on its own as a mock/real parity cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)