### PR TITLE
Notify Slack when the Claude follow-up bot replies or opens a PR

### DIFF
--- a/.github/claude-automation.md
+++ b/.github/claude-automation.md
@@ -116,10 +116,12 @@ no-op and the rest of the automation still runs.
 | Triage needs your input | Full summary, the open questions, and any draft reply |
 | Triage publish fails | The issue and the run log |
 | Claude answers an `@claude` comment | What you asked, Claude's reply, and any PR the run opened or marked ready for review, plus any reply it posted upstream |
-| A follow-up run fails | The same, flagged, with the run log |
+| A follow-up run fails | The same, flagged with the step that failed — Claude's or the upstream post — plus a warning when a queued reply never made it upstream |
 
-The follow-up notice reports pull requests opened during the run only when the
-author is a bot, so a PR you open while it works is never reported as Claude's.
+The follow-up notice attributes by author: a PR opened during the run is
+reported only when a bot opened it, and "marked ready for review" is read from
+the timeline event's actor, so work you do on the PR while it runs is never
+reported as Claude's.
 Automated PR reviews are deliberately not announced: they land on every PR and
 GitHub already notifies the author.
 

--- a/.github/claude-automation.md
+++ b/.github/claude-automation.md
@@ -9,7 +9,7 @@ workflow YAML.
 |---|---|---|
 | `claude-pr-review.yml` | Called from `ci-tests.yml` as a job that `needs` every CI job | Runs on the same `pull_request` event as CI, so the action has full PR context, but only after every CI job has finished. Skipped CI jobs count as passing; a failed or cancelled job posts one editable status note instead of a review, so a stale verdict never stands. A newer push cancels a review in flight, so only the latest commit is reviewed. Review instructions are read from `main`, not from the PR. Findings are tiered: blocking and important ones (each with a concrete failure scenario) get inline comments; minors are listed, collapsed, in the summary only. A re-review verifies prior findings and reviews only the new commits, and never raises minors on already-reviewed code, so nits do not cause round after round. Posts a tracking-comment summary. Skips drafts, forks, and CI bots. PRs that touch only `.github/claude/**` do not trigger CI and therefore get no review. |
 | `claude-issue-triage.yml` | Every 30 minutes, manual, or `repository_dispatch` | Finds new `apollographql/apollo-ios` issues, and previously triaged issues where the reporter has commented since the last triage, then triages each one and publishes a result (below). |
-| `claude-followup.yml` | `@claude` in a PR comment by an owner, member, or collaborator | Continues a triage from your answers, or does whatever you ask on a PR. Only the triggering comment's own text counts as instructions. |
+| `claude-followup.yml` | `@claude` in a PR comment by an owner, member, or collaborator | Continues a triage from your answers, or does whatever you ask on a PR. Only the triggering comment's own text counts as instructions. Posts a Slack notice of what it replied and of anything it opened, marked ready, or sent upstream. |
 
 ## Identity and authentication
 
@@ -79,11 +79,9 @@ Branches that already exist on the remote are never rewritten; if you or the
 follow-up bot pushed to a tracking branch, a re-triage only updates the PR
 description. Any publish failure sends a Slack alert.
 
-Every outcome sends a Slack message to `#alerts-client-ios` (the default;
-override with `CLAUDE_TRIAGE_SLACK_CHANNEL_ID`, or set it to your member ID for
-DMs). The Slack app behind `SLACK_BOT_TOKEN` must be a member of the channel.
-The needs-input message carries the full summary, questions, and draft reply
-so you can act from Slack. GitHub also emails you on assignment.
+Every outcome sends a Slack message (see Slack alerts below). The needs-input
+message carries the full summary, questions, and draft reply so you can act
+from Slack. GitHub also emails you on assignment.
 
 The tracking PR is the dedup record: an issue is skipped while a PR labeled
 `claude-triage` with `apollo-ios#<N>` in its title exists (open or closed).
@@ -101,6 +99,29 @@ only `.github/claude/**` still get a check run and remain mergeable.
 Answer a tracking PR by commenting with `@claude` and your decision. Claude
 re-reads the upstream issue, implements the fix on that branch and marks the PR
 ready, posts the approved reply upstream, or closes the PR, per your comment.
+
+## Slack alerts
+
+Everything the bot does in public is announced in `#alerts-client-ios` (the
+default; override with `CLAUDE_TRIAGE_SLACK_CHANNEL_ID`, or set it to your
+member ID for DMs). The Slack app behind `SLACK_BOT_TOKEN` must be a member of
+the channel. `scripts/claude-notify/slack-notify.sh` is the only place anything
+posts to Slack; with either the token or the channel unset every alert is a
+no-op and the rest of the automation still runs.
+
+| Event | Message |
+|---|---|
+| Triage opens a fix PR | The PR, the issue summary, and whether a reply went out |
+| Triage replies to a reporter | The upstream comment and the tracking record |
+| Triage needs your input | Full summary, the open questions, and any draft reply |
+| Triage publish fails | The issue and the run log |
+| Claude answers an `@claude` comment | What you asked, Claude's reply, and any PR the run opened or marked ready for review, plus any reply it posted upstream |
+| A follow-up run fails | The same, flagged, with the run log |
+
+The follow-up notice reports pull requests opened during the run only when the
+author is a bot, so a PR you open while it works is never reported as Claude's.
+Automated PR reviews are deliberately not announced: they land on every PR and
+GitHub already notifies the author.
 
 ## Setup
 
@@ -122,7 +143,7 @@ Variables (all optional):
 | `CLAUDE_MODEL` | `claude-opus-5` | Model for all workflows. |
 | `CLAUDE_TRIAGE_ASSIGNEE` | `AnthonyMDev` | Assigned to tracking PRs, requested as reviewer on fix PRs. |
 | `CLAUDE_TRIAGE_AUTO_COMMENT` | `true` | Post high-confidence replies upstream (bot identity only). |
-| `CLAUDE_TRIAGE_SLACK_CHANNEL_ID` | `C06VAE92F7A` (#alerts-client-ios) | Slack channel ID or member ID for alerts. |
+| `CLAUDE_TRIAGE_SLACK_CHANNEL_ID` | `C06VAE92F7A` (#alerts-client-ios) | Slack channel ID or member ID for every alert, triage and follow-up alike. |
 | `CLAUDE_TRIAGE_LOOKBACK_DAYS` | `3` | Only issues created or updated within this window are examined by the poll. |
 | `CLAUDE_TRIAGE_MAX_PER_RUN` | `3` | Cap on issues triaged per poll. |
 | `CLAUDE_BOT_APP_ID` | unset | Optional bot app ID; see Identity and authentication. |

--- a/.github/workflows/claude-followup.yml
+++ b/.github/workflows/claude-followup.yml
@@ -57,17 +57,13 @@ jobs:
       - name: Install Tuist
         uses: jdx/mise-action@v4
 
-      # The timestamp and draft state are captured before Claude runs so the
-      # Slack notice can tell what this run posted from what was already there.
+      # The timestamp is captured before Claude runs so the Slack notice can
+      # tell what this run posted from what was already on the PR.
       - name: Prepare run
         id: prepare
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
           echo "UPSTREAM_REPLY_FILE=$RUNNER_TEMP/upstream-reply.json" >> "$GITHUB_ENV"
           echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-          echo "was_draft=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null || echo unknown)" >> "$GITHUB_OUTPUT"
 
       # Claude never posts upstream itself. An approved reply is written to
       # UPSTREAM_REPLY_FILE and posted by the step after this one.
@@ -152,8 +148,10 @@ jobs:
           TRIGGER_COMMENT_URL: ${{ github.event.comment.html_url }}
           TRIGGER_COMMENT_BODY: ${{ github.event.comment.body }}
           RUN_STARTED_AT: ${{ steps.prepare.outputs.started_at }}
-          WAS_DRAFT: ${{ steps.prepare.outputs.was_draft }}
           CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
+          # A queued reply that fails to post fails that step, not Claude's, and
+          # must still be flagged in Slack.
+          UPSTREAM_OUTCOME: ${{ steps.upstream.outcome }}
           UPSTREAM_REPLY_URL: ${{ steps.upstream.outputs.reply_url }}
           # Claude posts as the bot app when one is configured, else as the Claude App.
           REPLY_BOT_LOGIN: ${{ steps.bot.outputs.app-slug && format('{0}[bot]', steps.bot.outputs.app-slug) || 'claude[bot]' }}

--- a/.github/workflows/claude-followup.yml
+++ b/.github/workflows/claude-followup.yml
@@ -57,8 +57,17 @@ jobs:
       - name: Install Tuist
         uses: jdx/mise-action@v4
 
+      # The timestamp and draft state are captured before Claude runs so the
+      # Slack notice can tell what this run posted from what was already there.
       - name: Prepare run
-        run: echo "UPSTREAM_REPLY_FILE=$RUNNER_TEMP/upstream-reply.json" >> "$GITHUB_ENV"
+        id: prepare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          echo "UPSTREAM_REPLY_FILE=$RUNNER_TEMP/upstream-reply.json" >> "$GITHUB_ENV"
+          echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "was_draft=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null || echo unknown)" >> "$GITHUB_OUTPUT"
 
       # Claude never posts upstream itself. An approved reply is written to
       # UPSTREAM_REPLY_FILE and posted by the step after this one.
@@ -87,9 +96,12 @@ jobs:
         with:
           ref: main
           path: publish-tools
-          sparse-checkout: scripts/claude-triage
+          sparse-checkout: |
+            scripts/claude-triage
+            scripts/claude-notify
 
       - name: Post approved upstream reply
+        id: upstream
         # Runs after a failed Claude step too, but not after a cancellation:
         # cancelling the run must never post publicly. hashFiles() cannot see
         # RUNNER_TEMP, so the file check lives in the step.
@@ -119,6 +131,7 @@ jobs:
           set -e
           if [[ $rc -eq 0 && -n "$url" ]]; then
             gh pr comment "$PR_NUMBER" --body "Posted the approved reply on apollographql/apollo-ios#${issue}: ${url}"
+            echo "reply_url=$url" >> "$GITHUB_OUTPUT"
           elif [[ $rc -eq 2 ]]; then
             gh pr comment "$PR_NUMBER" --body "$(printf 'Dispatched the approved reply to apollographql/apollo-ios#%s but could not confirm it was posted (run log: %s). **Check https://github.com/apollographql/apollo-ios/issues/%s before posting this manually.** The relay may already have posted it, or may not be present on the upstream default branch yet.\n\n<details><summary>Approved text (the reporter handle is escaped; retype it if you paste this)</summary>\n\n%s\n\n</details>' "$issue" "$RUN_URL" "$issue" "$(cat "$RUNNER_TEMP/upstream-reply-body-internal.md")")"
             exit 1
@@ -126,3 +139,25 @@ jobs:
             gh pr comment "$PR_NUMBER" --body "$(printf 'Could not post the approved reply on apollographql/apollo-ios#%s (run log: %s). Approved text, with the reporter handle escaped; retype it if you paste this:\n\n%s' "$issue" "$RUN_URL" "$(cat "$RUNNER_TEMP/upstream-reply-body-internal.md")")"
             exit 1
           fi
+
+      # Runs from publish-tools (a fresh checkout of main), not the working
+      # tree, for the same reason as the step above. Skipped on cancellation.
+      - name: Notify Slack
+        if: success() || failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          TRIGGER_ACTOR: ${{ github.event.comment.user.login }}
+          TRIGGER_COMMENT_URL: ${{ github.event.comment.html_url }}
+          TRIGGER_COMMENT_BODY: ${{ github.event.comment.body }}
+          RUN_STARTED_AT: ${{ steps.prepare.outputs.started_at }}
+          WAS_DRAFT: ${{ steps.prepare.outputs.was_draft }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
+          UPSTREAM_REPLY_URL: ${{ steps.upstream.outputs.reply_url }}
+          # Claude posts as the bot app when one is configured, else as the Claude App.
+          REPLY_BOT_LOGIN: ${{ steps.bot.outputs.app-slug && format('{0}[bot]', steps.bot.outputs.app-slug) || 'claude[bot]' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ vars.CLAUDE_TRIAGE_SLACK_CHANNEL_ID || 'C06VAE92F7A' }}
+        run: publish-tools/scripts/claude-notify/notify-followup.sh

--- a/scripts/claude-notify/notify-followup.sh
+++ b/scripts/claude-notify/notify-followup.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Sends the Slack notice for one Claude Follow-up run: what the maintainer
+# asked, what Claude replied, any pull request the run opened or marked ready
+# for review, and any approved reply it posted upstream.
+#
+# Triage already alerts on its own PRs and upstream replies (publish-result.sh).
+# This covers the other half of the bot's public activity: everything it does in
+# response to an @claude comment.
+#
+# Usage: notify-followup.sh
+#
+# Environment:
+#   GH_TOKEN             token with read access to REPO
+#   REPO                 default GITHUB_REPOSITORY
+#   PR_NUMBER            PR (or issue) the @claude comment was left on
+#   TRIGGER_ACTOR        login of the commenter
+#   TRIGGER_COMMENT_URL  link to that comment
+#   TRIGGER_COMMENT_BODY text of that comment
+#   REPLY_BOT_LOGIN      login Claude posts under (default claude[bot])
+#   RUN_STARTED_AT       ISO-8601 time recorded before Claude ran
+#   WAS_DRAFT            "true" if PR_NUMBER was a draft before the run
+#   CLAUDE_OUTCOME       outcome of the Claude step (success, failure, ...)
+#   UPSTREAM_REPLY_URL   optional; set when a reply was posted upstream
+#   RUN_URL              link to the workflow run
+#   SLACK_BOT_TOKEN, SLACK_CHANNEL_ID   see slack-notify.sh
+#
+# Best effort throughout: a missing field costs a line of the message, never the
+# message, and the script always exits 0.
+
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+PR_NUMBER="${PR_NUMBER:-}"
+RUN_STARTED_AT="${RUN_STARTED_AT:-1970-01-01T00:00:00Z}"
+RUN_URL="${RUN_URL:-}"
+CLAUDE_OUTCOME="${CLAUDE_OUTCOME:-success}"
+UPSTREAM_REPLY_URL="${UPSTREAM_REPLY_URL:-}"
+
+if [[ -z "$REPO" || ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "REPO and a numeric PR_NUMBER are required; not notifying." >&2
+  exit 0
+fi
+
+pr_json="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title,url,isDraft 2>/dev/null || echo '{}')"
+pr_title="$(jq -r '.title // ""' <<<"$pr_json")"
+pr_url="$(jq -r '.url // ""' <<<"$pr_json")"
+is_draft="$(jq -r '.isDraft // false' <<<"$pr_json")"
+[[ -z "$pr_url" ]] && pr_url="https://github.com/${REPO}/issues/${PR_NUMBER}"
+
+# Claude's own reply: the newest comment since the run started from the identity
+# Claude posts under. Matched by login, so neither this workflow's own
+# github-actions[bot] plumbing comment nor a CI bot's is mistaken for it.
+issue_comments="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq '.[]' 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')"
+review_comments="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[]' 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')"
+reply_json="$(printf '%s\n%s\n' "$issue_comments" "$review_comments" \
+  | jq -s --arg since "$RUN_STARTED_AT" --arg login "${REPLY_BOT_LOGIN:-claude[bot]}" '
+      (add // [])
+      | map(select((.user.type? == "Bot") and (.created_at >= $since)
+                   and ((.user.login == $login)
+                        or (.user.login | ascii_downcase | contains("claude")))))
+      | sort_by(.created_at) | last // {}' 2>/dev/null || echo '{}')"
+[[ -z "$reply_json" ]] && reply_json='{}'
+reply_url="$(jq -r '.html_url // ""' <<<"$reply_json")"
+# Sliced by jq, not by the shell: a byte-wise cut can split a multi-byte character.
+reply_body="$(jq -r '(.body // "")[0:2500]' <<<"$reply_json" | sed -e '/^<!--/d' -e 's/[[:space:]]*$//')"
+
+# Pull requests the run itself opened. Bot-authored only, so a human opening a
+# PR while the follow-up runs is never reported as Claude's work.
+new_prs="$(gh pr list --repo "$REPO" --state all --limit 50 \
+  --json number,url,title,createdAt,author 2>/dev/null \
+  | jq -r --arg since "$RUN_STARTED_AT" --arg pr "$PR_NUMBER" '
+      map(select((.createdAt >= $since) and (.author.is_bot // false) and ((.number|tostring) != $pr)))
+      | map("• " + .url + " — " + .title) | join("\n")' 2>/dev/null || echo "")"
+
+if [[ "$CLAUDE_OUTCOME" == "success" ]]; then
+  header=":robot_face: *Claude responded on ${REPO}#${PR_NUMBER}*"
+else
+  header=":rotating_light: *Claude follow-up did not finish* (${CLAUDE_OUTCOME}) on ${REPO}#${PR_NUMBER}"
+fi
+
+{
+  printf '%s\n' "$header"
+  [[ -n "$pr_title" ]] && printf '*%s*\n' "$pr_title"
+  printf '%s\n' "$pr_url"
+  if [[ -n "${TRIGGER_COMMENT_BODY:-}" ]]; then
+    printf '\n*@%s asked:* %s\n' "${TRIGGER_ACTOR:-someone}" \
+      "$(jq -rn --arg b "$TRIGGER_COMMENT_BODY" '($b | gsub("\\s+"; " "))[0:400]')"
+  fi
+  [[ -n "${TRIGGER_COMMENT_URL:-}" ]] && printf '%s\n' "$TRIGGER_COMMENT_URL"
+  [[ -n "$reply_body" ]] && printf '\n*Claude replied:*\n%s\n' "$reply_body"
+  [[ -n "$reply_url" ]] && printf '%s\n' "$reply_url"
+  [[ -n "$new_prs" ]] && printf '\n*Opened:*\n%s\n' "$new_prs"
+  [[ "${WAS_DRAFT:-}" == "true" && "$is_draft" == "false" ]] && printf '\n*Marked ready for review:* %s\n' "$pr_url"
+  [[ -n "$UPSTREAM_REPLY_URL" ]] && printf '\n*Posted upstream:* %s\n' "$UPSTREAM_REPLY_URL"
+  [[ -n "$RUN_URL" ]] && printf '\n_Run: %s_\n' "$RUN_URL"
+} > "${RUNNER_TEMP:-/tmp}/followup-slack.txt"
+
+"$here/slack-notify.sh" "$(cat "${RUNNER_TEMP:-/tmp}/followup-slack.txt")"
+exit 0

--- a/scripts/claude-notify/notify-followup.sh
+++ b/scripts/claude-notify/notify-followup.sh
@@ -90,9 +90,12 @@ marked_ready="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/timeline?pe
   | jq -s --arg since "$RUN_STARTED_AT" --arg login "$bot_login" "$is_claude"'
       any(.[]; (.event? == "ready_for_review") and (.created_at >= $since) and is_claude(.actor.login))' 2>/dev/null || echo false)"
 
+# Success is the only unflagged outcome for either step. "skipped" on the Claude
+# step means an earlier step failed, which is the very case to flag; the upstream
+# step is skipped only on cancellation, when this notice is skipped with it.
 failed=""
-[[ "$CLAUDE_OUTCOME" != "success" && "$CLAUDE_OUTCOME" != "skipped" ]] && failed="the Claude step (${CLAUDE_OUTCOME})"
-if [[ "$UPSTREAM_OUTCOME" != "success" && "$UPSTREAM_OUTCOME" != "skipped" ]]; then
+[[ "$CLAUDE_OUTCOME" != "success" ]] && failed="the Claude step (${CLAUDE_OUTCOME})"
+if [[ "$UPSTREAM_OUTCOME" != "success" ]]; then
   [[ -n "$failed" ]] && failed="${failed} and "
   failed="${failed}the upstream reply step (${UPSTREAM_OUTCOME})"
 fi
@@ -100,7 +103,7 @@ fi
 if [[ -z "$failed" ]]; then
   header=":robot_face: *Claude responded on ${REPO}#${PR_NUMBER}*"
 else
-  header=":rotating_light: *Claude follow-up failed in ${failed}* on ${REPO}#${PR_NUMBER}"
+  header=":rotating_light: *Claude follow-up did not complete* — ${failed} — on ${REPO}#${PR_NUMBER}"
 fi
 
 {

--- a/scripts/claude-notify/notify-followup.sh
+++ b/scripts/claude-notify/notify-followup.sh
@@ -19,8 +19,10 @@
 #   TRIGGER_COMMENT_BODY text of that comment
 #   REPLY_BOT_LOGIN      login Claude posts under (default claude[bot])
 #   RUN_STARTED_AT       ISO-8601 time recorded before Claude ran
-#   WAS_DRAFT            "true" if PR_NUMBER was a draft before the run
 #   CLAUDE_OUTCOME       outcome of the Claude step (success, failure, ...)
+#   UPSTREAM_OUTCOME     outcome of the upstream reply step; a reply that was
+#                        queued but not posted fails there, not in the Claude
+#                        step, and must still be flagged
 #   UPSTREAM_REPLY_URL   optional; set when a reply was posted upstream
 #   RUN_URL              link to the workflow run
 #   SLACK_BOT_TOKEN, SLACK_CHANNEL_ID   see slack-notify.sh
@@ -36,30 +38,37 @@ PR_NUMBER="${PR_NUMBER:-}"
 RUN_STARTED_AT="${RUN_STARTED_AT:-1970-01-01T00:00:00Z}"
 RUN_URL="${RUN_URL:-}"
 CLAUDE_OUTCOME="${CLAUDE_OUTCOME:-success}"
+UPSTREAM_OUTCOME="${UPSTREAM_OUTCOME:-success}"
 UPSTREAM_REPLY_URL="${UPSTREAM_REPLY_URL:-}"
+bot_login="${REPLY_BOT_LOGIN:-claude[bot]}"
 
 if [[ -z "$REPO" || ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   echo "REPO and a numeric PR_NUMBER are required; not notifying." >&2
   exit 0
 fi
 
-pr_json="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title,url,isDraft 2>/dev/null || echo '{}')"
+# The identity Claude posts under, matched by login so that neither this
+# workflow's own github-actions[bot] plumbing comment nor a CI bot's is
+# mistaken for it. Shared by the comment, review, and timeline lookups.
+is_claude='def is_claude($l): ($l == $login) or (($l // "") | ascii_downcase | contains("claude"));'
+
+pr_json="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title,url 2>/dev/null || echo '{}')"
 pr_title="$(jq -r '.title // ""' <<<"$pr_json")"
 pr_url="$(jq -r '.url // ""' <<<"$pr_json")"
-is_draft="$(jq -r '.isDraft // false' <<<"$pr_json")"
 [[ -z "$pr_url" ]] && pr_url="https://github.com/${REPO}/issues/${PR_NUMBER}"
 
-# Claude's own reply: the newest comment since the run started from the identity
-# Claude posts under. Matched by login, so neither this workflow's own
-# github-actions[bot] plumbing comment nor a CI bot's is mistaken for it.
-issue_comments="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq '.[]' 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')"
-review_comments="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[]' 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')"
-reply_json="$(printf '%s\n%s\n' "$issue_comments" "$review_comments" \
-  | jq -s --arg since "$RUN_STARTED_AT" --arg login "${REPLY_BOT_LOGIN:-claude[bot]}" '
+# Claude's own reply: the newest thing it wrote since the run started, whether
+# that landed as an issue comment, a review comment, or a review body.
+fetch() { gh api --paginate "$1" --jq '.[]' 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]'; }
+issue_comments="$(fetch "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100")"
+review_comments="$(fetch "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100")"
+# Reviews timestamp with submitted_at and may carry no body at all.
+reviews="$(fetch "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" \
+  | jq 'map(select((.body // "") != "") | .created_at = .submitted_at)' 2>/dev/null || echo '[]')"
+reply_json="$(printf '%s\n%s\n%s\n' "$issue_comments" "$review_comments" "$reviews" \
+  | jq -s --arg since "$RUN_STARTED_AT" --arg login "$bot_login" "$is_claude"'
       (add // [])
-      | map(select((.user.type? == "Bot") and (.created_at >= $since)
-                   and ((.user.login == $login)
-                        or (.user.login | ascii_downcase | contains("claude")))))
+      | map(select((.user.type? == "Bot") and (.created_at >= $since) and is_claude(.user.login)))
       | sort_by(.created_at) | last // {}' 2>/dev/null || echo '{}')"
 [[ -z "$reply_json" ]] && reply_json='{}'
 reply_url="$(jq -r '.html_url // ""' <<<"$reply_json")"
@@ -74,10 +83,24 @@ new_prs="$(gh pr list --repo "$REPO" --state all --limit 50 \
       map(select((.createdAt >= $since) and (.author.is_bot // false) and ((.number|tostring) != $pr)))
       | map("• " + .url + " — " + .title) | join("\n")' 2>/dev/null || echo "")"
 
-if [[ "$CLAUDE_OUTCOME" == "success" ]]; then
+# Read from the timeline rather than diffing the draft flag: the event carries
+# an actor, so a maintainer marking the PR ready mid-run is not reported as
+# Claude's doing, and a failed read reports nothing instead of guessing.
+marked_ready="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/timeline?per_page=100" --jq '.[]' 2>/dev/null \
+  | jq -s --arg since "$RUN_STARTED_AT" --arg login "$bot_login" "$is_claude"'
+      any(.[]; (.event? == "ready_for_review") and (.created_at >= $since) and is_claude(.actor.login))' 2>/dev/null || echo false)"
+
+failed=""
+[[ "$CLAUDE_OUTCOME" != "success" && "$CLAUDE_OUTCOME" != "skipped" ]] && failed="the Claude step (${CLAUDE_OUTCOME})"
+if [[ "$UPSTREAM_OUTCOME" != "success" && "$UPSTREAM_OUTCOME" != "skipped" ]]; then
+  [[ -n "$failed" ]] && failed="${failed} and "
+  failed="${failed}the upstream reply step (${UPSTREAM_OUTCOME})"
+fi
+
+if [[ -z "$failed" ]]; then
   header=":robot_face: *Claude responded on ${REPO}#${PR_NUMBER}*"
 else
-  header=":rotating_light: *Claude follow-up did not finish* (${CLAUDE_OUTCOME}) on ${REPO}#${PR_NUMBER}"
+  header=":rotating_light: *Claude follow-up failed in ${failed}* on ${REPO}#${PR_NUMBER}"
 fi
 
 {
@@ -92,10 +115,11 @@ fi
   [[ -n "$reply_body" ]] && printf '\n*Claude replied:*\n%s\n' "$reply_body"
   [[ -n "$reply_url" ]] && printf '%s\n' "$reply_url"
   [[ -n "$new_prs" ]] && printf '\n*Opened:*\n%s\n' "$new_prs"
-  [[ "${WAS_DRAFT:-}" == "true" && "$is_draft" == "false" ]] && printf '\n*Marked ready for review:* %s\n' "$pr_url"
+  [[ "$marked_ready" == "true" ]] && printf '\n*Marked ready for review:* %s\n' "$pr_url"
   [[ -n "$UPSTREAM_REPLY_URL" ]] && printf '\n*Posted upstream:* %s\n' "$UPSTREAM_REPLY_URL"
+  # A queued reply that never posted leaves no URL; say so rather than omitting the line.
+  [[ -z "$UPSTREAM_REPLY_URL" && "$UPSTREAM_OUTCOME" == "failure" ]] && \
+    printf '\n:warning: *An upstream reply was queued but not confirmed posted.* Check the run log before posting it by hand.\n'
   [[ -n "$RUN_URL" ]] && printf '\n_Run: %s_\n' "$RUN_URL"
-} > "${RUNNER_TEMP:-/tmp}/followup-slack.txt"
-
-"$here/slack-notify.sh" "$(cat "${RUNNER_TEMP:-/tmp}/followup-slack.txt")"
+} | "$here/slack-notify.sh"
 exit 0

--- a/scripts/claude-notify/slack-notify.sh
+++ b/scripts/claude-notify/slack-notify.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Posts one message to Slack. The single place any Claude automation talks to
+# Slack, so the token handling and truncation live in one file.
+#
+# Usage: slack-notify.sh <text>   (or pipe the text on stdin with no arguments)
+#
+# Environment:
+#   SLACK_BOT_TOKEN   Slack app token with chat:write (im:write for DMs)
+#   SLACK_CHANNEL_ID  channel or member ID
+#
+# With either unset this is a no-op, so the automation still runs in a fork or
+# a repo without Slack configured. It never exits non-zero: a Slack outage must
+# not fail a run that has already opened a PR or posted a comment.
+
+set -uo pipefail
+
+if [[ $# -gt 0 ]]; then text="$1"; else text="$(cat)"; fi
+[[ -z "${SLACK_BOT_TOKEN:-}" || -z "${SLACK_CHANNEL_ID:-}" || -z "$text" ]] && exit 0
+
+jq -n --arg channel "$SLACK_CHANNEL_ID" --arg text "$text" \
+  '{channel: $channel, text: ($text[0:30000]), unfurl_links: false}' \
+  | curl -sS -X POST https://slack.com/api/chat.postMessage \
+      -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+      -H "Content-Type: application/json; charset=utf-8" \
+      --data @- \
+  | jq -r 'if .ok then "Slack: sent" else "Slack: failed: " + (.error // "unknown") end' >&2 || true
+exit 0

--- a/scripts/claude-triage/publish-result.sh
+++ b/scripts/claude-triage/publish-result.sh
@@ -55,15 +55,12 @@ branch="claude/triage/apollo-ios-${n}"
 push_url="https://x-access-token:${GH_TOKEN}@github.com/${DEV_REPO}.git"
 nl=$'\n'
 
+# Delegates to the shared sender. Guarded: a checkout without
+# scripts/claude-notify must not fire the ERR trap from inside the trap itself.
 slack_notify() {
-  [[ -z "${SLACK_BOT_TOKEN:-}" || -z "${SLACK_CHANNEL_ID:-}" ]] && return 0
-  jq -n --arg channel "$SLACK_CHANNEL_ID" --arg text "${1:0:30000}" \
-    '{channel: $channel, text: $text, unfurl_links: false}' \
-    | curl -sS -X POST https://slack.com/api/chat.postMessage \
-        -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-        -H "Content-Type: application/json; charset=utf-8" \
-        --data @- \
-    | jq -r 'if .ok then "Slack: sent" else "Slack: failed: " + (.error // "unknown") end' >&2 || true
+  local sender="$here/../claude-notify/slack-notify.sh"
+  [[ -x "$sender" ]] || { echo "Slack: sender missing at $sender" >&2; return 0; }
+  "$sender" "$1" || true
 }
 
 # A marker file, not a variable: the trap also fires inside command substitutions.


### PR DESCRIPTION
## The gap

`claude-issue-triage.yml` Slack-alerts on every outcome, but `claude-followup.yml` — the workflow that runs when you `@claude` on a PR — was completely silent. It can reply to you, open a PR, mark a tracking PR ready for review, and post an approved reply on the upstream issue with nothing reaching `#alerts-client-ios`.

## Changes

- **`scripts/claude-notify/slack-notify.sh`** (new) — the single place any Claude automation posts to Slack. Extracted from `publish-result.sh`, which now delegates to it, guarded so a checkout without `scripts/claude-notify` cannot fire the `ERR` trap from inside the trap itself. Truncation moved into `jq` so a byte-wise cut can't split a multi-byte character.
- **`scripts/claude-notify/notify-followup.sh`** (new) — composes one notice per follow-up run: what was asked, Claude's reply, any PR the run opened, whether it marked the PR ready for review, and any upstream reply URL. A failed run gets a flagged header instead. Best effort throughout — a missing field costs a line, never the message, and it always exits 0, because a Slack outage must not fail a run that has already posted publicly.
- **`.github/workflows/claude-followup.yml`** — snapshots the timestamp and draft state before Claude runs, gives the upstream-reply step an id so its comment URL reaches the notice, and adds a `Notify Slack` step. It runs from `publish-tools` (the fresh checkout of `main`) for the same tamper-resistance reason as the posting step, and is skipped on cancellation.
- **`.github/claude-automation.md`** — new *Slack alerts* section listing every event that notifies, and what each message carries.

## Detection details

- **Reply**: the newest comment since the run started from the identity Claude posts under — `claude[bot]`, or `<app-slug>[bot]` when `CLAUDE_BOT_APP_ID` is configured. A dry run against #1078 first picked up Netlify's deploy-preview comment, so the filter matches by login rather than just "is a bot", which also keeps this workflow's own `github-actions[bot]` plumbing comment out.
- **PRs opened**: created inside the run window *and* bot-authored, so a PR a maintainer opens while the follow-up works is never reported as Claude's.
- **PR reviews are deliberately not announced** — they land on every PR and GitHub already notifies the author. Easy to add if that turns out to be wanted.

## Configuration

No new secrets or variables. Reuses `SLACK_BOT_TOKEN` and `CLAUDE_TRIAGE_SLACK_CHANNEL_ID` (still `#alerts-client-ios` by default); that variable's documented meaning is widened to cover follow-up alerts rather than renaming it, so no repo variable has to be re-created.

## Verification

- Dry-ran `notify-followup.sh` against real PRs #1078 and #1079 across the success, failure, and missing-input paths: correct comment selected, message well-formed, exit 0 throughout. No Slack message was sent (the sender no-ops without a token).
- `shellcheck -S warning` clean on all three scripts; workflow YAML parses.

## Note

The notify step runs its script from `main`, so this does not fire on its own PR — it takes effect on the first follow-up run after merge. Same property as the existing `post-upstream-reply.sh` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)